### PR TITLE
Harmonize toolchains with OpenBLAS (GCC for OpenMP, Xcode's Clang for CUDA)

### DIFF
--- a/blas/CMakeLists.txt
+++ b/blas/CMakeLists.txt
@@ -8,7 +8,6 @@ if(APPLE)
     link_directories(/usr/local/lib)
     link_directories(/usr/lib)
     link_directories(/lib)
-    link_directories(/usr/local/opt/llvm/lib)
 endif()
 if(WIN32)
     get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
@@ -30,14 +29,10 @@ ENDIF()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # using Clang
-    set(CMAKE_C_COMPILER clang-omp++)
-    set(CMAKE_CXX_COMPILER clang-omp++)
-
-    SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${ARCH_TUNE} -fopenmp ")
+    SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${ARCH_TUNE}")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-    SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${ARCH_TUNE} -O3 -fp-model fast")
-
     # using Intel C++
+    SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${ARCH_TUNE} -O3 -fp-model fast")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # using Visual Studio C++
 
@@ -63,9 +58,7 @@ if(CUDA_BLAS)
     message("Build cublas")
     find_package(CUDA)
     add_definitions(-D__CUDABLAS__=true)
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        list(APPEND CUDA_NVCC_FLAGS "-ccbin clang-omp")
-    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         set (CMAKE_CXX_FLAGS "")
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         if ("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER 4.9 AND "$ENV{TRICK_NVCC}" STREQUAL "YES")

--- a/buildnativeoperations.sh
+++ b/buildnativeoperations.sh
@@ -125,8 +125,13 @@ case "$OS" in
 
     macosx)
     # Do something under Mac OS X platform
-    export CC=clang-omp
-    export CXX=clang-omp++
+    if [ "$CHIP" == "cuda" ]; then
+        export CC=clang
+        export CXX=clang++
+    else
+        export CC=$(ls /usr/local/bin/gcc-?)
+        export CXX=$(ls /usr/local/bin/g++-?)
+    fi
     ;;
 
     windows)

--- a/include/convolution.h
+++ b/include/convolution.h
@@ -5,7 +5,9 @@
 #ifndef NATIVEOPERATIONS_CONVOLUTION_H
 #define NATIVEOPERATIONS_CONVOLUTION_H
 
+#ifndef __CUDACC__
 #include <omp.h>
