### PR TITLE
Build using `cmake3` when available (under CentOS, etc)

### DIFF
--- a/buildnativeoperations.sh
+++ b/buildnativeoperations.sh
@@ -2,6 +2,9 @@
 
 
 export CMAKE_COMMAND="cmake"
+if which cmake3 &> /dev/null; then
+    export CMAKE_COMMAND="cmake3"
+fi
 export MAKE_COMMAND="make"
 echo eval $CMAKE_COMMAND
 if [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
In those cases, the `cmake` command is usually CMake 2.8, but we want to use CMake 3.x