### PR TITLE
Update OS X build guide to include xcode-select

### DIFF
--- a/macOSx10 (CPU only).md
+++ b/macOSx10 (CPU only).md
@@ -5,7 +5,7 @@ Make sure you follow the instructions in order (its proved to work so far, and i
 1. Make sure you have all the Apple updates installed (at time of writing 10.11.4
 
 2. Make sure you have the latest XCode (go to the app store and make sure you have the latest, at time of writing 7.3)
-  Now that that is done proceed...
+  You will also want to run `xcode-select --install` to ensure the correct version of clang is available.
 
 3. Make sure you have brew (if not get it http://brew.sh)
 


### PR DESCRIPTION
Without running `xcode-select --install` the correct version of clang may not be in the path, and linking errors will occur at build time.