### PR TITLE
Moar tests

### DIFF
--- a/blas/cuda/NativeOps.cu
+++ b/blas/cuda/NativeOps.cu
@@ -60,7 +60,7 @@ dim3 getOptimalLaunchParameters(Nd4jPointer *extraPointers, cudaFuncAttributes a
 
 	dim3 launchDims = getOptimalDimensions<T>(n,attributes, properties);
 
-	//    printf("Params: gridSize: [%i], blockSize: [%i], shMem: [%i], problemLength: [%i], totalThreads:[%i]\n", launchDims.x, launchDims.y, launchDims.z, n, (launchDims.x * launchDims.y));
+	printf("Params: gridSize: [%i], blockSize: [%i], shMem: [%i], problemLength: [%i], totalThreads:[%i]\n", launchDims.x, launchDims.y, launchDims.z, n, (launchDims.x * launchDims.y));
 
 	return launchDims;
 }
@@ -1429,7 +1429,7 @@ void   NativeOps::execReduceFloat(
 
 	dim3 launchDims = getOptimalLaunchParameters<float>(&extraPointers[0], funcAttributes[8], deviceProperties[(int) extraPointers[2]]);
 
-	reduceFloat<<<launchDims.x,launchDims.y,launchDims.z, *stream>>>(
+	reduceFloat<<<1,launchDims.y,launchDims.z, *stream>>>(
 			opNum,
 			xPointer,
 			xShapeInfoPointer
@@ -1474,7 +1474,7 @@ void   NativeOps::execReduceFloat(
 
 	dim3 launchDims = getOptimalLaunchParameters<float>(&extraPointers[0], funcAttributes[8], deviceProperties[(int) extraPointers[2]]);
 
-	reduceFloat<<<launchDims.x,launchDims.y,launchDims.z, *stream>>>(
+	reduceFloat<<<1,launchDims.y,launchDims.z, *stream>>>(
 			opNum,
 			xPointer,
 			xShapeInfoPointer

--- a/blas/cuda/NativeOps.cu
+++ b/blas/cuda/NativeOps.cu
@@ -60,7 +60,7 @@ dim3 getOptimalLaunchParameters(Nd4jPointer *extraPointers, cudaFuncAttributes a
 
 	dim3 launchDims = getOptimalDimensions<T>(n,attributes, properties);
 
-	printf("Params: gridSize: [%i], blockSize: [%i], shMem: [%i], problemLength: [%i], totalThreads:[%i]\n", launchDims.x, launchDims.y, launchDims.z, n, (launchDims.x * launchDims.y));
+	//printf("Params: gridSize: [%i], blockSize: [%i], shMem: [%i], problemLength: [%i], totalThreads:[%i]\n", launchDims.x, launchDims.y, launchDims.z, n, (launchDims.x * launchDims.y));
 
 	return launchDims;
 }

--- a/include/reduce.h
+++ b/include/reduce.h
@@ -209,7 +209,10 @@ public:
 
 
 			if (dimensionLength > 1) {
-				xElementWiseStride = shape::stride(xShapeInfo)[dimensionLength - 1];
+				int dimz = dimension[dimensionLength - 1];
+				printf("DimensionLength > 1, using [%i] as dimension\n", dimz);
+
+				xElementWiseStride = shape::stride(xShapeInfo)[dimz];
 			} else {
 				printf("Going for stride...\n");
 				int *xShape = shape::shapeOf(xShapeInfo);
@@ -222,6 +225,7 @@ public:
 
 				if (dimension[0] != shape::MAX_DIMENSION) {
 					printf("Computing stride...\n");
+					printf("Requested dimension: [%i]\n", dimension[0]);
 					xElementWiseStride =  xStride[dimension[0]];//shape::computeElementWiseStride(xRank,xShape,xStride,xOrder == 'f');
 				} else {
 					printf("Using passed in stride...\n");
@@ -277,7 +281,7 @@ public:
 				sPartials[tid] = op(dx[offsetForTad], extraParams);
 				__syncthreads();
 				for(j = 1; j < elementsPerReductionIndex; j++) {
-					printf("Cycled Tid: [%i], index: [%i], offsetForTad: [%i], value: [%f] \n", tid, offsetForTad + xElementWiseStride * j , offsetForTad, dx[offsetForTad + xElementWiseStride * j]);
+					//printf("Cycled Tid: [%i], index: [%i], offsetForTad: [%i], value: [%f] \n", tid, offsetForTad + xElementWiseStride * j , offsetForTad, dx[offsetForTad + xElementWiseStride * j]);
 					sPartials[tid] =  update(sPartials[tid],op(dx[offsetForTad + xElementWiseStride * j], extraParams), extraParams);
 					__syncthreads();
 				}

--- a/include/reduce.h
+++ b/include/reduce.h
@@ -184,6 +184,7 @@ public:
 
 		T reduction = this->startingValue(dx);
 		if (tid == 0) {
+			printf("Starting stride check...\n");
 			resultLength = shape::length(resultShapeInfo);
 			if (dimensionLength == 1) {
 				if (dimension[0] == shape::MAX_DIMENSION)
@@ -210,25 +211,38 @@ public:
 			if (dimensionLength > 1) {
 				xElementWiseStride = shape::stride(xShapeInfo)[dimensionLength - 1];
 			} else {
+				printf("Going for stride...\n");
 				int *xShape = shape::shapeOf(xShapeInfo);
 				int *xStride = shape::stride(xShapeInfo);
 				char xOrder = shape::order(xShapeInfo);
 				int n = shape::length(xShapeInfo);
 				int xRank = shape::rank(xShapeInfo);
 				int xOffset = shape::offset(xShapeInfo);
+//				int
 
-				if (dimension[0] != shape::MAX_DIMENSION)
-					xElementWiseStride = shape::computeElementWiseStride(xRank,xShape,xStride,xOrder == 'f', dimension, dimensionLength);
-				else xElementWiseStride = shape::elementWiseStride(xShapeInfo);
+				if (dimension[0] != shape::MAX_DIMENSION) {
+					printf("Computing stride...\n");
+					xElementWiseStride =  xStride[dimension[0]];//shape::computeElementWiseStride(xRank,xShape,xStride,xOrder == 'f');
+				} else {
+					printf("Using passed in stride...\n");
+					xElementWiseStride = shape::elementWiseStride(xShapeInfo);
+				}
+
+
+				printf("Order is: [%c], stride is: xElementStride: [%i], passed strides are: [%i], dimension: [%i]\n", xOrder, xElementWiseStride, xStride[0], dimension[0]);
 			}
 			xLength = shape::length(xShapeInfo);
 			elementsPerTad = xLength / resultLength;
+			printf("xElementStride: [%i]\n", xElementWiseStride);
 		}
 		__syncthreads();
 		int n = xLength;
 
 
 		if (!resultScalar) {
+			if (threadIdx.x == 0)
+				printf("NOT Scalar\n");
+
 			if(tid == 0) {
 				xTadInfo = shape::tadInfo(xShapeInfo, dimension, dimensionLength);
 			}
@@ -253,12 +267,17 @@ public:
 			int tadLength = xTadInfo.tensorShapeProd;
 			int xLength = shape::length(xShapeInfo);
 			int i = 0,j = 0;
+
+            if (threadIdx.x == 0)
+            	printf("ElementsPerReduction: [%i], tadLength: [%i]\n", elementsPerReductionIndex, tadLength);
 #pragma unroll
 			for(i = tid; i < resultLength; i+= blockDim.x * gridDim.x) {
 				int offsetForTad = shape::offset(i, xShapeInfo, dimension,dimensionLength, xTadInfo);
+				printf("Initial Tid: [%i], index: [%i], offsetForTad: [%i], value: [%f] \n", tid, offsetForTad, offsetForTad, dx[offsetForTad]);
 				sPartials[tid] = op(dx[offsetForTad], extraParams);
 				__syncthreads();
 				for(j = 1; j < elementsPerReductionIndex; j++) {
+					printf("Cycled Tid: [%i], index: [%i], offsetForTad: [%i], value: [%f] \n", tid, offsetForTad + xElementWiseStride * j , offsetForTad, dx[offsetForTad + xElementWiseStride * j]);
 					sPartials[tid] =  update(sPartials[tid],op(dx[offsetForTad + xElementWiseStride * j], extraParams), extraParams);
 					__syncthreads();
 				}
@@ -273,6 +292,9 @@ public:
 
 		}
 		else {
+			if (threadIdx.x == 0)
+					printf("Scalar here\n");
+
 			T curr;
 			if (resultScalar) {
 				if(blockIdx.x >= resultLength)
@@ -304,6 +326,8 @@ public:
 				 */
 				unsigned int i = blockIdx.x * xElementWiseStride + tid;
 				unsigned int gridSize = blockDim.x * gridDim.x * xElementWiseStride;
+				if (threadIdx.x == 0)
+					printf("GridSize: [%i]\n", gridSize);
 				if(!this->indexBased) {
 #pragma unroll
 					while (i < n) {
@@ -315,13 +339,14 @@ public:
 				else {
 #pragma unroll
 					while (i < n) {
+						printf("Idx: [%i]\n", i);
 						int tadIndex = shape::tadIndexForLinear(i,elementsPerTad);
 						if(tadIndex == 0) {
-							curr = op(dx[i],realExtraParams);
+							curr = op(dx[i * xElementWiseStride],realExtraParams);
 							reduction = curr;
 						}
 						else {
-							curr = op(dx[i],realExtraParams);
+							curr = op(dx[i * xElementWiseStride],realExtraParams);
 							reduction = update(reduction,curr, realExtraParams);
 						}
 

--- a/include/shape.h
+++ b/include/shape.h
@@ -3679,7 +3679,7 @@ __device__ int tadOffset(int *xInfo, int offset) {
                 return sliceIdx;
             } else {
                 // special case for F ordering on 0 dimension
-                return index * info.tensorShapeLength;
+                return index * info.tensorShapeProd;
             }
         }
 

--- a/include/shape.h
+++ b/include/shape.h
@@ -3672,13 +3672,14 @@ __device__ int tadOffset(int *xInfo, int offset) {
         int ret2Rank = info.xRank - 1;
 
         int retOffset = sliceIdx * info.permutedStrides[0];
-        if(dimension[0] == 0) {
+        if(dimension[0] == 0 ) {
             printf("Falling back...\n");
             char xOrder = order(xShapeInfo);
             if (xOrder == 'c') {
                 return sliceIdx;
             } else {
                 // special case for F ordering on 0 dimension
+                printf("tensorShapeProd: [%i]\n", info.tensorShapeProd);
                 return index * info.tensorShapeProd;
             }
         }

--- a/include/shape.h
+++ b/include/shape.h
@@ -3137,8 +3137,10 @@ namespace shape {
         int tensorLength = prod(tensorShape, tensorShapeLength);
         int lengthPerSlice2 = lengthPerSlice(rank, shape, dimension,
                                              dimensionLength);
-        if (lengthPerSlice2 <= 0)
+        if (lengthPerSlice2 <= 0) {
             return 0;
+        }
+
 
         int offset = index * tensorLength / lengthPerSlice2;
         return offset;
@@ -3670,8 +3672,16 @@ __device__ int tadOffset(int *xInfo, int offset) {
         int ret2Rank = info.xRank - 1;
 
         int retOffset = sliceIdx * info.permutedStrides[0];
-        if(dimension[0] == 0)
-            return sliceIdx;
+        if(dimension[0] == 0) {
+            printf("Falling back...\n");
+            char xOrder = order(xShapeInfo);
+            if (xOrder == 'c') {
+                return sliceIdx;
+            } else {
+                // special case for F ordering on 0 dimension
+                return index * info.tensorShapeLength;
+            }
+        }
 
         int tensorShapeProd = info.tensorShapeProd;
         int val = nd4j::math::nd4j_abs<int>(


### PR DESCRIPTION
reduce single dimensions c/f order seems to be passing now.

indexreduce/stats seems to share the same logic, so after multidimensional reduce is fixed idx handling could be transferred.