### PR TITLE
Optimize some more CPU processing with OpenMP

### DIFF
--- a/include/shape.h
+++ b/include/shape.h
@@ -1773,6 +1773,7 @@ namespace shape {
             traceNew(1);
 
             this->tadOffsets = new int[this->numTads];
+#pragma omp parallel for
             for(int i = 0; i < this->numTads; i++) {
                 this->tadOffsets[i] = this->tadOffset(i);
 

--- a/include/special_ops.h
+++ b/include/special_ops.h
@@ -162,24 +162,22 @@ namespace simdOps {
 			int xOutFrom = 0;
 			int xOutTo = outSize(inShape[3], kernelWidth, strideX, padWidth, coverAll);
 
-
-			int *outIndices = new int[6];
-			int *inIndices = new int[4];
-
-			int inStride2 = inStride[2];
-			int inStride3 = inStride[3];
-			int outStride2 = outStride[2];
-			int outStride3 = outStride[3];
-			int inShape2 = inShape[2];
-			int inShape3 = inShape[3];
-
-			bool padding = padHeight > 0 || padWidth > 0;
-
 			T *dIn = dx;
 			T *dOut = result;
-			//#pragma omp parallel for collapse(2)
+#pragma omp parallel for collapse(2)
 			for (int ex = exampleFrom; ex < exampleTo; ex++) {
 				for (int d = depthFrom; d < depthTo; d++) {
+					int outIndices[6];
+					int inIndices[4];
+
+					int inStride2 = inStride[2];
+					int inStride3 = inStride[3];
+					int outStride2 = outStride[2];
+					int outStride3 = outStride[3];
+					int inShape2 = inShape[2];
+					int inShape3 = inShape[3];
+
+					bool padding = padHeight > 0 || padWidth > 0;
 					inIndices[0] = ex;
 					inIndices[1] = d;
 					outIndices[0] = ex;
@@ -275,9 +273,6 @@ namespace simdOps {
 					}
 				}
 			}
-
-			delete[] inIndices;
-			delete[] outIndices;
 
 		}
 
@@ -454,27 +449,26 @@ namespace simdOps {
 			int *outStride = shape::stride(resultShapeBuffer);
 
 
-			int *outIndices = new int[4];
-			int *inIndices = new int[6];
-
-			int inStride2 = inStride[2];
-			int inStride3 = inStride[3];
-			int outStride2 = outStride[2];
-			int outStride3 = outStride[3];
-			int outShape2 = outShape[2];
-			int outShape3 = outShape[3];
-
-			int yOutTo = inShape[4];
-			int xOutTo = inShape[5];
-
-
-			bool padding = padHeight > 0 || padWidth > 0;
-
 			T *fIn = dx;
 			T *fOut = result;
-			//#pragma omp parallel for collapse(2)
+#pragma omp parallel for collapse(2)
 			for (int ex = exampleFrom; ex < exampleTo; ex++) {
 				for (int d = depthFrom; d < depthTo; d++) {
+					int outIndices[4];
+					int inIndices[6];
+
+					int inStride2 = inStride[2];
+					int inStride3 = inStride[3];
+					int outStride2 = outStride[2];
+					int outStride3 = outStride[3];
+					int outShape2 = outShape[2];
+					int outShape3 = outShape[3];
+
+					int yOutTo = inShape[4];
+					int xOutTo = inShape[5];
+
+
+					bool padding = padHeight > 0 || padWidth > 0;
 					inIndices[0] = ex;
 					inIndices[1] = d;
 					outIndices[0] = ex;
@@ -563,8 +557,6 @@ namespace simdOps {
 			}
 
 
-			delete[] outIndices;
-			delete[] inIndices;
 		}
 
 		op_def static T op(T d1, T *params) {
@@ -1215,16 +1207,27 @@ namespace simdOps {
 					else {
 						int maxIdx = 0;
 						T currMax = dx[0];
-#pragma omp parallel for shared(maxIdx,currMax) schedule(guided)
+#pragma omp parallel
+{
+						int maxIdxLocal = maxIdx;
+						T currMaxLocal = currMax;
+#pragma omp for nowait
 						for (int i = 0; i < length; i++) {
-							if (currMax < dx[i]) {
-								currMax = dx[i];
-								maxIdx = i;
+							if (currMaxLocal < dx[i]) {
+								currMaxLocal = dx[i];
+								maxIdxLocal = i;
 							}
 							result[i] = 0.0;
 
 						}
-
+#pragma omp critical
+{
+						if (currMax < currMaxLocal) {
+							currMax = currMaxLocal;
+							maxIdx = maxIdxLocal;
+						}
+}
+}
 						result[maxIdx] = 1.0;
 					}
 
@@ -1248,15 +1251,27 @@ namespace simdOps {
 					else {
 						int maxIdx = 0;
 						T currMax = dx[0];
-#pragma omp parallel for shared(maxIdx,currMax) schedule(guided)
+#pragma omp parallel
+{
+						int maxIdxLocal = maxIdx;
+						T currMaxLocal = currMax;
+#pragma omp for nowait
 						for (int i = 0; i < length; i++) {
 							result[i * resultEleStride] = 0.0;
-							if (currMax < dx[i * eleStride]) {
-								currMax = dx[i * eleStride];
-								maxIdx = i;
+							if (currMaxLocal < dx[i * eleStride]) {
+								currMaxLocal = dx[i * eleStride];
+								maxIdxLocal = i;
 							}
 						}
 
+#pragma omp critical
+{
+						if (currMax < currMaxLocal) {
+							currMax = currMaxLocal;
+							maxIdx = maxIdxLocal;
+						}
+}
+}
 						result[maxIdx * resultEleStride] = 1.0;
 					}
 
@@ -1383,17 +1398,28 @@ namespace simdOps {
 							}
 						}
 						else {
-
-#pragma omp parallel for simd shared(maxIdx,currMax) schedule(guided)
+#pragma omp parallel
+{
+							int maxIdxLocal = maxIdx;
+							T currMaxLocal = currMax;
+#pragma omp for nowait
 							for (int i = 0; i < length; i++) {
-								if (currMax < dx[i]) {
-									currMax = dx[i];
-									maxIdx = i;
+								if (currMaxLocal < dx[i]) {
+									currMaxLocal = dx[i];
+									maxIdxLocal = i;
 								}
 
 								result[i] = 0.0;
 
 							}
+#pragma omp critical
+{
+							if (currMax < currMaxLocal) {
+								currMax = currMaxLocal;
+								maxIdx = maxIdxLocal;
+							}
+}
+}
 						}
 
 						result[maxIdx] = 1.0;
@@ -1417,16 +1443,28 @@ namespace simdOps {
 							}
 						}
 						else {
-#pragma omp parallel for simd shared(maxIdx,currMax) schedule(guided)
+#pragma omp parallel
+{
+							int maxIdxLocal = maxIdx;
+							T currMaxLocal = currMax;
+#pragma omp for nowait
 							for (int i = 0; i < length; i++) {
-								if (currMax < dx[i * eleStride]) {
-									currMax = dx[i * eleStride];
-									maxIdx = i;
+								if (currMaxLocal < dx[i * eleStride]) {
+									currMaxLocal = dx[i * eleStride];
+									maxIdxLocal = i;
 								}
 
 								result[i] = 0.0;
 
 							}
+#pragma omp critical
+{
+							if (currMax < currMaxLocal) {
+								currMax = currMaxLocal;
+								maxIdx = maxIdxLocal;
+							}
+}
+}
 						}
 
 						result[maxIdx] = 1.0;
@@ -1438,7 +1476,7 @@ namespace simdOps {
 			}
 			else {
 				int dimensionLength = (int)extraParams[0];
-				int *dimension = (int *)malloc(sizeof(int) *dimensionLength);
+				int *dimension = new int[dimensionLength];
 				for (int i = 0; i < dimensionLength; i++) {
 					dimension[i] = (int)extraParams[i + 1];
 				}
@@ -1506,7 +1544,6 @@ namespace simdOps {
 						maxCursor[0] = 1.0;
 					}
 				}
-
 			}
 		}
 

--- a/include/util.h
+++ b/include/util.h
@@ -1,0 +1,32 @@
+/* 
+ * File:   util.h
+ * Author: saudet
+ *
+ * Created on July 18, 2016, 1:28 PM
+ */
+
+#ifndef NATIVEOPERATIONS_UTIL_H
+#define NATIVEOPERATIONS_UTIL_H
+
+#ifdef WIN32
+#include <windows.h>
+#else
+#include <sys/time.h>
+#endif
+
+#include "pointercast.h"
+
+static inline Nd4jIndex microTime() {
+#ifdef WIN32
+    LARGE_INTEGER freq, count;
+    QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&count);
+    return (Nd4jIndex)count.QuadPart/freq.QuadPart;
+#else
+    timeval tv;
+    gettimeofday(&tv, NULL);
+    return (Nd4jIndex)tv.tv_sec*1000000 + tv.tv_usec;
+#endif
+}
+
+#endif /* NATIVEOPERATIONS_UTIL_H */


### PR DESCRIPTION
With these changes, the CPU usage of the non-BLAS function calls by  MLPMnistSingleLayerExample and LenetMnistExample goes from about 50% to pretty much 100%. However, execution time of MLPMnistSingleLayerExample is only reduced by about 25% and LenetMnistExample by about 40% (so this one almost twice as fast though :).

The remaining bottlenecks basically involves memory access patterns that are not cache-friendly, for operations where, for example, even though the shape might be the same, the strides are reversed. We should try to eliminate as much of those as possible, obviously, but the goal is to come up with a list of such operations that we deem "crucial". And then optimize those with cache blocking techniques.

As for the BLAS operations, for these two examples, OpenBLAS executes faster with a single thread, even though the multithreaded version uses 100% of the CPU. MKL is faster than OpenBLAS, and doesn't use 100% of the CPU, so it looks like there are also operations we are asking BLAS to do that do not parallelize well and MKL detects those...

In any case, if this PR here looks alright for now, please merge!