### PR TITLE
windows.md update

### DIFF
--- a/windows.md
+++ b/windows.md
@@ -34,9 +34,10 @@ The CUDA Backend has some additional requirements before it can be built:
 
 In order to build the CUDA backend you will have to setup some more environment variables first, by calling `vcvars64.bat`.
 But first, set the system environment variable `SET_FULL_PATH` to `true`, so all of the variables that `vcvars64.bat` sets up, are passed to the mingw shell.
+Additionally, you need to open the `mingw64.ini` in your msys64 installation folder and add the command: `MSYS2_PATH_TYPE=inherit`.
 
 1. Inside a normal cmd.exe command prompt, run `C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\amd64\vcvars64.bat`
-2. Run `c:\msys64\mingw64_shell.bat` inside that
+2. Run `c:\msys64\mingw64.exe` inside that
 3. Change to your libnd4j folder
 4. `./buildnativeoperations.sh -c cuda`
 


### PR DESCRIPTION
Msys changed their environment. There is no 'mingw64_shell.bat' anymore but a 'mingw64.exe'. Also one needs to add a line to the 'mingw64.ini' so the mingw64 shell finds required commands.