+#endif
 
 template <typename T>
 class Im2col {

--- a/include/indexreduce.h
+++ b/include/indexreduce.h
@@ -8,7 +8,9 @@
 #ifndef INDEXREDUCE_H_
 #define INDEXREDUCE_H_
 #include <shape.h>
+#ifndef __CUDACC__
 #include <omp.h>
+#endif
 #include <dll.h>
 #include <ops.h>
 #include <op_boilerplate.h>
@@ -17,12 +19,11 @@
 #include <helper_cuda.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#define omp_get_thread_num() 0
+#define omp_get_max_threads() 1
 #endif
 
 
-#ifdef __JNI__
-#include <jni.h>
-#endif
 #include <pairwise_util.h>
 
 

--- a/include/pairwise_transform.h
+++ b/include/pairwise_transform.h
@@ -7,10 +7,9 @@
 
 #ifndef PAIRWISE_TRANSFORM_H_
 #define PAIRWISE_TRANSFORM_H_
-#ifdef __JNI__
-#include <jni.h>
-#endif
+#ifndef __CUDACC__
 #include <omp.h>
+#endif
 #include <templatemath.h>
 #include <helper_cuda.h>
 #include <shape.h>
@@ -23,6 +22,8 @@
 #ifdef __CUDACC__
 #include <cuda.h>
 #include <cuda_runtime.h>
+#define omp_get_thread_num() 0
+#define omp_get_max_threads() 1
 #endif
 
 #define PAIRWISE_TRANSFORM_OPS \

--- a/include/pairwise_util.h
+++ b/include/pairwise_util.h
@@ -7,12 +7,16 @@
 #ifdef __CUDACC__
 #include <cuda.h>
 #include <cuda_runtime.h>
+#define omp_get_thread_num() 0
+#define omp_get_max_threads() 1
 #endif
 #include <pairwise_util.h>
 #include <pointercast.h>
 #include <dll.h>
 #include <nd4jmemset.h>
+#ifndef __CUDACC__
 #include <omp.h>
+#endif
 //Loops adapted from:
 //https://github.com/numpy/numpy/blob/009b17a85a22707e63ac9ea1896413992bbf9ce5/numpy/core/src/private/lowlevel_strided_loops.h#L401-L401
 

--- a/include/reduce.h
+++ b/include/reduce.h
@@ -3,7 +3,9 @@
 #include <sharedmem.h>
 #include <stdio.h>
 #include <shape.h>
+#ifndef __CUDACC__
 #include <omp.h>
+#endif
 #include <templatemath.h>
 #include <helper_cuda.h>
 #include <nd4jmalloc.h>
@@ -15,9 +17,8 @@
 #ifdef __CUDACC__
 #include <cuda.h>
 #include <cuda_runtime.h>
-#endif
-#ifdef __JNI__
-#include <jni.h>
+#define omp_get_thread_num() 0
+#define omp_get_max_threads() 1
 #endif
 
 

--- a/include/reduce3.h
+++ b/include/reduce3.h
@@ -13,20 +13,20 @@
 #include <templatemath.h>
 #include <helper_cuda.h>
 #include <sharedmem.h>
+#ifndef __CUDACC__
 #include <omp.h>
+#endif
 #include <pairwise_util.h>
 #include <dll.h>
 #include <shape.h>
 #include <ops.h>
 #include <op_boilerplate.h>
 
-#ifdef __JNI__
-#include <jni.h>
-#endif
-
 #ifdef __CUDACC__
 #include <cuda.h>
 #include <cuda_runtime.h>
+#define omp_get_thread_num() 0
+#define omp_get_max_threads() 1
 #endif
 
 

--- a/include/transform.h
+++ b/include/transform.h
@@ -11,7 +11,9 @@
 #include <vector>
 #include <templatemath.h>
 #include <ops.h>
+#ifndef __CUDACC__
 #include <omp.h>
+#endif
 #include <pairwise_util.h>
 #include <dll.h>
 #include "reduce.h"
@@ -25,15 +27,11 @@
 #include "types/float8.h"
 
 #ifdef __CUDACC__
-#include <helper_cuda.h>
-#endif
-
-#ifdef __JNI__
-#include <jni.h>
-#endif
-#ifdef __CUDACC__
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <helper_cuda.h>
+#define omp_get_thread_num() 0
+#define omp_get_max_threads() 1
 #endif
 
 

--- a/macOSx10 (CPU only).md
+++ b/macOSx10 (CPU only).md
@@ -5,23 +5,24 @@ Make sure you follow the instructions in order (its proved to work so far, and i
 1. Make sure you have all the Apple updates installed (at time of writing 10.11.4
 
 2. Make sure you have the latest XCode (go to the app store and make sure you have the latest, at time of writing 7.3)
-  You will also want to run `xcode-select --install` to ensure the correct version of clang is available.
+  You will also want to run `xcode-select --install` to ensure the correct version of Xcode is available.
 
 3. Make sure you have brew (if not get it http://brew.sh)
 
-4. run `brew install llvm openblas` in terminal (this will install llvm/clang (at time of writing 3.8.0). Also please note: openblas is optional, Apple Accelerate library is supported as well.
+4. run `brew install gcc5` in terminal (this will install GCC (at time of writing 5.4.0). Also please note: openblas is optional, Apple Accelerate library is supported as well.
 
 4.1 Add following symbolic links:
 ```
-ln -s /usr/local/opt/llvm/bin/clang /usr/local/bin/clang-omp
-ln -s /usr/local/opt/llvm/bin/clang++ /usr/local/bin/clang-omp++
+ln -s /usr/local/Cellar/gcc5/5.4.0/bin/gcc-5 /usr/local/bin/gcc-5
+ln -s /usr/local/Cellar/gcc5/5.4.0/bin/g++-5 /usr/local/bin/g++-5
+ln -s /usr/local/Cellar/gcc5/5.4.0/bin/gfortran-5 /usr/local/bin/gfortran-5
 ```
 
 5. Clone the libnd4j repo from the deeplearning4j (and unzip if its not automatically done)
 
 6. export the path to the folder as LIBND4J_HOME (eg: export LIBND4J_HOME=/workspace/libnd4j-master) 
-6b. run `export` in terminal and make sure your path variable contains the path to `clang-omp` (`/usr/local/Cellar/clang-omp/2015-04-01/bin`)
-6c. make sure there are no exports for variables like LIBRARY_PATH, or LD_LIBRARY_PATH or DYLD_LIBRARY_PATH, but if they are, and are pointing to anything inside clang-omp remove the clang-omp bits (or if you have trouble, remove the paths entirely)
+6b. run `export` in terminal and make sure your path variable contains the path to `gcc-5` (`/usr/local/Cellar/gcc5/5.4.0/bin/`)
+6c. make sure there are no exports for variables like LIBRARY_PATH, or LD_LIBRARY_PATH or DYLD_LIBRARY_PATH, but if they are, and are pointing to anything inside `gcc-5` remove the `gcc-5` bits (or if you have trouble, remove the paths entirely)
 
 7. `cd $LIBND4J_HOME` 
 8. `./buildnativeoperations.sh` (This will give a LOT of warnings, dont fret, if the last line is something like `[100%] Built target nd4j`)


### PR DESCRIPTION
Removes dependency on `clang-omp` in the case of Mac OS X