### PR TITLE
Re-add export declaration for windows dll files

### DIFF
--- a/blas/NativeOps.h
+++ b/blas/NativeOps.h
@@ -29,7 +29,7 @@
 
 
 
-class  NativeOps {
+class ND4J_EXPORT NativeOps {
 #ifdef __CUDACC__
 cudaDeviceProp *deviceProperties;
         cudaFuncAttributes *funcAttributes;


### PR DESCRIPTION
this declaration is needed for windows, or the nd4j build fails with a linker error that it can't find symbols.