### PR TITLE
Use OpenMP based SIMD pragmas

### DIFF
--- a/include/indexreduce.h
+++ b/include/indexreduce.h
@@ -670,7 +670,7 @@ public:
 
 			if (xElementWiseStride == 1) {
 				if(length < 8000) {
-#pragma  simd
+#pragma omp simd
 					for (int i = 0; i < length; i++) {
 						IndexValue<T> curr;
 						curr.value = x[i];

--- a/include/reduce.h
+++ b/include/reduce.h
@@ -600,7 +600,7 @@ public:
 		if (xElementWiseStride == 1) {
 			if(length < 8000) {
 				T local = this->startingValue(x);
-#pragma simd
+#pragma omp simd
 				for(int i = 0; i < length; i++) {
 					T curr = op(x[i], extraParams);
 					local = update(local, curr, extraParams);
@@ -656,7 +656,7 @@ public:
 		else {
 			if(length < 8000) {
 				T local = this->startingValue(x);
-#pragma simd
+#pragma omp simd
 				for(int i = 0; i < length; i++) {
 					T curr = op(x[i *xElementWiseStride], extraParams);
 					local = update(local, curr, extraParams);

--- a/include/reduce3.h
+++ b/include/reduce3.h
@@ -663,10 +663,10 @@ public:
 		if(xOrder == yOrder) {
 			if (xElementWiseStride == 1 && yElementWiseStride == 1) {
 				if(length < 8000) {
-#pragma simd
-for(int i = 0; i < length; i++) {
-	startingVal = update(startingVal,op(x[i],y[i],&extraParamsVals),&extraParamsVals);
-}
+#pragma omp simd
+					for(int i = 0; i < length; i++) {
+						startingVal = update(startingVal,op(x[i],y[i],&extraParamsVals),&extraParamsVals);
+					}
 
 				}
 				else {

--- a/include/shape.h
+++ b/include/shape.h
@@ -3082,7 +3082,7 @@ namespace shape {
     int *concat(int numArrays, int numTotalElements, int **arr, int *lengths) {
         int *ret = (int *) malloc(numTotalElements * sizeof(int));
         int count = 0;
-#pragma simd
+#pragma omp simd
         for (int i = 0; i < numArrays; i++) {
             for (int j = 0; j < lengths[i]; j++) {
                 ret[count++] = arr[i][j];
@@ -3804,11 +3804,11 @@ __device__ int tadOffset(int *xInfo, int offset) {
         int count = 1;
         const int rank = info->rank;
         ret[0] = info->rank;
-#pragma simd
+#pragma omp simd
         for (int i = 0; i < rank; i++) {
             ret[count++] = info->shape[i];
         }
-#pragma simd
+#pragma omp simd
         for (int i = 0; i < rank; i++) {
             ret[count++] = info->stride[i];
         }

--- a/include/transform.h
+++ b/include/transform.h
@@ -229,7 +229,7 @@ public:
 			T *extraParams,
 			int *indexes) {
 		int n = shape::length(xShapeInfo);
-#pragma simd
+#pragma omp simd
 		for (int i = 0; i < n; i++) {
 			result[indexes[i]] = op(dx[indexes[i]], extraParams);
 		}
@@ -352,7 +352,7 @@ public:
 			int n) {
 		if (xStride == 1 && resultStride == 1) {
 			if(n < 8000) {
-#pragma simd 
+#pragma omp simd 
 				for (int i = 0; i < n; i++) {
 					result[i] = op(dx[i], extraParams);
 				}
@@ -369,6 +369,7 @@ public:
 
 		else {
 			if(n < 8000) {
+#pragma omp simd 
 				for (int i = 0; i < n; i++) {
 					result[i * resultStride] = op(dx[i * xStride],
 							extraParams);


### PR DESCRIPTION
Only the intel compiler understands "#pragma simd" while the portable way
is to use the "#pragma omp simd" that was introduced in OpenMP 4.0.