### PR TITLE
Native sort

### DIFF
--- a/blas/NativeOpExcutioner.h
+++ b/blas/NativeOpExcutioner.h
@@ -767,6 +767,10 @@ public:
     static void execSort(T *x, int *xShapeInfo, bool descending) {
         sortGeneric<T>(x, xShapeInfo, descending);
     }
+
+    static void execSort(T *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
+        sortTadGeneric<T>(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending);
+    }
 };
 
 

--- a/blas/NativeOpExcutioner.h
+++ b/blas/NativeOpExcutioner.h
@@ -16,6 +16,7 @@
 #include <loops/aggregates.h>
 #include <loops/random.h>
 #include <pointercast.h>
+#include <ops/specials.h>
 /**
  * Native op executioner:
  *
@@ -760,6 +761,11 @@ public:
                                                             z,
                                                             zShapeBuffer,
                                                             extraArguments);
+    }
+
+
+    static void execSort(T *x, int *xShapeInfo, bool descending) {
+        sortGeneric<T>(x, xShapeInfo, descending);
     }
 };
 

--- a/blas/NativeOps.h
+++ b/blas/NativeOps.h
@@ -2905,6 +2905,10 @@ public:
     void decodeThresholdDouble(Nd4jPointer *extraPointers, void *dx, Nd4jIndex N, double *dz);
 
     void decodeThresholdHalf(Nd4jPointer *extraPointers, void *dx, Nd4jIndex N, float16 *dz);
+
+
+
+    void sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, bool descending);
 };
 
 

--- a/blas/NativeOps.h
+++ b/blas/NativeOps.h
@@ -2910,7 +2910,17 @@ public:
 
     void sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, bool descending);
 
+    void sortDouble(Nd4jPointer *extraPointers, double *x, int *xShapeInfo, bool descending);
+
+    void sortHalf(Nd4jPointer *extraPointers, float16 *x, int *xShapeInfo, bool descending);
+
+
+
     void sortTadFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending);
+
+    void sortTadDouble(Nd4jPointer *extraPointers, double *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending);
+
+    void sortTadHalf(Nd4jPointer *extraPointers, float16 *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending);
 };
 
 

--- a/blas/NativeOps.h
+++ b/blas/NativeOps.h
@@ -2909,6 +2909,8 @@ public:
 
 
     void sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, bool descending);
+
+    void sortTadFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending);
 };
 
 

--- a/blas/cpu/NativeOps.cpp
+++ b/blas/cpu/NativeOps.cpp
@@ -2974,3 +2974,7 @@ Nd4jPointer NativeOps::pointerForAddress(long address) {
 void NativeOps::sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, bool descending) {
     NativeOpExcutioner<float>::execSort(x, xShapeInfo, descending);
 }
+
+void NativeOps::sortTadFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
+    NativeOpExcutioner<float>::execSort(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending);
+}

--- a/blas/cpu/NativeOps.cpp
+++ b/blas/cpu/NativeOps.cpp
@@ -2970,3 +2970,7 @@ int NativeOps::elementSizeForNpyArray(Nd4jPointer npyArray) {
 Nd4jPointer NativeOps::pointerForAddress(long address) {
     return reinterpret_cast<Nd4jPointer >(address);
 }
+
+void NativeOps::sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, bool descending) {
+    NativeOpExcutioner<float>::execSort(x, xShapeInfo, descending);
+}

--- a/blas/cpu/NativeOps.cpp
+++ b/blas/cpu/NativeOps.cpp
@@ -2975,6 +2975,22 @@ void NativeOps::sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo,
     NativeOpExcutioner<float>::execSort(x, xShapeInfo, descending);
 }
 
+void NativeOps::sortDouble(Nd4jPointer *extraPointers, double *x, int *xShapeInfo, bool descending) {
+    NativeOpExcutioner<double>::execSort(x, xShapeInfo, descending);
+}
+
+void NativeOps::sortHalf(Nd4jPointer *extraPointers, float16 *x, int *xShapeInfo, bool descending) {
+    //NativeOpExcutioner<float16>::execSort(x, xShapeInfo, descending);
+}
+
 void NativeOps::sortTadFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
     NativeOpExcutioner<float>::execSort(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending);
+}
+
+void NativeOps::sortTadDouble(Nd4jPointer *extraPointers, double *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
+    NativeOpExcutioner<double>::execSort(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending);
+}
+
+void NativeOps::sortTadHalf(Nd4jPointer *extraPointers, float16 *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
+    //NativeOpExcutioner<float16>::execSort(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending);
 }

--- a/blas/cuda/NativeOps.cu
+++ b/blas/cuda/NativeOps.cu
@@ -6468,9 +6468,10 @@ void NativeOps::sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo,
     int *hostXShapeInfo = reinterpret_cast<int *>(extraPointers[0]);
 
     int xLength = shape::length(hostXShapeInfo);
+    int xEWS = shape::elementWiseStride(hostXShapeInfo);
 
     // check if xLength is a power of 2, and use bitonic sort, if that's the case
-    if ((xLength != 0) && ((xLength & (xLength - 1)) == 0)) {
+    if ((xLength != 0) && ((xLength & (xLength - 1)) == 0) && (xLength <= 1024 * 1024 * 10)) {
         int numThreads = nd4j::math::nd4j_min<int>(512, xLength);
         int numBlocks = xLength / numThreads;
         if (xLength % numThreads > 0 || numBlocks == 0)
@@ -6482,7 +6483,7 @@ void NativeOps::sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo,
             }
         }
     } else {
-        if (xLength > 1024 * 1024 * 10) {
+        if ((xLength > 1024 * 1024 * 10) && xEWS == 1) {
             b40c::radix_sort::Enactor enactor;
 
             b40c::util::DoubleBuffer<float> sort_storage(x);
@@ -6530,9 +6531,10 @@ void NativeOps::sortDouble(Nd4jPointer *extraPointers, double *x, int *xShapeInf
     int *hostXShapeInfo = reinterpret_cast<int *>(extraPointers[0]);
 
     int xLength = shape::length(hostXShapeInfo);
+    int xEWS = shape::elementWiseStride(hostXShapeInfo);
 
     // check if xLength is a power of 2, and use bitonic sort, if that's the case
-    if ((xLength != 0) && ((xLength & (xLength - 1)) == 0)) {
+    if ((xLength != 0) && ((xLength & (xLength - 1)) == 0) && (xLength <= 1024 * 1024 * 10)) {
         int numThreads = nd4j::math::nd4j_min<int>(512, xLength);
         int numBlocks = xLength / numThreads;
         if (xLength % numThreads > 0 || numBlocks == 0)
@@ -6544,7 +6546,7 @@ void NativeOps::sortDouble(Nd4jPointer *extraPointers, double *x, int *xShapeInf
             }
         }
     } else {
-        if (xLength > 1024 * 1024 * 10) {
+        if ((xLength > 1024 * 1024 * 10) && xEWS == 1) {
             b40c::radix_sort::Enactor enactor;
 
             b40c::util::DoubleBuffer<double> sort_storage(x);

--- a/blas/cuda/NativeOps.cu
+++ b/blas/cuda/NativeOps.cu
@@ -35,10 +35,13 @@
 #include <ops/specials_cuda.h>
 //#include <sys/time.h>
 
+// b40c only available for gcc :(
+#ifdef __GNUC__
 #include <b40c/util/error_utils.cuh>
 #include <b40c/util/multiple_buffering.cuh>
 
 #include <b40c/radix_sort/enactor.cuh>
+#endif
 
 #include <curand.h>
 
@@ -6483,6 +6486,8 @@ void NativeOps::sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo,
             }
         }
     } else {
+
+#ifdef __GNUC__
         if ((xLength > 1024 * 1024 * 10) && xEWS == 1) {
             b40c::radix_sort::Enactor enactor;
 
@@ -6494,6 +6499,9 @@ void NativeOps::sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo,
             if (descending)
                 execTransformFloat(extraPointers, 70, x, xShapeInfo, x, xShapeInfo, nullptr);
         } else {
+#else
+        if (1 > 0) {
+#endif
             int numThreads = nd4j::math::nd4j_min<int>(512, xLength);
             int numBlocks = xLength / numThreads;
             if (xLength % numThreads > 0 || numBlocks == 0)
@@ -6546,6 +6554,7 @@ void NativeOps::sortDouble(Nd4jPointer *extraPointers, double *x, int *xShapeInf
             }
         }
     } else {
+#ifdef __GNUC__
         if ((xLength > 1024 * 1024 * 10) && xEWS == 1) {
             b40c::radix_sort::Enactor enactor;
 
@@ -6557,6 +6566,9 @@ void NativeOps::sortDouble(Nd4jPointer *extraPointers, double *x, int *xShapeInf
             if (descending)
                 execTransformDouble(extraPointers, 70, x, xShapeInfo, x, xShapeInfo, nullptr);
         } else {
+#else
+        if ( 1 > 0) {
+#endif
             int numThreads = nd4j::math::nd4j_min<int>(512, xLength);
             int numBlocks = xLength / numThreads;
             if (xLength % numThreads > 0 || numBlocks == 0)

--- a/blas/cuda/NativeOps.cu
+++ b/blas/cuda/NativeOps.cu
@@ -31,6 +31,8 @@
 #include <loops/grid.h>
 #include <loops/aggregates.h>
 #include <helpers/threshold.h>
+
+#include <ops/specials_cuda.h>
 //#include <sys/time.h>
 
 #include <curand.h>
@@ -6445,9 +6447,50 @@ void NativeOps::execReduce3AllHalf(Nd4jPointer *extraPointers,
 }
 
 void NativeOps::sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, bool descending) {
-	// to be implemented
+    cudaStream_t *stream = reinterpret_cast<cudaStream_t *>(&extraPointers[1]);
+    int *hostXShapeInfo = reinterpret_cast<int *>(extraPointers[0]);
+
+    int xLength = shape::length(hostXShapeInfo);
+    int numThreads = nd4j::math::nd4j_min<int>(512, xLength);
+    int numBlocks = xLength / numThreads;
+    if (xLength % numThreads > 0 || numBlocks == 0)
+        numBlocks++;
+    int i,j,k;
+/*
+   int i,j,k;
+    for (k=2;k<=N;k=2*k) {
+      for (j=k>>1;j>0;j=j>>1) {
+        for (i=0;i<N;i++) {
+          int ixj=i^j;
+          if ((ixj)>i) {
+            if ((i&k)==0 && get(i)>get(ixj)) exchange(i,ixj);
+            if ((i&k)!=0 && get(i)<get(ixj)) exchange(i,ixj);
+          }
+        }
+      }
+    }
+ */
+/*
+    int j, k;
+      for (k = 2; k <= xLength; k = 2*k) {
+          for (j=k>>1; j>0; j=j>>1) {
+            printf("K: %i; J: %i\n", k, j);
+            bitonicFloat<<<numBlocks, numThreads, 512, *stream>>>(x, xShapeInfo, j, k, descending);
+        }
+    }
+*/
+
+	cudaSortFloat<<<numBlocks, numThreads, 512, *stream>>>(x, xShapeInfo, j, k, descending);
+
+    checkCudaErrors(cudaStreamSynchronize(*stream));
 }
 
 void NativeOps::sortTadFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
     // to be implemented
+    cudaStream_t *stream = reinterpret_cast<cudaStream_t *>(&extraPointers[1]);
+    int *hostXShapeInfo = reinterpret_cast<int *>(extraPointers[0]);
+
+    cudaSortTadFloat<<<512, 512, 512, *stream>>>(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending);
+
+    checkCudaErrors(cudaStreamSynchronize(*stream));
 }

--- a/blas/cuda/NativeOps.cu
+++ b/blas/cuda/NativeOps.cu
@@ -1654,6 +1654,10 @@ void   NativeOps::execTransformDouble(
             launchDims.x = 512;
             launchDims.y = 512;
             launchDims.z += 768;
+        } else if (opNum == 70) {
+            // we'll be using shared memory to speed up reverse
+
+            launchDims.z += launchDims.y * sizeof(float);
         }
 
 		// Histogram op requires additional memory chunk
@@ -3798,7 +3802,11 @@ void   NativeOps::execTransformFloat(Nd4jPointer *extraPointers,int opNum,
             launchDims.x = 512;
             launchDims.y = 512;
             launchDims.z += 384;
-        }
+        } else if (opNum == 70) {
+			// we'll be using shared memory to speed up reverse
+
+			launchDims.z += launchDims.y * sizeof(float);
+		}
 
 		// histogram op requies additional memory chunk :(
         if (opNum == 48) {
@@ -4043,6 +4051,10 @@ void   NativeOps::execTransformHalf(Nd4jPointer *extraPointers,int opNum,
             launchDims.x = 512;
             launchDims.y = 512;
             launchDims.z += 384;
+        } else if (opNum == 70) {
+            // we'll be using shared memory to speed up reverse
+
+            launchDims.z += launchDims.y * sizeof(float);
         }
 
 		// Histogram op requires additional memory chunk

--- a/blas/cuda/NativeOps.cu
+++ b/blas/cuda/NativeOps.cu
@@ -6447,3 +6447,7 @@ void NativeOps::execReduce3AllHalf(Nd4jPointer *extraPointers,
 void NativeOps::sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, bool descending) {
 	// to be implemented
 }
+
+void NativeOps::sortTadFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
+    // to be implemented
+}

--- a/blas/cuda/NativeOps.cu
+++ b/blas/cuda/NativeOps.cu
@@ -6443,3 +6443,7 @@ void NativeOps::execReduce3AllHalf(Nd4jPointer *extraPointers,
     if (debug)
         checkCudaErrors(cudaStreamSynchronize(*stream));
 }
+
+void NativeOps::sortFloat(Nd4jPointer *extraPointers, float *x, int *xShapeInfo, bool descending) {
+	// to be implemented
+}

--- a/blas/cuda/NativeOps.cu
+++ b/blas/cuda/NativeOps.cu
@@ -6490,7 +6490,7 @@ void NativeOps::sortTadFloat(Nd4jPointer *extraPointers, float *x, int *xShapeIn
     cudaStream_t *stream = reinterpret_cast<cudaStream_t *>(&extraPointers[1]);
     int *hostXShapeInfo = reinterpret_cast<int *>(extraPointers[0]);
 
-    cudaSortTadFloat<<<512, 512, 512, *stream>>>(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending);
+    cudaSortTadFloat<<<512, 512, 1088 * sizeof(float), *stream>>>(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending);
 
     checkCudaErrors(cudaStreamSynchronize(*stream));
 }

--- a/include/b40c/partition/downsweep/cta.cuh
+++ b/include/b40c/partition/downsweep/cta.cuh
@@ -1,0 +1,176 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ * Abstract CTA-processing functionality for partitioning downsweep
+ * scan kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/util/device_intrinsics.cuh>
+#include <b40c/util/io/load_tile.cuh>
+#include <b40c/util/io/scatter_tile.cuh>
+
+namespace b40c {
+namespace partition {
+namespace downsweep {
+
+
+/**
+ * Partitioning downsweep scan CTA
+ *
+ * Abstract class
+ */
+template <
+	typename KernelPolicy,
+	typename DerivedCta,									// Derived CTA class
+	template <typename Policy> class Tile>			// Derived Tile class to use
+struct Cta
+{
+	//---------------------------------------------------------------------
+	// Typedefs and Constants
+	//---------------------------------------------------------------------
+
+	typedef typename KernelPolicy::KeyType 					KeyType;
+	typedef typename KernelPolicy::ValueType 				ValueType;
+	typedef typename KernelPolicy::SizeT 					SizeT;
+	typedef typename KernelPolicy::SmemStorage				SmemStorage;
+	typedef typename KernelPolicy::Grid::LanePartial		LanePartial;
+
+	typedef DerivedCta Dispatch;
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Shared storage for this CTA
+	typename KernelPolicy::SmemStorage 	&smem_storage;
+
+	// Input and output device pointers
+	KeyType								*&d_in_keys;
+	KeyType								*&d_out_keys;
+
+	ValueType							*&d_in_values;
+	ValueType							*&d_out_values;
+
+	SizeT								*&d_spine;
+
+	// Raking details
+	LanePartial							base_composite_counter;
+	int									*raking_segment;
+
+
+	//---------------------------------------------------------------------
+	// Methods
+	//---------------------------------------------------------------------
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ Cta(
+		SmemStorage 	&smem_storage,
+		KeyType 		*&d_in_keys,
+		KeyType 		*&d_out_keys,
+		ValueType 		*&d_in_values,
+		ValueType 		*&d_out_values,
+		SizeT 			*&d_spine,
+		LanePartial		base_composite_counter,
+		int				*raking_segment) :
+			smem_storage(smem_storage),
+			d_in_keys(d_in_keys),
+			d_out_keys(d_out_keys),
+			d_in_values(d_in_values),
+			d_out_values(d_out_values),
+			d_spine(d_spine),
+			base_composite_counter(base_composite_counter),
+			raking_segment(raking_segment)
+	{
+		if (threadIdx.x < KernelPolicy::BINS) {
+
+			// Reset value-area of bin_warpscan
+			smem_storage.bin_warpscan[1][threadIdx.x] = 0;
+
+			// Read bin_carry in parallel
+			SizeT my_bin_carry;
+			int spine_bin_offset = util::FastMul(gridDim.x, threadIdx.x) + blockIdx.x;
+			util::io::ModifiedLoad<KernelPolicy::READ_MODIFIER>::Ld(
+				my_bin_carry,
+				d_spine + spine_bin_offset);
+
+			smem_storage.bin_carry[threadIdx.x] = my_bin_carry;
+		}
+	}
+
+
+	/**
+	 * Process tile
+	 */
+	__device__ __forceinline__ void ProcessTile(
+		SizeT cta_offset,
+		const SizeT &guarded_elements = KernelPolicy::TILE_ELEMENTS)
+	{
+		Tile<KernelPolicy> tile;
+
+		tile.Partition(
+			cta_offset,
+			guarded_elements,
+			(Dispatch *) this);
+	}
+
+
+	/**
+	 * Process work range of tiles
+	 */
+	__device__ __forceinline__ void ProcessWorkRange(
+		util::CtaWorkLimits<SizeT> &work_limits)
+	{
+		// Make sure we get a local copy of the cta's offset (work_limits may be in smem)
+		SizeT cta_offset = work_limits.offset;
+
+		// Process full tiles of tile_elements
+		while (cta_offset < work_limits.guarded_offset) {
+
+			ProcessTile(cta_offset);
+			cta_offset += KernelPolicy::TILE_ELEMENTS;
+		}
+
+		// Clean up last partial tile with guarded-io
+		if (work_limits.guarded_elements) {
+			ProcessTile(
+				cta_offset,
+				work_limits.guarded_elements);
+		}
+	}
+};
+
+
+} // namespace downsweep
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/partition/downsweep/kernel_policy.cuh
+++ b/include/b40c/partition/downsweep/kernel_policy.cuh
@@ -1,0 +1,147 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Configuration policy for partitioning downsweep scan kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/util/srts_grid.cuh>
+
+namespace b40c {
+namespace partition {
+namespace downsweep {
+
+
+/**
+ * A detailed partitioning downsweep kernel configuration policy type that specializes
+ * kernel code for a specific pass.  It encapsulates tuning configuration policy
+ * details derived from TuningPolicy
+ */
+template <typename TuningPolicy>
+struct KernelPolicy : TuningPolicy
+{
+	typedef typename TuningPolicy::SizeT 		SizeT;
+	typedef typename TuningPolicy::KeyType 		KeyType;
+	typedef typename TuningPolicy::ValueType 	ValueType;
+
+	enum {
+
+		BINS 							= 1 << TuningPolicy::LOG_BINS,
+		THREADS							= 1 << TuningPolicy::LOG_THREADS,
+
+		LOG_WARPS						= TuningPolicy::LOG_THREADS - B40C_LOG_WARP_THREADS(TuningPolicy::CUDA_ARCH),
+		WARPS							= 1 << LOG_WARPS,
+
+		LOAD_VEC_SIZE					= 1 << TuningPolicy::LOG_LOAD_VEC_SIZE,
+		LOADS_PER_CYCLE					= 1 << TuningPolicy::LOG_LOADS_PER_CYCLE,
+		CYCLES_PER_TILE					= 1 << TuningPolicy::LOG_CYCLES_PER_TILE,
+
+		LOG_LOADS_PER_TILE				= TuningPolicy::LOG_LOADS_PER_CYCLE +
+												TuningPolicy::LOG_CYCLES_PER_TILE,
+		LOADS_PER_TILE					= 1 << LOG_LOADS_PER_TILE,
+
+		LOG_CYCLE_ELEMENTS				= TuningPolicy::LOG_THREADS +
+												TuningPolicy::LOG_LOADS_PER_CYCLE +
+												TuningPolicy::LOG_LOAD_VEC_SIZE,
+		CYCLE_ELEMENTS					= 1 << LOG_CYCLE_ELEMENTS,
+
+		LOG_TILE_ELEMENTS				= TuningPolicy::LOG_CYCLES_PER_TILE + LOG_CYCLE_ELEMENTS,
+		TILE_ELEMENTS					= 1 << LOG_TILE_ELEMENTS,
+
+		LOG_TILE_ELEMENTS_PER_THREAD	= LOG_TILE_ELEMENTS - TuningPolicy::LOG_THREADS,
+		TILE_ELEMENTS_PER_THREAD		= 1 << LOG_TILE_ELEMENTS_PER_THREAD,
+	
+		LOG_SCAN_LANES_PER_LOAD			= B40C_MAX((TuningPolicy::LOG_BINS - 2), 0),		// Always at least one lane per load
+		SCAN_LANES_PER_LOAD				= 1 << LOG_SCAN_LANES_PER_LOAD,
+
+		LOG_SCAN_LANES_PER_CYCLE		= TuningPolicy::LOG_LOADS_PER_CYCLE + LOG_SCAN_LANES_PER_LOAD,
+		SCAN_LANES_PER_CYCLE			= 1 << LOG_SCAN_LANES_PER_CYCLE,
+	};
+
+
+	// Smem raking grid type for reducing and scanning a cycle of 
+	// (bins/4) lanes of composite 8-bit bin counters
+	typedef util::RakingGrid<
+		TuningPolicy::CUDA_ARCH,
+		int,									// Partial type
+		TuningPolicy::LOG_THREADS,				// Depositing threads (the CTA size)
+		LOG_SCAN_LANES_PER_CYCLE,				// Lanes (the number of loads)
+		TuningPolicy::LOG_RAKING_THREADS,		// Raking threads
+		false>									// Any prefix dependences between lanes are explicitly managed
+			Grid;
+
+	
+	/**
+	 * Shared storage for partitioning upsweep
+	 */
+	struct SmemStorage
+	{
+		volatile int 					lanes_warpscan[SCAN_LANES_PER_CYCLE][3][Grid::RAKING_THREADS_PER_LANE];		// One warpscan per lane
+		volatile int 					bin_warpscan[2][BINS];
+
+		SizeT							bin_carry[BINS];
+		SizeT 							bin_prefixes[CYCLES_PER_TILE][LOADS_PER_CYCLE][BINS];
+		union {
+			int 						lane_totals[CYCLES_PER_TILE][SCAN_LANES_PER_CYCLE][2];
+			unsigned char				lane_totals_c[CYCLES_PER_TILE][LOADS_PER_CYCLE][SCAN_LANES_PER_LOAD][2][4];
+		};
+
+		bool 							non_trivial_pass;
+		util::CtaWorkLimits<SizeT> 		work_limits;
+
+		union {
+			int 						raking_lanes[Grid::RAKING_ELEMENTS];
+			KeyType 					key_exchange[TILE_ELEMENTS + 1];			// Last index is for invalid elements to be culled (if any)
+			ValueType 					value_exchange[TILE_ELEMENTS + 1];
+		};
+	};
+
+	enum {
+		THREAD_OCCUPANCY					= B40C_SM_THREADS(TuningPolicy::CUDA_ARCH) >> TuningPolicy::LOG_THREADS,
+		SMEM_OCCUPANCY						= B40C_SMEM_BYTES(TuningPolicy::CUDA_ARCH) / sizeof(SmemStorage),
+		MAX_CTA_OCCUPANCY					= B40C_MIN(B40C_SM_CTAS(TuningPolicy::CUDA_ARCH), B40C_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY)),
+
+		VALID								= (MAX_CTA_OCCUPANCY > 0),
+	};
+
+
+	__device__ __forceinline__ static void PreprocessKey(KeyType &key) {}
+
+	__device__ __forceinline__ static void PostprocessKey(KeyType &key) {}
+};
+	
+
+
+} // namespace downsweep
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/partition/downsweep/tile.cuh
+++ b/include/b40c/partition/downsweep/tile.cuh
@@ -1,0 +1,1158 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Abstract tile-processing functionality for partitioning downsweep scan
+ * kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+#include <b40c/util/io/load_tile.cuh>
+#include <b40c/util/io/scatter_tile.cuh>
+#include <b40c/util/reduction/serial_reduce.cuh>
+#include <b40c/util/scan/serial_scan.cuh>
+#include <b40c/util/scan/warp_scan.cuh>
+#include <b40c/util/device_intrinsics.cuh>
+
+namespace b40c {
+namespace partition {
+namespace downsweep {
+
+
+/**
+ * Tile
+ *
+ * Abstract class
+ */
+template <
+	typename KernelPolicy,
+	typename DerivedTile>
+struct Tile
+{
+	//---------------------------------------------------------------------
+	// Typedefs and Constants
+	//---------------------------------------------------------------------
+
+	typedef typename KernelPolicy::KeyType 					KeyType;
+	typedef typename KernelPolicy::ValueType 				ValueType;
+	typedef typename KernelPolicy::SizeT 					SizeT;
+
+	typedef DerivedTile Dispatch;
+
+	enum {
+		LOAD_VEC_SIZE 				= KernelPolicy::LOAD_VEC_SIZE,
+		LOADS_PER_CYCLE 			= KernelPolicy::LOADS_PER_CYCLE,
+		CYCLES_PER_TILE 			= KernelPolicy::CYCLES_PER_TILE,
+		TILE_ELEMENTS_PER_THREAD 	= KernelPolicy::TILE_ELEMENTS_PER_THREAD,
+		SCAN_LANES_PER_CYCLE		= KernelPolicy::SCAN_LANES_PER_CYCLE,
+
+		INVALID_BIN					= -1,
+	};
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+
+	// The keys (and values) this thread will read this cycle
+	KeyType 	keys[CYCLES_PER_TILE][LOADS_PER_CYCLE][LOAD_VEC_SIZE];
+	ValueType 	values[TILE_ELEMENTS_PER_THREAD];
+
+	int 		local_ranks[CYCLES_PER_TILE][LOADS_PER_CYCLE][LOAD_VEC_SIZE];		// The local rank of each key
+	int 		key_bins[CYCLES_PER_TILE][LOADS_PER_CYCLE][LOAD_VEC_SIZE];			// The bin for each key
+	SizeT 		scatter_offsets[CYCLES_PER_TILE][LOADS_PER_CYCLE][LOAD_VEC_SIZE];	// The global rank of each key
+	int 		counter_offsets[LOADS_PER_CYCLE][LOAD_VEC_SIZE];					// The (byte) counter offset for each key
+
+	// Counts of my bin in each load in each cycle, valid in threads [0,BINS)
+	int 		bin_counts[CYCLES_PER_TILE][LOADS_PER_CYCLE];
+
+
+	//---------------------------------------------------------------------
+	// Abstract Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Returns whether or not the key is valid.
+	 *
+	 * To be overloaded.
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ SizeT ValidElements(Cta *cta, const SizeT &guarded_elements)
+	{
+		return guarded_elements;
+	}
+
+	/**
+	 * Returns the bin into which the specified key is to be placed.
+	 *
+	 * To be overloaded
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ int DecodeBin(KeyType key, Cta *cta);
+
+
+	/**
+	 * Returns whether or not the key is valid.
+	 *
+	 * To be overloaded.
+	 */
+	template <int CYCLE, int LOAD, int VEC>
+	__device__ __forceinline__ bool IsValid();
+
+
+	/**
+	 * Loads keys into the tile
+	 *
+	 * Can be overloaded.
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void LoadKeys(
+		Cta *cta,
+		SizeT cta_offset,
+		const SizeT &guarded_elements)
+	{
+		util::io::LoadTile<
+			KernelPolicy::LOG_LOADS_PER_TILE,
+			KernelPolicy::LOG_LOAD_VEC_SIZE,
+			KernelPolicy::THREADS,
+			KernelPolicy::READ_MODIFIER,
+			KernelPolicy::CHECK_ALIGNMENT>::LoadValid(
+				(KeyType (*)[KernelPolicy::LOAD_VEC_SIZE]) keys,
+				cta->d_in_keys,
+				cta_offset,
+				guarded_elements);
+	}
+
+
+	/**
+	 * Scatter keys from the tile
+	 *
+	 * Can be overloaded.
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void ScatterKeys(
+		Cta *cta,
+		const SizeT &guarded_elements)
+	{
+		// Scatter keys to global bin partitions
+		util::io::ScatterTile<
+			KernelPolicy::LOG_TILE_ELEMENTS_PER_THREAD,
+			0,
+			KernelPolicy::THREADS,
+			KernelPolicy::WRITE_MODIFIER>::Scatter(
+				cta->d_out_keys,
+				(KeyType (*)[1]) keys,
+				(SizeT (*)[1]) scatter_offsets,
+				guarded_elements);
+	}
+
+
+	/**
+	 * Loads values into the tile
+	 *
+	 * Can be overloaded.
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void LoadValues(
+		Cta *cta,
+		SizeT cta_offset,
+		const SizeT &guarded_elements)
+	{
+		// Read values
+		util::io::LoadTile<
+			KernelPolicy::LOG_LOADS_PER_TILE,
+			KernelPolicy::LOG_LOAD_VEC_SIZE,
+			KernelPolicy::THREADS,
+			KernelPolicy::READ_MODIFIER,
+			KernelPolicy::CHECK_ALIGNMENT>::LoadValid(
+				(ValueType (*)[KernelPolicy::LOAD_VEC_SIZE]) values,
+				cta->d_in_values,
+				cta_offset,
+				guarded_elements);
+	}
+
+
+	/**
+	 * Scatter values from the tile
+	 *
+	 * Can be overloaded.
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void ScatterValues(
+		Cta *cta,
+		const SizeT &guarded_elements)
+	{
+		// Scatter values to global bin partitions
+		util::io::ScatterTile<
+			KernelPolicy::LOG_TILE_ELEMENTS_PER_THREAD,
+			0,
+			KernelPolicy::THREADS,
+			KernelPolicy::WRITE_MODIFIER>::Scatter(
+				cta->d_out_values,
+				(ValueType (*)[1]) values,
+				(SizeT (*)[1]) scatter_offsets,
+				guarded_elements);
+	}
+
+
+	//---------------------------------------------------------------------
+	// Helper Structures
+	//---------------------------------------------------------------------
+
+	/**
+	 * Computes the number of previously-binned keys owned by the calling thread
+	 * that have been marked for the specified bin.
+	 */
+	struct SameBinCount
+	{
+		// Inspect previous vec-element
+		template <int CYCLE, int LOAD, int VEC>
+		struct Iterate
+		{
+			static __device__ __forceinline__ int Invoke(Tile *tile, int current_bin)
+			{
+				return (current_bin == tile->key_bins[CYCLE][LOAD][VEC - 1]) +
+					Iterate<CYCLE, LOAD, VEC - 1>::Invoke(tile, current_bin);
+			}
+		};
+
+		// Terminate (0th vec-element has no previous elements)
+		template <int CYCLE, int LOAD>
+		struct Iterate<CYCLE, LOAD, 0>
+		{
+			static __device__ __forceinline__ int Invoke(Tile *tile, int current_bin)
+			{
+				return 0;
+			}
+		};
+	};
+
+
+	//---------------------------------------------------------------------
+	// Cycle Methods
+	//---------------------------------------------------------------------
+
+
+	/**
+	 * DecodeKeys
+	 */
+	template <int CYCLE, int LOAD, int VEC, typename Cta>
+	__device__ __forceinline__ void DecodeKeys(Cta *cta)
+	{
+		Dispatch *dispatch = (Dispatch *) this;
+
+		// Update composite-counter
+		if (dispatch->template IsValid<CYCLE, LOAD, VEC>()) {
+
+			const int PADDED_BYTES_PER_LANE 	= KernelPolicy::Grid::ROWS_PER_LANE * KernelPolicy::Grid::PADDED_PARTIALS_PER_ROW * 4;
+			const int LOAD_OFFSET_BYTES 		= LOAD * KernelPolicy::SCAN_LANES_PER_LOAD * PADDED_BYTES_PER_LANE;
+			const KeyType COUNTER_BYTE_MASK 	= (KernelPolicy::LOG_BINS < 2) ? 0x1 : 0x3;
+
+			// Decode the bin for this key
+			key_bins[CYCLE][LOAD][VEC] = dispatch->DecodeBin(keys[CYCLE][LOAD][VEC], cta);
+
+			// Decode composite-counter lane and sub-counter from bin
+			int lane = key_bins[CYCLE][LOAD][VEC] >> 2;										// extract composite counter lane
+			int sub_counter = key_bins[CYCLE][LOAD][VEC] & COUNTER_BYTE_MASK;				// extract 8-bit counter offset
+
+			// Compute partial (because we overwrite, we need to accommodate all previous
+			// vec-elements if they have the same bin)
+			int partial = 1 + SameBinCount::template Iterate<CYCLE, LOAD, VEC>::Invoke(
+				dispatch,
+				key_bins[CYCLE][LOAD][VEC]);
+
+			// Counter offset in bytes from this thread's "base_composite_counter" location
+			counter_offsets[LOAD][VEC] =
+				LOAD_OFFSET_BYTES +
+				util::FastMul(lane, PADDED_BYTES_PER_LANE) +
+				sub_counter;
+
+			// Overwrite partial
+			unsigned char *base_partial_chars = (unsigned char *) cta->base_composite_counter;
+			base_partial_chars[counter_offsets[LOAD][VEC]] = partial;
+
+		} else {
+
+			key_bins[CYCLE][LOAD][VEC] = INVALID_BIN;
+		}
+	}
+
+
+	/**
+	 * ExtractRanks
+	 */
+	template <int CYCLE, int LOAD, int VEC, typename Cta>
+	__device__ __forceinline__ void ExtractRanks(Cta *cta)
+	{
+		Dispatch *dispatch = (Dispatch *) this;
+
+		if (dispatch->template IsValid<CYCLE, LOAD, VEC>()) {
+
+			unsigned char *base_partial_chars = (unsigned char *) cta->base_composite_counter;
+
+			local_ranks[CYCLE][LOAD][VEC] = base_partial_chars[counter_offsets[LOAD][VEC]] +
+				SameBinCount::template Iterate<CYCLE, LOAD, VEC>::Invoke(
+					dispatch,
+					key_bins[CYCLE][LOAD][VEC]);
+		} else {
+
+			// Put invalid keys just after the end of the valid swap exchange.
+			local_ranks[CYCLE][LOAD][VEC] = KernelPolicy::TILE_ELEMENTS;
+		}
+	}
+
+
+	/**
+	 * UpdateRanks
+	 */
+	template <int CYCLE, int LOAD, int VEC, typename Cta>
+	__device__ __forceinline__ void UpdateRanks(Cta *cta)
+	{
+		Dispatch *dispatch = (Dispatch *) this;
+
+		if (dispatch->template IsValid<CYCLE, LOAD, VEC>()) {
+			// Update this key's rank with the bin-prefix for it's bin
+			local_ranks[CYCLE][LOAD][VEC] +=
+				cta->smem_storage.bin_prefixes[CYCLE][LOAD][key_bins[CYCLE][LOAD][VEC]];
+		}
+	}
+
+
+	/**
+	 * UpdateGlobalOffsets
+	 */
+	template <int CYCLE, int LOAD, int VEC, typename Cta>
+	__device__ __forceinline__ void UpdateGlobalOffsets(Cta *cta)
+	{
+		Dispatch *dispatch = (Dispatch *) this;
+
+		if (dispatch->template IsValid<CYCLE, LOAD, VEC>()) {
+			// Update this key's global scatter offset with its
+			// cycle rank and with the bin-prefix for it's bin
+			scatter_offsets[CYCLE][LOAD][VEC] =
+				local_ranks[CYCLE][LOAD][VEC] +
+				cta->smem_storage.bin_prefixes[CYCLE][LOAD][key_bins[CYCLE][LOAD][VEC]];
+		}
+	}
+
+
+	/**
+	 * ResetLanes
+	 */
+	template <int LANE, typename Cta>
+	__device__ __forceinline__ void ResetLanes(Cta *cta)
+	{
+		cta->base_composite_counter[LANE][0] = 0;
+	}
+
+
+	//---------------------------------------------------------------------
+	// IterateCycleLanes Structures
+	//---------------------------------------------------------------------
+
+	/**
+	 * Iterate next lane
+	 */
+	template <int LANE, int dummy = 0>
+	struct IterateCycleLanes
+	{
+		// ResetLanes
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void ResetLanes(Cta *cta, Tile *tile)
+		{
+			tile->ResetLanes<LANE>(cta);
+			IterateCycleLanes<LANE + 1>::ResetLanes(cta, tile);
+		}
+	};
+
+	/**
+	 * Terminate lane iteration
+	 */
+	template <int dummy>
+	struct IterateCycleLanes<SCAN_LANES_PER_CYCLE, dummy>
+	{
+		// ResetLanes
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void ResetLanes(Cta *cta, Tile *tile) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// IterateCycleElements Structures
+	//---------------------------------------------------------------------
+
+	/**
+	 * Iterate next vector element
+	 */
+	template <int CYCLE, int LOAD, int VEC, int dummy = 0>
+	struct IterateCycleElements
+	{
+		// DecodeKeys
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void DecodeKeys(Cta *cta, Tile *tile)
+		{
+			tile->DecodeKeys<CYCLE, LOAD, VEC>(cta);
+			IterateCycleElements<CYCLE, LOAD, VEC + 1>::DecodeKeys(cta, tile);
+		}
+
+		// ExtractRanks
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void ExtractRanks(Cta *cta, Tile *tile)
+		{
+			tile->ExtractRanks<CYCLE, LOAD, VEC>(cta);
+			IterateCycleElements<CYCLE, LOAD, VEC + 1>::ExtractRanks(cta, tile);
+		}
+
+		// UpdateRanks
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateRanks(Cta *cta, Tile *tile)
+		{
+			tile->UpdateRanks<CYCLE, LOAD, VEC>(cta);
+			IterateCycleElements<CYCLE, LOAD, VEC + 1>::UpdateRanks(cta, tile);
+		}
+
+		// UpdateGlobalOffsets
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateGlobalOffsets(Cta *cta, Tile *tile)
+		{
+			tile->UpdateGlobalOffsets<CYCLE, LOAD, VEC>(cta);
+			IterateCycleElements<CYCLE, LOAD, VEC + 1>::UpdateGlobalOffsets(cta, tile);
+		}
+	};
+
+
+	/**
+	 * IterateCycleElements next load
+	 */
+	template <int CYCLE, int LOAD, int dummy>
+	struct IterateCycleElements<CYCLE, LOAD, LOAD_VEC_SIZE, dummy>
+	{
+		// DecodeKeys
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void DecodeKeys(Cta *cta, Tile *tile)
+		{
+			IterateCycleElements<CYCLE, LOAD + 1, 0>::DecodeKeys(cta, tile);
+		}
+
+		// ExtractRanks
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void ExtractRanks(Cta *cta, Tile *tile)
+		{
+			IterateCycleElements<CYCLE, LOAD + 1, 0>::ExtractRanks(cta, tile);
+		}
+
+		// UpdateRanks
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateRanks(Cta *cta, Tile *tile)
+		{
+			IterateCycleElements<CYCLE, LOAD + 1, 0>::UpdateRanks(cta, tile);
+		}
+
+		// UpdateGlobalOffsets
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateGlobalOffsets(Cta *cta, Tile *tile)
+		{
+			IterateCycleElements<CYCLE, LOAD + 1, 0>::UpdateGlobalOffsets(cta, tile);
+		}
+	};
+
+	/**
+	 * Terminate iteration
+	 */
+	template <int CYCLE, int dummy>
+	struct IterateCycleElements<CYCLE, LOADS_PER_CYCLE, 0, dummy>
+	{
+		// DecodeKeys
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void DecodeKeys(Cta *cta, Tile *tile) {}
+
+		// ExtractRanks
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void ExtractRanks(Cta *cta, Tile *tile) {}
+
+		// UpdateRanks
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateRanks(Cta *cta, Tile *tile) {}
+
+		// UpdateGlobalOffsets
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateGlobalOffsets(Cta *cta, Tile *tile) {}
+	};
+
+
+
+	//---------------------------------------------------------------------
+	// Tile Internal Methods
+	//---------------------------------------------------------------------
+
+	/**
+	 * Scan Cycle
+	 */
+	template <int CYCLE, typename Cta>
+	__device__ __forceinline__ void ScanCycle(Cta *cta)
+	{
+		Dispatch *dispatch = (Dispatch*) this;
+
+		// Reset smem composite counters
+		IterateCycleLanes<0>::ResetLanes(cta, dispatch);
+
+		// Decode bins and update 8-bit composite counters for the keys in this cycle
+		IterateCycleElements<CYCLE, 0, 0>::DecodeKeys(cta, dispatch);
+
+		__syncthreads();
+
+		// Use our raking threads to, in aggregate, scan the composite counter lanes
+		if (threadIdx.x < KernelPolicy::Grid::RAKING_THREADS) {
+
+			// Upsweep rake
+			int partial = util::reduction::SerialReduce<KernelPolicy::Grid::PARTIALS_PER_SEG>::Invoke(
+				cta->raking_segment);
+
+			int warpscan_lane 		= threadIdx.x >> KernelPolicy::Grid::LOG_RAKING_THREADS_PER_LANE;
+			int warpscan_tid 		= threadIdx.x & (KernelPolicy::Grid::RAKING_THREADS_PER_LANE - 1);
+
+			// Inclusive warpscan in bin warpscan_lane
+			int inclusive_prefix 	= util::scan::WarpScan<KernelPolicy::Grid::LOG_RAKING_THREADS_PER_LANE, false>::Invoke(
+				partial,
+				cta->smem_storage.lanes_warpscan[warpscan_lane],
+				warpscan_tid);
+			int exclusive_prefix 	= inclusive_prefix - partial;
+
+			// Save off each lane's warpscan total for this cycle
+			if (warpscan_tid == KernelPolicy::Grid::RAKING_THREADS_PER_LANE - 1) {
+				cta->smem_storage.lane_totals[CYCLE][warpscan_lane][0] = exclusive_prefix;
+				cta->smem_storage.lane_totals[CYCLE][warpscan_lane][1] = partial;
+			}
+
+			// Downsweep rake
+			util::scan::SerialScan<KernelPolicy::Grid::PARTIALS_PER_SEG>::Invoke(
+				cta->raking_segment,
+				exclusive_prefix);
+		}
+
+		__syncthreads();
+
+		// Extract the local ranks of each key
+		IterateCycleElements<CYCLE, 0, 0>::ExtractRanks(cta, dispatch);
+	}
+
+
+	/**
+	 * RecoverBinCounts
+	 *
+	 * Called by threads [0, KernelPolicy::BINS)
+	 */
+	template <int CYCLE, int LOAD, typename Cta>
+	__device__ __forceinline__ void RecoverBinCounts(
+		int my_base_lane, int my_quad_byte, Cta *cta)
+	{
+		bin_counts[CYCLE][LOAD] =
+			cta->smem_storage.lane_totals_c[CYCLE][LOAD][my_base_lane][0][my_quad_byte] +
+			cta->smem_storage.lane_totals_c[CYCLE][LOAD][my_base_lane][1][my_quad_byte];
+	}
+
+
+	/**
+	 * UpdateBinPrefixes
+	 *
+	 * Called by threads [0, KernelPolicy::BINS)
+	 */
+	template <int CYCLE, int LOAD, typename Cta>
+	__device__ __forceinline__ void UpdateBinPrefixes(int bin_prefix, Cta *cta)
+	{
+		cta->smem_storage.bin_prefixes[CYCLE][LOAD][threadIdx.x] = bin_counts[CYCLE][LOAD] + bin_prefix;
+	}
+
+
+	/**
+	 * DecodeGlobalOffsets
+	 */
+	template <int ELEMENT, typename Cta>
+	__device__ __forceinline__ void DecodeGlobalOffsets(Cta *cta)
+	{
+		Dispatch *dispatch = (Dispatch*) this;
+
+		KeyType *linear_keys 	= (KeyType *) keys;
+		SizeT *linear_offsets 	= (SizeT *) scatter_offsets;
+
+		int bin = dispatch->DecodeBin(linear_keys[ELEMENT], cta);
+
+		linear_offsets[ELEMENT] =
+			cta->smem_storage.bin_carry[bin] +
+			(KernelPolicy::THREADS * ELEMENT) + threadIdx.x;
+	}
+
+
+	//---------------------------------------------------------------------
+	// IterateCycles Structures
+	//---------------------------------------------------------------------
+
+	/**
+	 * Iterate next cycle
+	 */
+	template <int CYCLE, int dummy = 0>
+	struct IterateCycles
+	{
+		// UpdateRanks
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateRanks(Cta *cta, Tile *tile)
+		{
+			IterateCycleElements<CYCLE, 0, 0>::UpdateRanks(cta, tile);
+			IterateCycles<CYCLE + 1>::UpdateRanks(cta, tile);
+		}
+
+		// UpdateRanks
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateGlobalOffsets(Cta *cta, Tile *tile)
+		{
+			IterateCycleElements<CYCLE, 0, 0>::UpdateGlobalOffsets(cta, tile);
+			IterateCycles<CYCLE + 1>::UpdateGlobalOffsets(cta, tile);
+		}
+
+		// ScanCycles
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void ScanCycles(Cta *cta, Tile *tile)
+		{
+			tile->ScanCycle<CYCLE>(cta);
+			IterateCycles<CYCLE + 1>::ScanCycles(cta, tile);
+		}
+	};
+
+	/**
+	 * Terminate iteration
+	 */
+	template <int dummy>
+	struct IterateCycles<CYCLES_PER_TILE, dummy>
+	{
+		// UpdateRanks
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateRanks(Cta *cta, Tile *tile) {}
+
+		// UpdateGlobalOffsets
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateGlobalOffsets(Cta *cta, Tile *tile) {}
+
+		// ScanCycles
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void ScanCycles(Cta *cta, Tile *tile) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// IterateCycleLoads Structures
+	//---------------------------------------------------------------------
+
+	/**
+	 * Iterate next load
+	 */
+	template <int CYCLE, int LOAD, int dummy = 0>
+	struct IterateCycleLoads
+	{
+		// RecoverBinCounts
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void RecoverBinCounts(
+			int my_base_lane, int my_quad_byte, Cta *cta, Tile *tile)
+		{
+			tile->template RecoverBinCounts<CYCLE, LOAD>(my_base_lane, my_quad_byte, cta);
+			IterateCycleLoads<CYCLE, LOAD + 1>::RecoverBinCounts(my_base_lane, my_quad_byte, cta, tile);
+		}
+
+		// UpdateBinPrefixes
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateBinPrefixes(
+			int bin_prefix, Cta *cta, Tile *tile)
+		{
+			tile->template UpdateBinPrefixes<CYCLE, LOAD>(bin_prefix, cta);
+			IterateCycleLoads<CYCLE, LOAD + 1>::UpdateBinPrefixes(bin_prefix, cta, tile);
+		}
+	};
+
+
+	/**
+	 * Iterate next cycle
+	 */
+	template <int CYCLE, int dummy>
+	struct IterateCycleLoads<CYCLE, LOADS_PER_CYCLE, dummy>
+	{
+		// RecoverBinCounts
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void RecoverBinCounts(
+			int my_base_lane, int my_quad_byte, Cta *cta, Tile *tile)
+		{
+			IterateCycleLoads<CYCLE + 1, 0>::RecoverBinCounts(my_base_lane, my_quad_byte, cta, tile);
+		}
+
+		// UpdateBinPrefixes
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateBinPrefixes(
+			int bin_prefix, Cta *cta, Tile *tile)
+		{
+			IterateCycleLoads<CYCLE + 1, 0>::UpdateBinPrefixes(bin_prefix, cta, tile);
+		}
+	};
+
+	/**
+	 * Terminate iteration
+	 */
+	template <int dummy>
+	struct IterateCycleLoads<CYCLES_PER_TILE, 0, dummy>
+	{
+		// RecoverBinCounts
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void RecoverBinCounts(int my_base_lane, int my_quad_byte, Cta *cta, Tile *tile) {}
+
+		// UpdateBinPrefixes
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void UpdateBinPrefixes(int bin_prefix, Cta *cta, Tile *tile) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// IterateElements Structures
+	//---------------------------------------------------------------------
+
+	/**
+	 * Iterate next tile element
+	 */
+	template <int ELEMENT, int dummy = 0>
+	struct IterateElements
+	{
+		// DecodeGlobalOffsets
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void DecodeGlobalOffsets(Cta *cta, Tile *tile)
+		{
+			tile->DecodeGlobalOffsets<ELEMENT>(cta);
+			IterateElements<ELEMENT + 1>::DecodeGlobalOffsets(cta, tile);
+		}
+	};
+
+
+	/**
+	 * Terminate iteration
+	 */
+	template <int dummy>
+	struct IterateElements<TILE_ELEMENTS_PER_THREAD, dummy>
+	{
+		// DecodeGlobalOffsets
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void DecodeGlobalOffsets(Cta *cta, Tile *tile) {}
+	};
+
+
+
+	//---------------------------------------------------------------------
+	// Partition/scattering specializations
+	//---------------------------------------------------------------------
+
+
+	template <
+		ScatterStrategy SCATTER_STRATEGY,
+		int dummy = 0>
+	struct PartitionTile;
+
+
+
+	/**
+	 * Specialized for two-phase scatter, keys-only
+	 */
+	template <
+		ScatterStrategy SCATTER_STRATEGY,
+		int dummy>
+	struct PartitionTile
+	{
+		enum {
+			MEM_BANKS 					= 1 << B40C_LOG_MEM_BANKS(__B40C_CUDA_ARCH__),
+			DIGITS_PER_SCATTER_PASS 	= KernelPolicy::WARPS * (B40C_WARP_THREADS(__B40C_CUDA_ARCH__) / (MEM_BANKS)),
+			SCATTER_PASSES 				= KernelPolicy::BINS / DIGITS_PER_SCATTER_PASS,
+		};
+
+		template <typename T>
+		static __device__ __forceinline__ void Nop(T &t) {}
+
+		/**
+		 * Warp based scattering that does not cross alignment boundaries, e.g., for SM1.0-1.1
+		 * coalescing rules
+		 */
+		template <int PASS, int SCATTER_PASSES>
+		struct WarpScatter
+		{
+			template <typename T, void Transform(T&), typename Cta>
+			static __device__ __forceinline__ void ScatterPass(
+				Cta *cta,
+				T *exchange,
+				T *d_out,
+				const SizeT &valid_elements)
+			{
+				const int LOG_STORE_TXN_THREADS = B40C_LOG_MEM_BANKS(__B40C_CUDA_ARCH__);
+				const int STORE_TXN_THREADS = 1 << LOG_STORE_TXN_THREADS;
+
+				int store_txn_idx = threadIdx.x & (STORE_TXN_THREADS - 1);
+				int store_txn_digit = threadIdx.x >> LOG_STORE_TXN_THREADS;
+
+				int my_digit = (PASS * DIGITS_PER_SCATTER_PASS) + store_txn_digit;
+
+				if (my_digit < KernelPolicy::BINS) {
+
+					int my_exclusive_scan = cta->smem_storage.bin_warpscan[1][my_digit - 1];
+					int my_inclusive_scan = cta->smem_storage.bin_warpscan[1][my_digit];
+					int my_digit_count = my_inclusive_scan - my_exclusive_scan;
+
+					int my_carry = cta->smem_storage.bin_carry[my_digit] + my_exclusive_scan;
+					int my_aligned_offset = store_txn_idx - (my_carry & (STORE_TXN_THREADS - 1));
+
+					while (my_aligned_offset < my_digit_count) {
+
+						if ((my_aligned_offset >= 0) && (my_exclusive_scan + my_aligned_offset < valid_elements)) {
+
+							T datum = exchange[my_exclusive_scan + my_aligned_offset];
+							Transform(datum);
+							d_out[my_carry + my_aligned_offset] = datum;
+						}
+						my_aligned_offset += STORE_TXN_THREADS;
+					}
+				}
+
+				WarpScatter<PASS + 1, SCATTER_PASSES>::template ScatterPass<T, Transform>(
+					cta,
+					exchange,
+					d_out,
+					valid_elements);
+			}
+		};
+
+		// Terminate
+		template <int SCATTER_PASSES>
+		struct WarpScatter<SCATTER_PASSES, SCATTER_PASSES>
+		{
+			template <typename T, void Transform(T&), typename Cta>
+			static __device__ __forceinline__ void ScatterPass(
+				Cta *cta,
+				T *exchange,
+				T *d_out,
+				const SizeT &valid_elements) {}
+		};
+
+		template <bool KEYS_ONLY, int dummy2 = 0>
+		struct ScatterValues
+		{
+			template <typename Cta, typename Tile>
+			static __device__ __forceinline__ void Invoke(
+				SizeT cta_offset,
+				const SizeT &guarded_elements,
+				const SizeT &valid_elements,
+				Cta *cta,
+				Tile *tile)
+			{
+				// Load values
+				tile->LoadValues(cta, cta_offset, guarded_elements);
+
+				// Scatter values to smem by local rank
+				util::io::ScatterTile<
+					KernelPolicy::LOG_TILE_ELEMENTS_PER_THREAD,
+					0,
+					KernelPolicy::THREADS,
+					util::io::st::NONE>::Scatter(
+						cta->smem_storage.value_exchange,
+						(ValueType (*)[1]) tile->values,
+						(int (*)[1]) tile->local_ranks);
+
+				__syncthreads();
+
+				if (SCATTER_STRATEGY == SCATTER_WARP_TWO_PHASE) {
+
+					WarpScatter<0, SCATTER_PASSES>::template ScatterPass<ValueType, Nop<ValueType> >(
+						cta,
+						cta->smem_storage.value_exchange,
+						cta->d_out_values,
+						valid_elements);
+
+					__syncthreads();
+
+				} else {
+
+					// Gather values linearly from smem (vec-1)
+					util::io::LoadTile<
+						KernelPolicy::LOG_TILE_ELEMENTS_PER_THREAD,
+						0,
+						KernelPolicy::THREADS,
+						util::io::ld::NONE,
+						false>::LoadValid(									// No need to check alignment
+							(ValueType (*)[1]) tile->values,
+							cta->smem_storage.value_exchange,
+							0);
+
+					__syncthreads();
+
+					// Scatter values to global bin partitions
+					tile->ScatterValues(cta, valid_elements);
+				}
+			}
+		};
+
+		template <int dummy2>
+		struct ScatterValues<true, dummy2>
+		{
+			template <typename Cta, typename Tile>
+			static __device__ __forceinline__ void Invoke(
+					SizeT cta_offset,
+					const SizeT &guarded_elements,
+					const SizeT &valid_elements,
+					Cta *cta,
+					Tile *tile) {}
+		};
+
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void Invoke(
+			SizeT cta_offset,
+			const SizeT &guarded_elements,
+			Cta *cta,
+			Tile *tile)
+		{
+			// Load keys
+			tile->LoadKeys(cta, cta_offset, guarded_elements);
+
+			// Scan cycles
+			IterateCycles<0>::ScanCycles(cta, tile);
+
+			// Scan across bins
+			if (threadIdx.x < KernelPolicy::BINS) {
+
+				// Recover bin-counts from lane totals
+				int my_base_lane = threadIdx.x >> 2;
+				int my_quad_byte = threadIdx.x & 3;
+				IterateCycleLoads<0, 0>::RecoverBinCounts(
+					my_base_lane, my_quad_byte, cta, tile);
+
+				// Scan across my bin counts for each load
+				int tile_bin_total = util::scan::SerialScan<KernelPolicy::LOADS_PER_TILE>::Invoke(
+					(int *) tile->bin_counts, 0);
+
+				// Add the previous tile's inclusive-scan to the running bin-carry
+				SizeT my_carry = cta->smem_storage.bin_carry[threadIdx.x] +
+					cta->smem_storage.bin_warpscan[1][threadIdx.x];
+
+				// Perform overflow-free inclusive SIMD Kogge-Stone across bins
+				int tile_bin_inclusive = util::scan::WarpScan<KernelPolicy::LOG_BINS, false>::Invoke(
+					tile_bin_total,
+					cta->smem_storage.bin_warpscan);
+
+				// Save inclusive scan in bin_warpscan
+				cta->smem_storage.bin_warpscan[1][threadIdx.x] = tile_bin_inclusive;
+
+				// Calculate exclusive scan
+				int tile_bin_exclusive = tile_bin_inclusive - tile_bin_total;
+
+				// Subtract the bin prefix from the running carry (to offset threadIdx during scatter)
+				cta->smem_storage.bin_carry[threadIdx.x] = my_carry - tile_bin_exclusive;
+
+				// Compute the bin prefixes for this tile for each load
+				IterateCycleLoads<0, 0>::UpdateBinPrefixes(tile_bin_exclusive, cta, tile);
+			}
+
+			__syncthreads();
+
+			// Update the local ranks in each load with the bin prefixes for the tile
+			IterateCycles<0>::UpdateRanks(cta, tile);
+
+			// Scatter keys to smem by local rank
+			util::io::ScatterTile<
+				KernelPolicy::LOG_TILE_ELEMENTS_PER_THREAD,
+				0,
+				KernelPolicy::THREADS,
+				util::io::st::NONE>::Scatter(
+					cta->smem_storage.key_exchange,
+					(KeyType (*)[1]) tile->keys,
+					(int (*)[1]) tile->local_ranks);
+
+			__syncthreads();
+
+			SizeT valid_elements = tile->ValidElements(cta, guarded_elements);
+
+			if (SCATTER_STRATEGY == SCATTER_WARP_TWO_PHASE) {
+
+				WarpScatter<0, SCATTER_PASSES>::template ScatterPass<KeyType, KernelPolicy::PostprocessKey>(
+					cta,
+					cta->smem_storage.key_exchange,
+					cta->d_out_keys,
+					valid_elements);
+
+				__syncthreads();
+
+			} else {
+
+				// Gather keys linearly from smem (vec-1)
+				util::io::LoadTile<
+					KernelPolicy::LOG_TILE_ELEMENTS_PER_THREAD,
+					0,
+					KernelPolicy::THREADS,
+					util::io::ld::NONE,
+					false>::LoadValid(									// No need to check alignment
+						(KeyType (*)[1]) tile->keys,
+						cta->smem_storage.key_exchange,
+						0);
+
+				__syncthreads();
+
+				// Compute global scatter offsets for gathered keys
+				IterateElements<0>::DecodeGlobalOffsets(cta, tile);
+
+				// Scatter keys to global bin partitions
+				tile->ScatterKeys(cta, valid_elements);
+
+			}
+
+			// Partition values
+			ScatterValues<KernelPolicy::KEYS_ONLY>::Invoke(
+				cta_offset, guarded_elements, valid_elements, cta, tile);
+		}
+	};
+
+
+	/**
+	 * Specialized for direct scatter
+	 */
+	template <int dummy>
+	struct PartitionTile<SCATTER_DIRECT, dummy>
+	{
+		template <bool KEYS_ONLY, int dummy2 = 0>
+		struct ScatterValues
+		{
+			template <typename Cta, typename Tile>
+			static __device__ __forceinline__ void Invoke(
+				SizeT cta_offset,
+				const SizeT &guarded_elements,
+				const SizeT &valid_elements,
+				Cta *cta,
+				Tile *tile)
+			{
+				// Load values
+				tile->LoadValues(cta, cta_offset, guarded_elements);
+
+				// Scatter values to global bin partitions
+				tile->ScatterValues(cta, valid_elements);
+			}
+		};
+
+		template <int dummy2>
+		struct ScatterValues<true, dummy2>
+		{
+			template <typename Cta, typename Tile>
+			static __device__ __forceinline__ void Invoke(
+					SizeT cta_offset,
+					const SizeT &guarded_elements,
+					const SizeT &valid_elements,
+					Cta *cta,
+					Tile *tile) {}
+		};
+
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void Invoke(
+			SizeT cta_offset,
+			const SizeT &guarded_elements,
+			Cta *cta,
+			Tile *tile)
+		{
+			// Load keys
+			tile->LoadKeys(cta, cta_offset, guarded_elements);
+
+			// Scan cycles
+			IterateCycles<0>::ScanCycles(cta, tile);
+
+			// Scan across bins
+			if (threadIdx.x < KernelPolicy::BINS) {
+
+				// Recover bin-counts from lane totals
+				int my_base_lane = threadIdx.x >> 2;
+				int my_quad_byte = threadIdx.x & 3;
+				IterateCycleLoads<0, 0>::RecoverBinCounts(
+					my_base_lane, my_quad_byte, cta, tile);
+
+				// Scan across my bin counts for each load
+				int tile_bin_total = util::scan::SerialScan<KernelPolicy::LOADS_PER_TILE>::Invoke(
+					(int *) tile->bin_counts, 0);
+
+				// Add the previous tile's inclusive-scan to the running bin-carry
+				SizeT my_carry = cta->smem_storage.bin_carry[threadIdx.x];
+
+				// Update bin prefixes with the incoming carry
+				IterateCycleLoads<0, 0>::UpdateBinPrefixes(my_carry, cta, tile);
+
+				// Update carry
+				cta->smem_storage.bin_carry[threadIdx.x] = my_carry + tile_bin_total;
+			}
+
+			__syncthreads();
+
+			SizeT valid_elements = tile->ValidElements(cta, guarded_elements);
+
+			// Update the scatter offsets in each load with the bin prefixes for the tile
+			IterateCycles<0>::UpdateGlobalOffsets(cta, tile);
+
+			// Scatter keys to global bin partitions
+			tile->ScatterKeys(cta, valid_elements);
+
+			// Partition values
+			ScatterValues<KernelPolicy::KEYS_ONLY>::Invoke(
+				cta_offset, guarded_elements, valid_elements, cta, tile);
+		}
+	};
+
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Loads, decodes, and scatters a tile into global partitions
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void Partition(
+		SizeT cta_offset,
+		const SizeT &guarded_elements,
+		Cta *cta)
+	{
+		PartitionTile<KernelPolicy::SCATTER_STRATEGY>::Invoke(
+			cta_offset,
+			guarded_elements,
+			cta,
+			(Dispatch *) this);
+	}
+
+};
+
+
+} // namespace downsweep
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/partition/downsweep/tuning_policy.cuh
+++ b/include/b40c/partition/downsweep/tuning_policy.cuh
@@ -1,0 +1,129 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Tuning policy for partitioning downsweep scan kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+#include <b40c/partition/downsweep/tuning_policy.cuh>
+
+namespace b40c {
+namespace partition {
+namespace downsweep {
+
+
+/**
+ * Types of scattering strategies
+ */
+enum ScatterStrategy {
+	SCATTER_DIRECT					= 0,
+	SCATTER_TWO_PHASE,
+	SCATTER_WARP_TWO_PHASE,
+};
+
+
+/**
+ * Partitioning downsweep scan tuning policy.  This type encapsulates our
+ * kernel-tuning parameters (they are reflected via the static fields).
+ *
+ * The kernel is specialized for problem-type, SM-version, etc. by declaring
+ * it with different performance-tuned parameterizations of this type.  By
+ * incorporating this type into the kernel code itself, we guide the compiler in
+ * expanding/unrolling the kernel code for specific architectures and problem
+ * types.
+ *
+ * Constraints:
+ * 		(i) 	A load can't contain more than 256 keys or we might overflow inside a lane of
+ * 				8-bit composite counters, i.e., (threads * load-vec-size <= 256), equivalently:
+ *
+ * 					(LOG_THREADS + LOG_LOAD_VEC_SIZE <= 8)
+ *
+ * 		(ii) 	We must have between one and one warp of raking threads per lane of composite
+ * 				counters, i.e., (1 <= raking-threads / (loads-per-cycle * bins / 4) <= 32),
+ * 				equivalently:
+ *
+ * 					(0 <= LOG_RAKING_THREADS - LOG_LOADS_PER_CYCLE - LOG_BINS + 2 <= B40C_LOG_WARP_THREADS(arch))
+ *
+ * 		(iii) 	We must have more (or equal) threads than bins in the threadblock,
+ * 				i.e., (threads >= bins) equivalently:
+ * 
+ * 					LOG_THREADS >= LOG_BINS
+ */
+template <
+	// Problem type
+	typename ProblemType,
+
+	int _CUDA_ARCH,
+	bool _CHECK_ALIGNMENT,
+	int _LOG_BINS,
+	int _LOG_SCHEDULE_GRANULARITY,
+	int _MIN_CTA_OCCUPANCY,
+	int _LOG_THREADS,
+	int _LOG_LOAD_VEC_SIZE,
+	int _LOG_LOADS_PER_CYCLE,
+	int _LOG_CYCLES_PER_TILE,
+	int _LOG_RAKING_THREADS,
+	util::io::ld::CacheModifier _READ_MODIFIER,
+	util::io::st::CacheModifier _WRITE_MODIFIER,
+	ScatterStrategy _SCATTER_STRATEGY>
+
+struct TuningPolicy : ProblemType
+{
+	enum {
+		CUDA_ARCH									= _CUDA_ARCH,
+		CHECK_ALIGNMENT								= _CHECK_ALIGNMENT,
+		LOG_BINS									= _LOG_BINS,
+		LOG_SCHEDULE_GRANULARITY					= _LOG_SCHEDULE_GRANULARITY,
+		MIN_CTA_OCCUPANCY  							= _MIN_CTA_OCCUPANCY,
+		LOG_THREADS 								= _LOG_THREADS,
+		LOG_LOAD_VEC_SIZE 							= _LOG_LOAD_VEC_SIZE,
+		LOG_LOADS_PER_CYCLE							= _LOG_LOADS_PER_CYCLE,
+		LOG_CYCLES_PER_TILE							= _LOG_CYCLES_PER_TILE,
+		LOG_RAKING_THREADS							= _LOG_RAKING_THREADS,
+
+		SCHEDULE_GRANULARITY						= 1 << LOG_SCHEDULE_GRANULARITY,
+		THREADS										= 1 << LOG_THREADS,
+		TILE_ELEMENTS								= 1 << (LOG_THREADS + LOG_LOAD_VEC_SIZE + LOG_LOADS_PER_CYCLE + LOG_CYCLES_PER_TILE),
+	};
+
+	static const util::io::ld::CacheModifier READ_MODIFIER 		= _READ_MODIFIER;
+	static const util::io::st::CacheModifier WRITE_MODIFIER 	= _WRITE_MODIFIER;
+	static const ScatterStrategy SCATTER_STRATEGY 				= _SCATTER_STRATEGY;
+};
+
+
+
+} // namespace downsweep
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/partition/policy.cuh
+++ b/include/b40c/partition/policy.cuh
@@ -1,0 +1,123 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Unified partitioning policy
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/operators.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+#include <b40c/partition/spine/kernel.cuh>
+
+#include <b40c/scan/problem_type.cuh>
+#include <b40c/scan/kernel_policy.cuh>
+
+namespace b40c {
+namespace partition {
+
+
+/**
+ * Unified partitioning policy type.
+ *
+ * In addition to kernel tuning parameters that guide the kernel compilation for
+ * upsweep, spine, and downsweep kernels, this type includes enactor tuning
+ * parameters that define kernel-dispatch policy.   By encapsulating all of the
+ * kernel tuning policies, we assure operational consistency over an entire
+ * partitioning pass.
+ */
+template <
+	// Problem Type
+	typename ProblemType,
+
+	// Common
+	int CUDA_ARCH,
+	util::io::ld::CacheModifier READ_MODIFIER,
+	util::io::st::CacheModifier WRITE_MODIFIER,
+	
+	// Spine-scan
+	int SPINE_LOG_THREADS,
+	int SPINE_LOG_LOAD_VEC_SIZE,
+	int SPINE_LOG_LOADS_PER_TILE,
+	int SPINE_LOG_RAKING_THREADS>
+
+struct Policy : ProblemType
+{
+	//---------------------------------------------------------------------
+	// Typedefs
+	//---------------------------------------------------------------------
+
+	typedef typename ProblemType::SizeT 		SizeT;
+
+	typedef void (*SpineKernelPtr)(SizeT*, SizeT*, int);
+
+	//---------------------------------------------------------------------
+	// Kernel Policies
+	//---------------------------------------------------------------------
+
+	// Problem type for spine scan
+	typedef scan::ProblemType<
+		SizeT,								// spine scan type T
+		int,								// spine scan SizeT
+		util::Sum<SizeT>,
+		util::Sum<SizeT>,
+		true,								// exclusive
+		true> SpineProblemType;				// addition is commutative
+
+	// Kernel config for spine scan
+	typedef scan::KernelPolicy <
+		SpineProblemType,
+		CUDA_ARCH,
+		false,								// do not check alignment
+		1,									// only a single-CTA grid
+		SPINE_LOG_THREADS,
+		SPINE_LOG_LOAD_VEC_SIZE,
+		SPINE_LOG_LOADS_PER_TILE,
+		SPINE_LOG_RAKING_THREADS,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		SPINE_LOG_LOADS_PER_TILE + SPINE_LOG_LOAD_VEC_SIZE + SPINE_LOG_THREADS>
+			Spine;
+
+	//---------------------------------------------------------------------
+	// Kernel function pointer retrieval
+	//---------------------------------------------------------------------
+
+	static SpineKernelPtr SpineKernel() {
+		return partition::spine::Kernel<Spine>;
+	}
+
+};
+		
+
+}// namespace partition
+}// namespace b40c
+

--- a/include/b40c/partition/problem_type.cuh
+++ b/include/b40c/partition/problem_type.cuh
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Partitioning problem type
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/basic_utils.cuh>
+
+namespace b40c {
+namespace partition {
+
+
+/**
+ * Type of partitioning problem (i.e., data types to partition)
+ */
+template <
+	typename _KeyType,
+	typename _ValueType,
+	typename _SizeT>
+struct ProblemType
+{
+	// The type of data we are operating upon
+	typedef _KeyType 		KeyType;
+	typedef _ValueType 		ValueType;
+
+	// The integer type we should use to index into data arrays (e.g., size_t, uint32, uint64, etc)
+	typedef _SizeT 			SizeT;
+
+	enum {
+		KEYS_ONLY = util::Equals<ValueType, util::NullType>::VALUE,
+	};
+};
+		
+
+}// namespace partition
+}// namespace b40c
+

--- a/include/b40c/partition/spine/kernel.cuh
+++ b/include/b40c/partition/spine/kernel.cuh
@@ -1,0 +1,72 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Partition spine scan kernel
+ *
+ * Requires a b40c::scan::KernelPolicy.
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/scan/spine/kernel.cuh>
+
+namespace b40c {
+namespace partition {
+namespace spine {
+
+
+/**
+ * Consecutive removal spine scan kernel entry point
+ */
+template <typename KernelPolicy>
+__launch_bounds__ (KernelPolicy::THREADS, KernelPolicy::MIN_CTA_OCCUPANCY)
+__global__ 
+void Kernel(
+	typename KernelPolicy::T			*d_in,
+	typename KernelPolicy::T			*d_out,
+	typename KernelPolicy::SizeT 		spine_elements)
+{
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	typename KernelPolicy::ReductionOp reduction_op;
+	typename KernelPolicy::IdentityOp identity_op;
+
+	scan::spine::SpinePass<KernelPolicy>(
+		d_in,
+		d_out,
+		spine_elements,
+		reduction_op,
+		identity_op,
+		smem_storage);
+}
+
+} // namespace spine
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/partition/upsweep/aggregate_counters.cuh
+++ b/include/b40c/partition/upsweep/aggregate_counters.cuh
@@ -1,0 +1,220 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Aggregate-counter functionality for partitioning upsweep reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace partition {
+namespace upsweep {
+
+
+/**
+ * Thread-local aggregate counters.  Each warp must periodically expand and
+ * aggregate its shared-memory composite-counter lanes into registers before
+ * they overflow.
+ *
+ * Each thread will aggregate a segment of (lane-length / warp-size)
+ * composite-counters within lane belonging to its warp.  There
+ * are four encoded bins within each composite counter.
+ */
+template <typename KernelPolicy>
+struct AggregateCounters
+{
+	//---------------------------------------------------------------------
+	// Typedefs and constants
+	//---------------------------------------------------------------------
+
+	typedef typename KernelPolicy::SizeT SizeT;
+
+	enum {
+		LANES_PER_WARP 						= KernelPolicy::LANES_PER_WARP,
+		COMPOSITES_PER_LANE_PER_THREAD 		= KernelPolicy::COMPOSITES_PER_LANE_PER_THREAD,
+		WARPS								= KernelPolicy::WARPS,
+		COMPOSITE_LANES						= KernelPolicy::COMPOSITE_LANES,
+	};
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Aggregate counters (four encoded bins per lane by the number of lanes
+	// aggregated per warp)
+	SizeT local_counts[KernelPolicy::LANES_PER_WARP][4];
+
+
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	/**
+	 * Iterate next composite counter
+	 */
+	template <int WARP_LANE, int THREAD_COMPOSITE, int dummy = 0>
+	struct Iterate
+	{
+		// ExtractComposites
+		template <typename Cta, typename AggregateCounters>
+		static __device__ __forceinline__ void ExtractComposites(
+			Cta *cta,
+			AggregateCounters *aggregate_counters)
+		{
+			int lane				= (WARP_LANE * WARPS) + cta->warp_id;
+			int composite			= (THREAD_COMPOSITE * B40C_WARP_THREADS(__B40C_CUDA_ARCH__)) + cta->warp_idx;
+
+			aggregate_counters->local_counts[WARP_LANE][0] += cta->smem_storage.composite_counters.counters[lane][composite][0];
+			aggregate_counters->local_counts[WARP_LANE][1] += cta->smem_storage.composite_counters.counters[lane][composite][1];
+			aggregate_counters->local_counts[WARP_LANE][2] += cta->smem_storage.composite_counters.counters[lane][composite][2];
+			aggregate_counters->local_counts[WARP_LANE][3] += cta->smem_storage.composite_counters.counters[lane][composite][3];
+
+			Iterate<WARP_LANE, THREAD_COMPOSITE + 1>::ExtractComposites(cta, aggregate_counters);
+		}
+	};
+
+	/**
+	 * Iterate next lane
+	 */
+	template <int WARP_LANE, int dummy>
+	struct Iterate<WARP_LANE, COMPOSITES_PER_LANE_PER_THREAD, dummy>
+	{
+		// ExtractComposites
+		template <typename Cta, typename AggregateCounters>
+		static __device__ __forceinline__ void ExtractComposites(
+			Cta *cta,
+			AggregateCounters *aggregate_counters)
+		{
+			Iterate<WARP_LANE + 1, 0>::ExtractComposites(cta, aggregate_counters);
+		}
+
+		// ShareCounters
+		template <typename Cta, typename AggregateCounters>
+		static __device__ __forceinline__ void ShareCounters(
+			Cta *cta,
+			AggregateCounters *aggregate_counters)
+		{
+			int lane				= (WARP_LANE * WARPS) + cta->warp_id;
+			int row 				= lane << 2;	// lane * 4;
+
+			cta->smem_storage.aggregate[row + 0][cta->warp_idx] = aggregate_counters->local_counts[WARP_LANE][0];
+			cta->smem_storage.aggregate[row + 1][cta->warp_idx] = aggregate_counters->local_counts[WARP_LANE][1];
+			cta->smem_storage.aggregate[row + 2][cta->warp_idx] = aggregate_counters->local_counts[WARP_LANE][2];
+			cta->smem_storage.aggregate[row + 3][cta->warp_idx] = aggregate_counters->local_counts[WARP_LANE][3];
+
+			Iterate<WARP_LANE + 1, COMPOSITES_PER_LANE_PER_THREAD>::ShareCounters(cta, aggregate_counters);
+		}
+
+		// ResetCounters
+		template <typename Cta, typename AggregateCounters>
+		static __device__ __forceinline__ void ResetCounters(
+			Cta *cta,
+			AggregateCounters *aggregate_counters)
+		{
+			aggregate_counters->local_counts[WARP_LANE][0] = 0;
+			aggregate_counters->local_counts[WARP_LANE][1] = 0;
+			aggregate_counters->local_counts[WARP_LANE][2] = 0;
+			aggregate_counters->local_counts[WARP_LANE][3] = 0;
+
+			Iterate<WARP_LANE + 1, COMPOSITES_PER_LANE_PER_THREAD>::ResetCounters(cta, aggregate_counters);
+		}
+	};
+
+	/**
+	 * Terminate iteration
+	 */
+	template <int dummy>
+	struct Iterate<LANES_PER_WARP, 0, dummy>
+	{
+		// ExtractComposites
+		template <typename Cta, typename AggregateCounters>
+		static __device__ __forceinline__ void ExtractComposites(
+			Cta *cta, AggregateCounters *aggregate_counters) {}
+	};
+
+	/**
+	 * Terminate iteration
+	 */
+	template <int dummy>
+	struct Iterate<LANES_PER_WARP, COMPOSITES_PER_LANE_PER_THREAD, dummy>
+	{
+		// ShareCounters
+		template <typename Cta, typename AggregateCounters>
+		static __device__ __forceinline__ void ShareCounters(
+			Cta *cta, AggregateCounters *aggregate_counters) {}
+
+		// ResetCounters
+		template <typename Cta, typename AggregateCounters>
+		static __device__ __forceinline__ void ResetCounters(
+			Cta *cta, AggregateCounters *aggregate_counters) {}
+	};
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Extracts and aggregates the shared-memory composite counters for each
+	 * composite-counter lane owned by this warp
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void ExtractComposites(Cta *cta)
+	{
+		if (cta->warp_id < COMPOSITE_LANES) {
+			Iterate<0, 0>::ExtractComposites(cta, this);
+		}
+	}
+
+	/**
+	 * Places aggregate-counters into shared storage for final bin-wise reduction
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void ShareCounters(Cta *cta)
+	{
+		if (cta->warp_id < COMPOSITE_LANES) {
+			Iterate<0, COMPOSITES_PER_LANE_PER_THREAD>::ShareCounters(cta, this);
+		}
+	}
+
+	/**
+	 * Resets the aggregate counters
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void ResetCounters(Cta *cta)
+	{
+		Iterate<0, COMPOSITES_PER_LANE_PER_THREAD>::ResetCounters(cta, this);
+	}
+};
+
+
+
+} // namespace upsweep
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/partition/upsweep/composite_counters.cuh
+++ b/include/b40c/partition/upsweep/composite_counters.cuh
@@ -1,0 +1,102 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Composite-counter functionality for partitioning upsweep reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace partition {
+namespace upsweep {
+
+
+/**
+ * Shared-memory lanes of composite counters.
+ *
+ * We keep our per-thread composite counters in smem because we simply don't
+ * have enough register storage.
+ */
+template <typename KernelPolicy>
+struct CompostiteCounters
+{
+	enum {
+		COMPOSITE_LANES = KernelPolicy::COMPOSITE_LANES,
+	};
+
+
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	/**
+	 * Iterate lane
+	 */
+	template <int LANE, int dummy = 0>
+	struct Iterate
+	{
+		// ResetCompositeCounters
+		template <typename Cta>
+		static __device__ __forceinline__ void ResetCompositeCounters(Cta *cta)
+		{
+			cta->smem_storage.composite_counters.words[LANE][threadIdx.x] = 0;
+			Iterate<LANE + 1>::ResetCompositeCounters(cta);
+		}
+	};
+
+	/**
+	 * Terminate iteration
+	 */
+	template <int dummy>
+	struct Iterate<COMPOSITE_LANES, dummy>
+	{
+		// ResetCompositeCounters
+		template <typename Cta>
+		static __device__ __forceinline__ void ResetCompositeCounters(Cta *cta) {}
+	};
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Resets our composite-counter lanes
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void ResetCompositeCounters(Cta *cta)
+	{
+		Iterate<0>::ResetCompositeCounters(cta);
+	}
+};
+
+
+} // namespace upsweep
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/partition/upsweep/cta.cuh
+++ b/include/b40c/partition/upsweep/cta.cuh
@@ -1,0 +1,315 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ * Abstract CTA-processing functionality for partitioning upsweep
+ * reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+#include <b40c/util/device_intrinsics.cuh>
+#include <b40c/util/reduction/serial_reduce.cuh>
+
+#include <b40c/partition/upsweep/aggregate_counters.cuh>
+#include <b40c/partition/upsweep/composite_counters.cuh>
+#include <b40c/partition/upsweep/tile.cuh>
+
+#include <b40c/radix_sort/sort_utils.cuh>
+
+namespace b40c {
+namespace partition {
+namespace upsweep {
+
+
+
+/**
+ * Partitioning upsweep reduction CTA
+ *
+ * Abstract class
+ */
+template <
+	typename KernelPolicy,
+	typename DerivedCta,						// Derived CTA class
+	template <
+		int LOG_LOADS_PER_TILE,
+		int LOG_LOAD_VEC_SIZE,
+		typename Policy> class Tile>			// Derived Tile class to use
+struct Cta
+{
+	//---------------------------------------------------------------------
+	// Typedefs and Constants
+	//---------------------------------------------------------------------
+
+	typedef typename KernelPolicy::KeyType 					KeyType;
+	typedef typename KernelPolicy::SizeT 					SizeT;
+	typedef typename KernelPolicy::SmemStorage				SmemStorage;
+	typedef DerivedCta 										Dispatch;
+
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Shared storage for this CTA
+	typename KernelPolicy::SmemStorage 	&smem_storage;
+
+	// Shared-memory lanes of composite-counters
+	CompostiteCounters<KernelPolicy> 	composite_counters;
+
+	// Thread-local counters for periodically aggregating composite-counter lanes
+	AggregateCounters<KernelPolicy>		aggregate_counters;
+
+	// Input and output device pointers
+	KeyType								*d_in_keys;
+	SizeT								*d_spine;
+
+	int 								warp_id;
+	int 								warp_idx;
+
+
+	//---------------------------------------------------------------------
+	// Helper Structures
+	//---------------------------------------------------------------------
+
+	/**
+	 * Unrolled tile processing
+	 */
+	struct UnrollTiles
+	{
+		// Recurse over counts
+		template <int UNROLL_COUNT, int __dummy = 0>
+		struct Iterate
+		{
+			static const int HALF = UNROLL_COUNT / 2;
+
+			template <typename Cta>
+			static __device__ __forceinline__ void ProcessTiles(
+				Cta *cta, SizeT cta_offset)
+			{
+				Iterate<HALF>::ProcessTiles(cta, cta_offset);
+				Iterate<HALF>::ProcessTiles(cta, cta_offset + (KernelPolicy::TILE_ELEMENTS * HALF));
+			}
+		};
+
+		// Terminate (process one tile)
+		template <int __dummy>
+		struct Iterate<1, __dummy>
+		{
+			template <typename Cta>
+			static __device__ __forceinline__ void ProcessTiles(
+				Cta *cta, SizeT cta_offset)
+			{
+				cta->ProcessFullTile(cta_offset);
+			}
+		};
+	};
+
+
+	//---------------------------------------------------------------------
+	// Methods
+	//---------------------------------------------------------------------
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ Cta(
+		SmemStorage 	&smem_storage,
+		KeyType 		*d_in_keys,
+		SizeT 			*d_spine) :
+			smem_storage(smem_storage),
+			d_in_keys(d_in_keys),
+			d_spine(d_spine),
+			warp_id(threadIdx.x >> B40C_LOG_WARP_THREADS(__B40C_CUDA_ARCH__)),
+			warp_idx(util::LaneId())
+	{}
+
+
+	/**
+	 * Processes a single, full tile
+	 */
+	__device__ __forceinline__ void ProcessFullTile(
+		SizeT cta_offset)
+	{
+		Dispatch *dispatch = (Dispatch*) this;
+
+		Tile<
+			KernelPolicy::LOG_LOADS_PER_TILE,
+			KernelPolicy::LOG_LOAD_VEC_SIZE,
+			KernelPolicy> tile;
+
+		// Load keys
+		tile.LoadKeys(dispatch, cta_offset);
+
+		// Prevent bucketing from being hoisted (otherwise we don't get the desired outstanding loads)
+		if (KernelPolicy::LOADS_PER_TILE > 1) __syncthreads();
+
+		// Bucket tile of keys
+		tile.Bucket(dispatch);
+
+		// Store keys (if necessary)
+		tile.StoreKeys(dispatch, cta_offset);
+	}
+
+
+	/**
+	 * Processes a single load (may have some threads masked off)
+	 */
+	__device__ __forceinline__ void ProcessPartialTile(
+		SizeT cta_offset,
+		const SizeT &out_of_bounds)
+	{
+		Dispatch *dispatch = (Dispatch*) this;
+
+		// Process partial tile if necessary using single loads
+		while (cta_offset + threadIdx.x < out_of_bounds) {
+
+			Tile<0, 0, KernelPolicy> tile;
+
+			// Load keys
+			tile.LoadKeys(dispatch, cta_offset);
+
+			// Bucket tile of keys
+			tile.Bucket(dispatch);
+
+			// Store keys (if necessary)
+			tile.StoreKeys(dispatch, cta_offset);
+
+			cta_offset += KernelPolicy::THREADS;
+		}
+	}
+
+
+	/**
+	 * Process work range of tiles
+	 */
+	__device__ __forceinline__ void ProcessWorkRange(
+		util::CtaWorkLimits<SizeT> &work_limits)
+	{
+		Dispatch *dispatch = (Dispatch*) this;
+
+		// Make sure we get a local copy of the cta's offset (work_limits may be in smem)
+		SizeT cta_offset = work_limits.offset;
+
+		aggregate_counters.ResetCounters(dispatch);
+		composite_counters.ResetCompositeCounters(dispatch);
+
+
+#if 1	// Use deep unrolling for better instruction efficiency
+
+		// Unroll batches of full tiles
+		const int UNROLLED_ELEMENTS = KernelPolicy::UNROLL_COUNT * KernelPolicy::TILE_ELEMENTS;
+		while (cta_offset  + UNROLLED_ELEMENTS < work_limits.out_of_bounds) {
+
+			UnrollTiles::template Iterate<KernelPolicy::UNROLL_COUNT>::ProcessTiles(
+				dispatch,
+				cta_offset);
+			cta_offset += UNROLLED_ELEMENTS;
+
+			__syncthreads();
+
+			// Aggregate back into local_count registers to prevent overflow
+			aggregate_counters.ExtractComposites(dispatch);
+
+			__syncthreads();
+
+			// Reset composite counters in lanes
+			composite_counters.ResetCompositeCounters(dispatch);
+		}
+
+		// Unroll single full tiles
+		while (cta_offset + KernelPolicy::TILE_ELEMENTS < work_limits.out_of_bounds) {
+
+			UnrollTiles::template Iterate<1>::ProcessTiles(
+				dispatch,
+				cta_offset);
+			cta_offset += KernelPolicy::TILE_ELEMENTS;
+		}
+
+#else 	// Use shallow unrolling for faster compilation tiles
+
+		// Unroll single full tiles
+		while (cta_offset < work_limits.guarded_offset) {
+
+			ProcessFullTile(cta_offset);
+			cta_offset += KernelPolicy::TILE_ELEMENTS;
+
+			const SizeT UNROLL_MASK = (KernelPolicy::UNROLL_COUNT - 1) << KernelPolicy::LOG_TILE_ELEMENTS;
+			if ((cta_offset & UNROLL_MASK) == 0) {
+
+				__syncthreads();
+
+				// Aggregate back into local_count registers to prevent overflow
+				aggregate_counters.ExtractComposites(dispatch);
+
+				__syncthreads();
+
+				// Reset composite counters in lanes
+				composite_counters.ResetCompositeCounters(dispatch);
+			}
+		}
+#endif
+
+		// Process partial tile if necessary
+		ProcessPartialTile(cta_offset, work_limits.out_of_bounds);
+
+		__syncthreads();
+
+		// Aggregate back into local_count registers
+		aggregate_counters.ExtractComposites(dispatch);
+
+		__syncthreads();
+
+		//Final raking reduction of counts by bin, output to spine.
+
+		aggregate_counters.ShareCounters(dispatch);
+
+		__syncthreads();
+
+		// Rake-reduce and write out the bin_count reductions
+		if (threadIdx.x < KernelPolicy::BINS) {
+
+			SizeT bin_count = util::reduction::SerialReduce<KernelPolicy::AGGREGATED_PARTIALS_PER_ROW>::Invoke(
+				smem_storage.aggregate[threadIdx.x]);
+
+			int spine_bin_offset = util::FastMul(gridDim.x, threadIdx.x) + blockIdx.x;
+
+			util::io::ModifiedStore<KernelPolicy::WRITE_MODIFIER>::St(
+					bin_count, d_spine + spine_bin_offset);
+		}
+	}
+};
+
+
+
+} // namespace upsweep
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/partition/upsweep/kernel_policy.cuh
+++ b/include/b40c/partition/upsweep/kernel_policy.cuh
@@ -1,0 +1,130 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Configuration policy for partitioning upsweep reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/basic_utils.cuh>
+
+namespace b40c {
+namespace partition {
+namespace upsweep {
+
+
+/**
+ * A detailed partitioning upsweep kernel configuration policy type that specializes kernel
+ * code for a specific pass. It encapsulates tuning configuration
+ * policy details derived from TuningPolicy
+ */
+template <typename TuningPolicy>
+struct KernelPolicy : TuningPolicy
+{
+	enum {		// N.B.: We use an enum type here b/c of a NVCC-win compiler bug involving ternary expressions in static-const fields
+
+		BINS 								= 1 << TuningPolicy::LOG_BINS,
+		THREADS								= 1 << TuningPolicy::LOG_THREADS,
+
+		LOG_WARPS							= TuningPolicy::LOG_THREADS - B40C_LOG_WARP_THREADS(TuningPolicy::CUDA_ARCH),
+		WARPS								= 1 << LOG_WARPS,
+
+		LOAD_VEC_SIZE						= 1 << TuningPolicy::LOG_LOAD_VEC_SIZE,
+		LOADS_PER_TILE						= 1 << TuningPolicy::LOG_LOADS_PER_TILE,
+
+		LOG_TILE_ELEMENTS_PER_THREAD		= TuningPolicy::LOG_LOAD_VEC_SIZE + TuningPolicy::LOG_LOADS_PER_TILE,
+		TILE_ELEMENTS_PER_THREAD			= 1 << LOG_TILE_ELEMENTS_PER_THREAD,
+
+		LOG_TILE_ELEMENTS 					= LOG_TILE_ELEMENTS_PER_THREAD + TuningPolicy::LOG_THREADS,
+		TILE_ELEMENTS						= 1 << LOG_TILE_ELEMENTS,
+
+		// A shared-memory composite counter lane is a row of 32-bit words, one word per thread, each word a
+		// composite of four 8-bit bin counters.  I.e., we need one lane for every four distribution bins.
+
+		LOG_COMPOSITE_LANES 				= (TuningPolicy::LOG_BINS >= 2) ?
+												TuningPolicy::LOG_BINS - 2 :
+												0,	// Always at least one lane
+		COMPOSITE_LANES 					= 1 << LOG_COMPOSITE_LANES,
+	
+		LOG_COMPOSITES_PER_LANE				= TuningPolicy::LOG_THREADS,				// Every thread contributes one partial for each lane
+		COMPOSITES_PER_LANE 				= 1 << LOG_COMPOSITES_PER_LANE,
+	
+		// To prevent bin-counter overflow, we must partially-aggregate the
+		// 8-bit composite counters back into SizeT-bit registers periodically.  Each lane
+		// is assigned to a warp for aggregation.  Each lane is therefore equivalent to
+		// four rows of SizeT-bit bin-counts, each the width of a warp.
+	
+		LOG_LANES_PER_WARP					= B40C_MAX(0, LOG_COMPOSITE_LANES - LOG_WARPS),
+		LANES_PER_WARP 						= 1 << LOG_LANES_PER_WARP,
+	
+		LOG_COMPOSITES_PER_LANE_PER_THREAD 	= LOG_COMPOSITES_PER_LANE - B40C_LOG_WARP_THREADS(TuningPolicy::CUDA_ARCH),					// Number of partials per thread to aggregate
+		COMPOSITES_PER_LANE_PER_THREAD 		= 1 << LOG_COMPOSITES_PER_LANE_PER_THREAD,
+	
+		AGGREGATED_ROWS						= BINS,
+		AGGREGATED_PARTIALS_PER_ROW 		= B40C_WARP_THREADS(TuningPolicy::CUDA_ARCH),
+		PADDED_AGGREGATED_PARTIALS_PER_ROW 	= AGGREGATED_PARTIALS_PER_ROW + 1,
+
+		// Unroll tiles in batches of X elements per thread (X = log(255) is maximum without risking overflow)
+		LOG_UNROLL_COUNT 					= 6 - LOG_TILE_ELEMENTS_PER_THREAD,		// X = 128
+		UNROLL_COUNT						= 1 << LOG_UNROLL_COUNT,
+	};
+
+	/**
+	 * Shared storage for radix distribution sorting upsweep
+	 */
+	struct SmemStorage
+	{
+		union {
+			// Composite counter storage
+			union {
+				char counters[COMPOSITE_LANES][THREADS][4];
+				int words[COMPOSITE_LANES][THREADS];
+			} composite_counters;
+
+			// Final bin reduction storage
+			typename TuningPolicy::SizeT aggregate[AGGREGATED_ROWS][PADDED_AGGREGATED_PARTIALS_PER_ROW];
+		};
+	};
+	
+	enum {
+		THREAD_OCCUPANCY					= B40C_SM_THREADS(TuningPolicy::CUDA_ARCH) >> TuningPolicy::LOG_THREADS,
+		SMEM_OCCUPANCY						= B40C_SMEM_BYTES(TuningPolicy::CUDA_ARCH) / sizeof(SmemStorage),
+		MAX_CTA_OCCUPANCY					= B40C_MIN(B40C_SM_CTAS(TuningPolicy::CUDA_ARCH), B40C_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY)),
+
+		VALID								= (MAX_CTA_OCCUPANCY > 0),
+	};
+};
+
+
+
+} // namespace upsweep
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/partition/upsweep/tile.cuh
+++ b/include/b40c/partition/upsweep/tile.cuh
@@ -1,0 +1,201 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Abstract tile-processing functionality for partitioning upsweep reduction
+ * kernels
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace partition {
+namespace upsweep {
+
+
+/**
+ * Tile
+ *
+ * Abstract class
+ */
+template <
+	int LOG_LOADS_PER_TILE,
+	int LOG_LOAD_VEC_SIZE,
+	typename KernelPolicy,
+	typename DerivedTile>
+struct Tile
+{
+	//---------------------------------------------------------------------
+	// Typedefs and Constants
+	//---------------------------------------------------------------------
+
+	typedef typename KernelPolicy::KeyType 			KeyType;
+	typedef typename KernelPolicy::SizeT			SizeT;
+	typedef DerivedTile 							Dispatch;
+
+	enum {
+		LOADS_PER_TILE 		= 1 << LOG_LOADS_PER_TILE,
+		LOAD_VEC_SIZE 		= 1 << LOG_LOAD_VEC_SIZE
+	};
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Dequeued vertex ids
+	KeyType 	keys[LOADS_PER_TILE][LOAD_VEC_SIZE];
+
+
+	//---------------------------------------------------------------------
+	// Abstract Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Returns the bin into which the specified key is to be placed
+	 *
+	 * To be overloaded.
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ int DecodeBin(KeyType key, Cta *cta);
+
+
+	/**
+	 * Returns whether or not the key is valid.
+	 *
+	 * To be overloaded.
+	 */
+	template <int LOAD, int VEC>
+	__device__ __forceinline__ bool IsValid();
+
+
+	/**
+	 * Loads keys into the tile
+	 *
+	 * To be overloaded.
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void LoadKeys(Cta *cta, SizeT cta_offset);
+
+
+	/**
+	 * Stores keys from the tile (if necessary)
+	 *
+	 * To be overloaded.
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void StoreKeys(Cta *cta, SizeT cta_offset);
+
+
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	/**
+	 * Iterate next vector element
+	 */
+	template <int LOAD, int VEC, int dummy = 0>
+	struct Iterate
+	{
+		// Bucket
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void Bucket(Cta *cta, Tile *tile)
+		{
+			if (tile->template IsValid<LOAD, VEC>()) {
+
+				const KeyType COUNTER_BYTE_MASK = (KernelPolicy::LOG_BINS < 2) ? 0x1 : 0x3;
+
+				// Decode the bin for this key
+				int bin = tile->DecodeBin(tile->keys[LOAD][VEC], cta);
+
+				// Decode composite-counter lane and sub-counter from bin
+				int lane = bin >> 2;										// extract composite counter lane
+				int sub_counter = bin & COUNTER_BYTE_MASK;					// extract 8-bit counter offset
+
+				if (__B40C_CUDA_ARCH__ >= 200) {
+
+					// Increment sub-field in composite counter
+					cta->smem_storage.composite_counters.counters[lane][threadIdx.x][sub_counter]++;
+
+				} else {
+
+					// Increment sub-field in composite counter
+					cta->smem_storage.composite_counters.words[lane][threadIdx.x] += (1 << (sub_counter << 0x3));
+				}
+			}
+
+			Iterate<LOAD, VEC + 1>::Bucket(cta, tile);
+		}
+	};
+
+
+	/**
+	 * Iterate next load
+	 */
+	template <int LOAD, int dummy>
+	struct Iterate<LOAD, LOAD_VEC_SIZE, dummy>
+	{
+		// Bucket
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void Bucket(Cta *cta, Tile *tile)
+		{
+			Iterate<LOAD + 1, 0>::Bucket(cta, tile);
+		}
+	};
+
+
+	/**
+	 * Terminate iteration
+	 */
+	template <int dummy>
+	struct Iterate<LOADS_PER_TILE, 0, dummy>
+	{
+		// Bucket
+		template <typename Cta, typename Tile>
+		static __device__ __forceinline__ void Bucket(Cta *cta, Tile *tile) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Decode keys in this tile and updates the cta's corresponding composite counters
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void Bucket(Cta *cta)
+	{
+		Iterate<0, 0>::Bucket(cta, (Dispatch *) this);
+	}
+};
+
+
+
+} // namespace upsweep
+} // namespace partition
+} // namespace b40c

--- a/include/b40c/partition/upsweep/tuning_policy.cuh
+++ b/include/b40c/partition/upsweep/tuning_policy.cuh
@@ -1,0 +1,97 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Tuning policy for partitioning upsweep reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+namespace b40c {
+namespace partition {
+namespace upsweep {
+
+
+/**
+ * Partitioning upsweep reduction tuning policy .  This type encapsulates our
+ * kernel-tuning parameters (they are reflected via the static fields).
+ *
+ * Note that the number of bins is considered a tuning parameter as opposed
+ * to a problem-type parameter.  (We can simply enact subsequent sub-partitioning
+ * passes to effect more bins).
+ *  
+ * The kernel is specialized for problem-type, SM-version, etc. by declaring
+ * it with different performance-tuned parameterizations of this type.  By
+ * incorporating this type into the kernel code itself, we guide the compiler in 
+ * expanding/unrolling the kernel code for specific architectures and problem 
+ * types.    
+ */
+template <
+	// Problem type
+	typename ProblemType,
+
+	int _CUDA_ARCH,
+	bool _CHECK_ALIGNMENT,
+	int _LOG_BINS,
+	int _LOG_SCHEDULE_GRANULARITY,
+	int _MIN_CTA_OCCUPANCY,
+	int _LOG_THREADS,
+	int _LOG_LOAD_VEC_SIZE,
+	int _LOG_LOADS_PER_TILE,
+	util::io::ld::CacheModifier _READ_MODIFIER,
+	util::io::st::CacheModifier _WRITE_MODIFIER>
+
+struct TuningPolicy : ProblemType
+{
+	enum {
+		CUDA_ARCH									= _CUDA_ARCH,
+		CHECK_ALIGNMENT								= _CHECK_ALIGNMENT,
+		LOG_BINS									= _LOG_BINS,
+		LOG_SCHEDULE_GRANULARITY					= _LOG_SCHEDULE_GRANULARITY,
+		MIN_CTA_OCCUPANCY  							= _MIN_CTA_OCCUPANCY,
+		LOG_THREADS 								= _LOG_THREADS,
+		LOG_LOAD_VEC_SIZE  							= _LOG_LOAD_VEC_SIZE,
+		LOG_LOADS_PER_TILE 							= _LOG_LOADS_PER_TILE,
+
+		SCHEDULE_GRANULARITY						= 1 << LOG_SCHEDULE_GRANULARITY,
+		THREADS										= 1 << LOG_THREADS,
+		TILE_ELEMENTS								= 1 << (LOG_THREADS + LOG_LOAD_VEC_SIZE + LOG_LOADS_PER_TILE),
+	};
+
+	static const util::io::ld::CacheModifier READ_MODIFIER 		= _READ_MODIFIER;
+	static const util::io::st::CacheModifier WRITE_MODIFIER 	= _WRITE_MODIFIER;
+};
+
+
+} // namespace upsweep
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/radix_sort/autotuned_policy.cuh
+++ b/include/b40c/radix_sort/autotuned_policy.cuh
@@ -1,0 +1,659 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ * Autotuned radix sort policy
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+#include <b40c/radix_sort/upsweep/kernel.cuh>
+#include <b40c/radix_sort/upsweep/kernel_policy.cuh>
+#include <b40c/radix_sort/downsweep/kernel.cuh>
+#include <b40c/radix_sort/downsweep/kernel_policy.cuh>
+#include <b40c/radix_sort/policy.cuh>
+
+#include <b40c/scan/spine/kernel.cuh>
+
+namespace b40c {
+namespace radix_sort {
+
+
+/******************************************************************************
+ * Genre enumerations to classify problems by
+ ******************************************************************************/
+
+/**
+ * Enumeration of problem-size genres that we may have tuned for
+ */
+enum ProbSizeGenre
+{
+	UNKNOWN_SIZE = -1,			// Not actually specialized on: the enactor should use heuristics to select another size genre
+	SMALL_SIZE,					// Tuned @ 128KB input
+	LARGE_SIZE					// Tuned @ 128MB input
+};
+
+
+/**
+ * Enumeration of architecture-family genres that we have tuned for below
+ */
+enum ArchGenre
+{
+	SM20 	= 200,
+	SM13	= 130,
+	SM10	= 100
+};
+
+
+/**
+ * Enumeration of type size genres
+ */
+enum TypeSizeGenre
+{
+	TINY_TYPE,
+	SMALL_TYPE,
+	MEDIUM_TYPE,
+	LARGE_TYPE
+};
+
+
+/**
+ * Autotuning policy genre, to be specialized
+ */
+template <
+	// Problem and machine types
+	typename ProblemType,
+	int CUDA_ARCH,
+
+	// Genres to specialize upon
+	ProbSizeGenre PROB_SIZE_GENRE,
+	ArchGenre ARCH_GENRE,
+	TypeSizeGenre TYPE_SIZE_GENRE,
+	TypeSizeGenre OFFSET_SIZE_GENRE,
+	TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre;
+
+
+/******************************************************************************
+ * Classifiers for identifying classification genres
+ ******************************************************************************/
+
+/**
+ * Classifies a given CUDA_ARCH into an architecture-family genre
+ */
+template <int CUDA_ARCH>
+struct ArchClassifier
+{
+	static const ArchGenre GENRE 			=	(CUDA_ARCH < SM13) ? SM10 :
+												(CUDA_ARCH < SM20) ? SM13 : SM20;
+};
+
+
+/**
+ * Classifies the problem type(s) into a type-size genre
+ */
+template <typename ProblemType>
+struct TypeSizeClassifier
+{
+	enum {
+		KEYS_ROUNDED_SIZE		= 1 << util::Log2<sizeof(typename ProblemType::KeyType)>::VALUE,	// Round up to the nearest arch subword
+		VALUES_ROUNDED_SIZE		= 1 << util::Log2<sizeof(typename ProblemType::ValueType)>::VALUE,
+		MAX_ROUNDED_SIZE		= B40C_MAX(KEYS_ROUNDED_SIZE, VALUES_ROUNDED_SIZE),
+	};
+
+	static const TypeSizeGenre GENRE 		= (MAX_ROUNDED_SIZE < 8) ? MEDIUM_TYPE : LARGE_TYPE;
+};
+
+
+/**
+ * Classifies the offset type into a type-size genre
+ */
+template <typename ProblemType>
+struct OffsetSizeClassifier
+{
+	static const TypeSizeGenre GENRE 		= (sizeof(typename ProblemType::SizeT) < 8) ? MEDIUM_TYPE : LARGE_TYPE;
+};
+
+
+/**
+ * Classifies the pointer type into a type-size genre
+ */
+struct PointerSizeClassifier
+{
+	static const TypeSizeGenre GENRE 		= (sizeof(size_t) < 8) ? MEDIUM_TYPE : LARGE_TYPE;
+};
+
+
+/**
+ * Autotuning policy classifier
+ */
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	ProbSizeGenre PROB_SIZE_GENRE>
+struct AutotunedClassifier :
+	AutotunedGenre<
+		ProblemType,
+		CUDA_ARCH,
+		PROB_SIZE_GENRE,
+		ArchClassifier<CUDA_ARCH>::GENRE,
+		TypeSizeClassifier<ProblemType>::GENRE,
+		OffsetSizeClassifier<ProblemType>::GENRE,
+		PointerSizeClassifier::GENRE>
+{};
+
+
+/******************************************************************************
+ * Autotuned genre specializations
+ ******************************************************************************/
+
+//-----------------------------------------------------------------------------
+// SM2.0 specializations(s)
+//-----------------------------------------------------------------------------
+
+// Large problems
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	TypeSizeGenre TYPE_SIZE_GENRE,
+	TypeSizeGenre OFFSET_SIZE_GENRE,
+	TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM20, TYPE_SIZE_GENRE, OFFSET_SIZE_GENRE, POINTER_SIZE_GENRE>
+	: Policy<
+		// Problem Type
+		ProblemType,
+
+		// Common
+		SM20,
+		4,						// RADIX_BITS
+		10,						// LOG_SCHEDULE_GRANULARITY
+		util::io::ld::NONE,		// CACHE_MODIFIER
+		util::io::st::NONE,		// CACHE_MODIFIER
+		true,					// EARLY_EXIT
+		false,					// UNIFORM_SMEM_ALLOCATION
+		true, 					// UNIFORM_GRID_SIZE
+		true,					// OVERSUBSCRIBED_GRID_SIZE
+
+		// Upsweep Kernel
+		8,						// UPSWEEP_MIN_CTA_OCCUPANCY
+		7,						// UPSWEEP_LOG_THREADS
+		0,						// UPSWEEP_LOG_LOAD_VEC_SIZE
+		2,						// UPSWEEP_LOG_LOADS_PER_TILE
+
+		// Spine-scan Kernel
+		7,						// SPINE_LOG_THREADS
+		2,						// SPINE_LOG_LOAD_VEC_SIZE
+		0,						// SPINE_LOG_LOADS_PER_TILE
+		5,						// SPINE_LOG_RAKING_THREADS
+
+		// Downsweep Kernel
+		partition::downsweep::SCATTER_TWO_PHASE,			// DOWNSWEEP_SCATTER_POLICY
+		8,						// DOWNSWEEP_MIN_CTA_OCCUPANCY
+		6,						// DOWNSWEEP_LOG_THREADS
+		2,						// DOWNSWEEP_LOG_LOAD_VEC_SIZE
+		1,						// DOWNSWEEP_LOG_LOADS_PER_CYCLE
+		(((ProblemType::KEYS_ONLY) || (POINTER_SIZE_GENRE < LARGE_TYPE)) && (OFFSET_SIZE_GENRE < LARGE_TYPE) && (TYPE_SIZE_GENRE < LARGE_TYPE)) ?		// DOWNSWEEP_LOG_CYCLES_PER_TILE
+			1 :
+			0,
+		6>						// DOWNSWEEP_LOG_RAKING_THREADS
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+
+// Small problems
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	TypeSizeGenre TYPE_SIZE_GENRE,
+	TypeSizeGenre OFFSET_SIZE_GENRE,
+	TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM20, TYPE_SIZE_GENRE, OFFSET_SIZE_GENRE, POINTER_SIZE_GENRE>
+	: Policy<
+		// Problem Type
+		ProblemType,
+
+		// Common
+		SM20,
+		4,						// RADIX_BITS
+		9,						// LOG_SCHEDULE_GRANULARITY
+		util::io::ld::NONE,		// CACHE_MODIFIER
+		util::io::st::NONE,		// CACHE_MODIFIER
+		false,					// EARLY_EXIT
+		false,					// UNIFORM_SMEM_ALLOCATION
+		false, 					// UNIFORM_GRID_SIZE
+		false,					// OVERSUBSCRIBED_GRID_SIZE
+
+		// Upsweep Kernel
+		8,						// UPSWEEP_MIN_CTA_OCCUPANCY
+		7,						// UPSWEEP_LOG_THREADS
+		1,						// UPSWEEP_LOG_LOAD_VEC_SIZE
+		0,						// UPSWEEP_LOG_LOADS_PER_TILE
+
+		// Spine-scan Kernel
+		8,						// SPINE_LOG_THREADS
+		2,						// SPINE_LOG_LOAD_VEC_SIZE
+		0,						// SPINE_LOG_LOADS_PER_TILE
+		5,						// SPINE_LOG_RAKING_THREADS
+
+		// Downsweep Kernel
+		partition::downsweep::SCATTER_TWO_PHASE,			// DOWNSWEEP_SCATTER_POLICY
+		7,						// DOWNSWEEP_MIN_CTA_OCCUPANCY
+		7,						// DOWNSWEEP_LOG_THREADS
+		1,						// DOWNSWEEP_LOG_LOAD_VEC_SIZE
+		1,						// DOWNSWEEP_LOG_LOADS_PER_CYCLE
+		0, 						// DOWNSWEEP_LOG_CYCLES_PER_TILE
+		7>						// DOWNSWEEP_LOG_RAKING_THREADS
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+
+//-----------------------------------------------------------------------------
+// SM1.3 specializations(s)
+//-----------------------------------------------------------------------------
+
+// Large problems
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	TypeSizeGenre TYPE_SIZE_GENRE,
+	TypeSizeGenre OFFSET_SIZE_GENRE,
+	TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM13, TYPE_SIZE_GENRE, OFFSET_SIZE_GENRE, POINTER_SIZE_GENRE>
+	: Policy<
+		// Problem Type
+		ProblemType,
+
+		// Common
+		SM13,
+		4,						// RADIX_BITS
+		9,						// LOG_SCHEDULE_GRANULARITY
+		util::io::ld::NONE,		// CACHE_MODIFIER
+		util::io::st::NONE,		// CACHE_MODIFIER
+		true,					// EARLY_EXIT
+		true,					// UNIFORM_SMEM_ALLOCATION
+		true, 					// UNIFORM_GRID_SIZE
+		true,					// OVERSUBSCRIBED_GRID_SIZE
+
+		// Upsweep Kernel
+		5,						// UPSWEEP_MIN_CTA_OCCUPANCY
+		7,						// UPSWEEP_LOG_THREADS
+		(TYPE_SIZE_GENRE < LARGE_TYPE) ?	// UPSWEEP_LOG_LOAD_VEC_SIZE
+			0: //1 :
+			0,
+		(TYPE_SIZE_GENRE < LARGE_TYPE) ?	// UPSWEEP_LOG_LOADS_PER_TILE
+			2: //0 :
+			1,
+
+		// Spine-scan Kernel
+		7,						// SPINE_LOG_THREADS
+		2,						// SPINE_LOG_LOAD_VEC_SIZE
+		0,						// SPINE_LOG_LOADS_PER_TILE
+		5,						// SPINE_LOG_RAKING_THREADS
+
+		// Downsweep Kernel
+		partition::downsweep::SCATTER_TWO_PHASE,			// DOWNSWEEP_SCATTER_POLICY
+		5,						// DOWNSWEEP_MIN_CTA_OCCUPANCY
+		(TYPE_SIZE_GENRE < LARGE_TYPE) ?	// DOWNSWEEP_LOG_THREADS
+			6 :
+			7,
+		(TYPE_SIZE_GENRE < LARGE_TYPE) ?	// DOWNSWEEP_LOG_LOAD_VEC_SIZE
+			2 :
+			1,
+		(TYPE_SIZE_GENRE < LARGE_TYPE) ?	// DOWNSWEEP_LOG_LOADS_PER_CYCLE
+			1 :
+			0,
+		(TYPE_SIZE_GENRE < LARGE_TYPE) ?	// DOWNSWEEP_LOG_CYCLES_PER_TILE
+			0 :
+			0,
+		5>						// DOWNSWEEP_LOG_RAKING_THREADS
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+
+// Small problems
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	TypeSizeGenre TYPE_SIZE_GENRE,
+	TypeSizeGenre OFFSET_SIZE_GENRE,
+	TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM13, TYPE_SIZE_GENRE, OFFSET_SIZE_GENRE, POINTER_SIZE_GENRE>
+	: Policy<
+		// Problem Type
+		ProblemType,
+
+		// Common
+		SM13,
+		4,						// RADIX_BITS
+		9,						// LOG_SCHEDULE_GRANULARITY
+		util::io::ld::NONE,		// CACHE_MODIFIER
+		util::io::st::NONE,		// CACHE_MODIFIER
+		true,					// EARLY_EXIT
+		true,					// UNIFORM_SMEM_ALLOCATION
+		true, 					// UNIFORM_GRID_SIZE
+		true,					// OVERSUBSCRIBED_GRID_SIZE
+
+		// Upsweep Kernel
+		5,						// UPSWEEP_MIN_CTA_OCCUPANCY
+		7,						// UPSWEEP_LOG_THREADS
+		1,						// UPSWEEP_LOG_LOAD_VEC_SIZE
+		0,						// UPSWEEP_LOG_LOADS_PER_TILE
+
+		// Spine-scan Kernel
+		7,						// SPINE_LOG_THREADS
+		2,						// SPINE_LOG_LOAD_VEC_SIZE
+		0,						// SPINE_LOG_LOADS_PER_TILE
+		5,						// SPINE_LOG_RAKING_THREADS
+
+		// Downsweep Kernel
+		partition::downsweep::SCATTER_TWO_PHASE,			// DOWNSWEEP_SCATTER_POLICY
+		5,						// DOWNSWEEP_MIN_CTA_OCCUPANCY
+		6,						// DOWNSWEEP_LOG_THREADS
+		2,						// DOWNSWEEP_LOG_LOAD_VEC_SIZE
+		1,						// DOWNSWEEP_LOG_LOADS_PER_CYCLE
+		(TYPE_SIZE_GENRE < LARGE_TYPE) ?	// DOWNSWEEP_LOG_CYCLES_PER_TILE
+			0 :
+			0,
+		5>						// DOWNSWEEP_LOG_RAKING_THREADS
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+
+
+
+//-----------------------------------------------------------------------------
+// SM1.0 specializations(s)
+//-----------------------------------------------------------------------------
+
+// Large problems
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	TypeSizeGenre TYPE_SIZE_GENRE,
+	TypeSizeGenre OFFSET_SIZE_GENRE,
+	TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM10, TYPE_SIZE_GENRE, OFFSET_SIZE_GENRE, POINTER_SIZE_GENRE>
+	: Policy<
+		// Problem Type
+		ProblemType,
+
+		// Common
+		SM10,
+		4,						// RADIX_BITS
+		9,						// LOG_SCHEDULE_GRANULARITY
+		util::io::ld::NONE,		// CACHE_MODIFIER
+		util::io::st::NONE,		// CACHE_MODIFIER
+		true,					// EARLY_EXIT
+		false,					// UNIFORM_SMEM_ALLOCATION
+		true, 					// UNIFORM_GRID_SIZE
+		true,					// OVERSUBSCRIBED_GRID_SIZE
+
+		// Upsweep Kernel
+		4,						// UPSWEEP_MIN_CTA_OCCUPANCY
+		7,						// UPSWEEP_LOG_THREADS
+		0,						// UPSWEEP_LOG_LOAD_VEC_SIZE
+		0,						// UPSWEEP_LOG_LOADS_PER_TILE
+
+		// Spine-scan Kernel
+		7,						// SPINE_LOG_THREADS
+		2,						// SPINE_LOG_LOAD_VEC_SIZE
+		0,						// SPINE_LOG_LOADS_PER_TILE
+		5,						// SPINE_LOG_RAKING_THREADS
+
+		// Downsweep Kernel
+		partition::downsweep::SCATTER_WARP_TWO_PHASE,			// DOWNSWEEP_SCATTER_POLICY
+		2,						// DOWNSWEEP_MIN_CTA_OCCUPANCY
+		7,						// DOWNSWEEP_LOG_THREADS
+		1,						// DOWNSWEEP_LOG_LOAD_VEC_SIZE
+		1,						// DOWNSWEEP_LOG_LOADS_PER_CYCLE
+		0,						// DOWNSWEEP_LOG_CYCLES_PER_TILE
+		7>						// DOWNSWEEP_LOG_RAKING_THREADS
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+
+// Small problems
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	TypeSizeGenre TYPE_SIZE_GENRE,
+	TypeSizeGenre OFFSET_SIZE_GENRE,
+	TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM10, TYPE_SIZE_GENRE, OFFSET_SIZE_GENRE, POINTER_SIZE_GENRE>
+	: Policy<
+		// Problem Type
+		ProblemType,
+
+		// Common
+		SM10,
+		4,						// RADIX_BITS
+		9,						// LOG_SCHEDULE_GRANULARITY
+		util::io::ld::NONE,		// CACHE_MODIFIER
+		util::io::st::NONE,		// CACHE_MODIFIER
+		false,					// EARLY_EXIT
+		false,					// UNIFORM_SMEM_ALLOCATION
+		true, 					// UNIFORM_GRID_SIZE
+		true,					// OVERSUBSCRIBED_GRID_SIZE
+
+		// Upsweep Kernel
+		4,						// UPSWEEP_MIN_CTA_OCCUPANCY
+		7,						// UPSWEEP_LOG_THREADS
+		0,						// UPSWEEP_LOG_LOAD_VEC_SIZE
+		0,						// UPSWEEP_LOG_LOADS_PER_TILE
+
+		// Spine-scan Kernel
+		7,						// SPINE_LOG_THREADS
+		2,						// SPINE_LOG_LOAD_VEC_SIZE
+		0,						// SPINE_LOG_LOADS_PER_TILE
+		5,						// SPINE_LOG_RAKING_THREADS
+
+		// Downsweep Kernel
+		partition::downsweep::SCATTER_WARP_TWO_PHASE,			// DOWNSWEEP_SCATTER_POLICY
+		2,						// DOWNSWEEP_MIN_CTA_OCCUPANCY
+		7,						// DOWNSWEEP_LOG_THREADS
+		1,						// DOWNSWEEP_LOG_LOAD_VEC_SIZE
+		1,						// DOWNSWEEP_LOG_LOADS_PER_CYCLE
+		0,						// DOWNSWEEP_LOG_CYCLES_PER_TILE
+		7>						// DOWNSWEEP_LOG_RAKING_THREADS
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+
+
+
+/******************************************************************************
+ * Kernel entry points that can derive a tuned granularity type
+ * implicitly from the PROB_SIZE_GENRE template parameter.  (As opposed to having
+ * the granularity type passed explicitly.)
+ *
+ * TODO: Section can be removed if CUDA Runtime is fixed to
+ * properly support template specialization around kernel call sites.
+ ******************************************************************************/
+
+/**
+ * Tuned upsweep reduction kernel entry point
+ */
+template <typename ProblemType, int PROB_SIZE_GENRE, typename PassPolicy>
+__launch_bounds__ (
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Upsweep::THREADS),
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Upsweep::MIN_CTA_OCCUPANCY))
+__global__ void TunedUpsweepKernel(
+	int 													*d_selectors,
+	typename ProblemType::SizeT 							*d_spine,
+	typename ProblemType::KeyType 							*d_in_keys,
+	typename ProblemType::KeyType 							*d_out_keys,
+	util::CtaWorkDistribution<typename ProblemType::SizeT> 	work_decomposition)
+{
+	// Load the kernel policy type identified by the enum for this architecture
+	typedef typename AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Upsweep TuningPolicy;
+	typedef upsweep::KernelPolicy<TuningPolicy, PassPolicy> KernelPolicy;
+
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	upsweep::UpsweepPass<KernelPolicy>(
+		d_selectors,
+		d_spine,
+		d_in_keys,
+		d_out_keys,
+		work_decomposition,
+		smem_storage);
+}
+
+/**
+ * Tuned spine scan kernel entry point
+ */
+template <typename ProblemType, int PROB_SIZE_GENRE>
+__launch_bounds__ (
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Spine::THREADS),
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Spine::MIN_CTA_OCCUPANCY))
+__global__ void TunedSpineKernel(
+	typename ProblemType::SizeT 		*d_spine_in,
+	typename ProblemType::SizeT 		*d_spine_out,
+	int									spine_elements)
+{
+	// Load the kernel policy type identified by the enum for this architecture
+	typedef typename AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Spine KernelPolicy;
+
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	typename KernelPolicy::ReductionOp scan_op;
+	typename KernelPolicy::IdentityOp identity_op;
+
+	// Invoke the wrapped kernel logic
+	scan::spine::SpinePass<KernelPolicy>(
+		d_spine_in,
+		d_spine_out,
+		spine_elements,
+		scan_op,
+		identity_op,
+		smem_storage);
+}
+
+
+/**
+ * Tuned downsweep scan kernel entry point
+ */
+template <typename ProblemType, int PROB_SIZE_GENRE, typename PassPolicy>
+__launch_bounds__ (
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Downsweep::THREADS),
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Downsweep::MIN_CTA_OCCUPANCY))
+__global__ void TunedDownsweepKernel(
+	int 													*d_selectors,
+	typename ProblemType::SizeT 							*d_spine,
+	typename ProblemType::KeyType 							*d_keys0,
+	typename ProblemType::KeyType 							*d_keys1,
+	typename ProblemType::ValueType 						*d_values0,
+	typename ProblemType::ValueType							*d_values1,
+	util::CtaWorkDistribution<typename ProblemType::SizeT>	work_decomposition)
+{
+	// Load the kernel policy type identified by the enum for this architecture
+	typedef typename AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Downsweep TuningPolicy;
+	typedef downsweep::KernelPolicy<TuningPolicy, PassPolicy> KernelPolicy;
+
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	// Invoke the wrapped kernel logic
+	downsweep::DownsweepPass<KernelPolicy>::Invoke(
+		d_selectors,
+		d_spine,
+		d_keys0,
+		d_keys1,
+		d_values0,
+		d_values1,
+		work_decomposition,
+		smem_storage);
+}
+
+
+/******************************************************************************
+ * Autotuned policy
+ *******************************************************************************/
+
+
+
+/**
+ * Autotuned policy type, derives from autotuned genre
+ */
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	ProbSizeGenre PROB_SIZE_GENRE>
+struct AutotunedPolicy :
+	AutotunedClassifier<
+		ProblemType,
+		CUDA_ARCH,
+		PROB_SIZE_GENRE>
+{
+	typedef typename ProblemType::KeyType 		KeyType;
+	typedef typename ProblemType::ValueType 	ValueType;
+	typedef typename ProblemType::SizeT 		SizeT;
+
+	typedef void (*UpsweepKernelPtr)(int*, SizeT*, KeyType*, KeyType*, util::CtaWorkDistribution<SizeT>);
+	typedef void (*SpineKernelPtr)(SizeT*, SizeT*, int);
+	typedef void (*DownsweepKernelPtr)(int*, SizeT*, KeyType*, KeyType*, ValueType*, ValueType*, util::CtaWorkDistribution<SizeT>);
+
+	//---------------------------------------------------------------------
+	// Kernel function pointer retrieval
+	//---------------------------------------------------------------------
+
+	template <typename PassPolicy>
+	static UpsweepKernelPtr UpsweepKernel()
+	{
+		return TunedUpsweepKernel<ProblemType, PROB_SIZE_GENRE, PassPolicy>;
+	}
+
+	static SpineKernelPtr SpineKernel()
+	{
+		return TunedSpineKernel<ProblemType, PROB_SIZE_GENRE>;
+	}
+
+	template <typename PassPolicy>
+	static DownsweepKernelPtr DownsweepKernel()
+	{
+		return TunedDownsweepKernel<ProblemType, PROB_SIZE_GENRE, PassPolicy>;
+	}
+};
+
+
+
+}// namespace radix_sort
+}// namespace b40c
+

--- a/include/b40c/radix_sort/downsweep/cta.cuh
+++ b/include/b40c/radix_sort/downsweep/cta.cuh
@@ -1,0 +1,102 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * CTA-processing functionality for radix sort downsweep scan kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/partition/downsweep/cta.cuh>
+#include <b40c/radix_sort/downsweep/tile.cuh>
+
+namespace b40c {
+namespace radix_sort {
+namespace downsweep {
+
+
+/**
+ * Radix sort downsweep scan CTA
+ *
+ * Derives from partition::downsweep::Cta
+ */
+template <typename KernelPolicy>
+struct Cta :
+	partition::downsweep::Cta<
+		KernelPolicy,
+		Cta<KernelPolicy>,			// This class
+		Tile>						// radix_sort::downsweep::Tile
+{
+	//---------------------------------------------------------------------
+	// Typedefs and Constants
+	//---------------------------------------------------------------------
+
+	// Base class type
+	typedef partition::downsweep::Cta<KernelPolicy, Cta, Tile> Base;
+
+	typedef typename KernelPolicy::KeyType 					KeyType;
+	typedef typename KernelPolicy::ValueType 				ValueType;
+	typedef typename KernelPolicy::SizeT 					SizeT;
+	typedef typename KernelPolicy::SmemStorage				SmemStorage;
+	typedef typename KernelPolicy::Grid::LanePartial		LanePartial;
+
+
+	//---------------------------------------------------------------------
+	// Methods
+	//---------------------------------------------------------------------
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ Cta(
+		SmemStorage 	&smem_storage,
+		KeyType 		*&d_in_keys,
+		KeyType 		*&d_out_keys,
+		ValueType 		*&d_in_values,
+		ValueType 		*&d_out_values,
+		SizeT 			*&d_spine,
+		LanePartial		base_composite_counter,
+		int				*raking_segment) :
+			Base(
+				smem_storage,
+				d_in_keys,
+				d_out_keys,
+				d_in_values,
+				d_out_values,
+				d_spine,
+				base_composite_counter,
+				raking_segment)
+	{}
+};
+
+
+} // namespace downsweep
+} // namespace radix_sort
+} // namespace b40c
+

--- a/include/b40c/radix_sort/downsweep/kernel.cuh
+++ b/include/b40c/radix_sort/downsweep/kernel.cuh
@@ -1,0 +1,264 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Radix sort downsweep scan kernel (scatter into bins)
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/device_intrinsics.cuh>
+
+#include <b40c/radix_sort/downsweep/cta.cuh>
+
+namespace b40c {
+namespace radix_sort {
+namespace downsweep {
+
+
+/**
+ * Radix sort downsweep scan pass (specialized for early-exit)
+ */
+template <typename KernelPolicy, bool EARLY_EXIT = KernelPolicy::EARLY_EXIT>
+struct DownsweepPass
+{
+	static __device__ __forceinline__ void Invoke(
+		int 								*&d_selectors,
+		typename KernelPolicy::SizeT 		*&d_spine,
+		typename KernelPolicy::KeyType 		*&d_keys0,
+		typename KernelPolicy::KeyType 		*&d_keys1,
+		typename KernelPolicy::ValueType 	*&d_values0,
+		typename KernelPolicy::ValueType 	*&d_values1,
+		util::CtaWorkDistribution<typename KernelPolicy::SizeT> &work_decomposition,
+		typename KernelPolicy::SmemStorage	&smem_storage)
+	{
+		typedef typename KernelPolicy::KeyType 				KeyType;
+		typedef typename KernelPolicy::ValueType 			ValueType;
+		typedef typename KernelPolicy::SizeT 				SizeT;
+		typedef Cta<KernelPolicy> 							Cta;
+		typedef typename KernelPolicy::Grid::LanePartial	LanePartial;
+
+		LanePartial base_composite_counter = KernelPolicy::Grid::MyLanePartial(smem_storage.raking_lanes);
+		int *raking_segment = 0;
+
+		// Shared storage to help us choose which set of inputs to stream from
+		__shared__ KeyType* 	d_keys[2];
+		__shared__ ValueType* 	d_values[2];
+
+		if (threadIdx.x < KernelPolicy::Grid::RAKING_THREADS) {
+
+			// initalize lane warpscans
+			int warpscan_lane = threadIdx.x >> KernelPolicy::Grid::LOG_RAKING_THREADS_PER_LANE;
+			int warpscan_tid = threadIdx.x & (KernelPolicy::Grid::RAKING_THREADS_PER_LANE - 1);
+			smem_storage.lanes_warpscan[warpscan_lane][0][warpscan_tid] = 0;
+
+			raking_segment = KernelPolicy::Grid::MyRakingSegment(smem_storage.raking_lanes);
+
+			// initialize bin warpscans
+			if (threadIdx.x < KernelPolicy::BINS) {
+
+				// Initialize bin_warpscan
+				smem_storage.bin_warpscan[0][threadIdx.x] = 0;
+
+				// We can early-exit if all keys go into the same bin (leave them as-is)
+				const int SELECTOR_IDX 			= (KernelPolicy::CURRENT_PASS) & 0x1;
+				const int NEXT_SELECTOR_IDX 	= (KernelPolicy::CURRENT_PASS + 1) & 0x1;
+
+				// Determine where to read our input
+				bool selector = (KernelPolicy::CURRENT_PASS == 0) ? 0 : d_selectors[SELECTOR_IDX];
+
+				// Determine whether or not we have work to do and setup the next round
+				// accordingly.  We can do this by looking at the first-block's
+				// histograms and counting the number of bins with counts that are
+				// non-zero and not-the-problem-size.
+				if (KernelPolicy::PreprocessTraits::MustApply || KernelPolicy::PostprocessTraits::MustApply) {
+					smem_storage.non_trivial_pass = true;
+				} else {
+					int first_block_carry = d_spine[util::FastMul(gridDim.x, threadIdx.x)];
+					int predicate = ((first_block_carry > 0) && (first_block_carry < work_decomposition.num_elements));
+					smem_storage.non_trivial_pass = util::WarpVoteAny<KernelPolicy::LOG_BINS>(predicate);
+				}
+
+				// Let the next round know which set of buffers to use
+				if (blockIdx.x == 0) {
+					d_selectors[NEXT_SELECTOR_IDX] = selector ^ smem_storage.non_trivial_pass;
+				}
+
+				// Determine our threadblock's work range
+				work_decomposition.template GetCtaWorkLimits<
+					KernelPolicy::LOG_TILE_ELEMENTS,
+					KernelPolicy::LOG_SCHEDULE_GRANULARITY>(smem_storage.work_limits);
+
+				d_keys[0] = (selector) ? d_keys1 : d_keys0;
+				d_keys[1] = (selector) ? d_keys0 : d_keys1;
+				d_values[0] = (selector) ? d_values1 : d_values0;
+				d_values[1] = (selector) ? d_values0 : d_values1;
+			}
+		}
+
+		// Sync to acquire non_trivial_pass, selector, and work limits
+		__syncthreads();
+
+		// Short-circuit this entire cycle
+		if (!smem_storage.non_trivial_pass) return;
+
+		Cta cta(
+			smem_storage,
+			d_keys[0],
+			d_keys[1],
+			d_values[0],
+			d_values[1],
+			d_spine,
+			base_composite_counter,
+			raking_segment);
+
+		cta.ProcessWorkRange(smem_storage.work_limits);
+	}
+};
+
+
+/**
+ * Radix sort downsweep scan pass (specialized for non-early-exit)
+ */
+template <typename KernelPolicy>
+struct DownsweepPass<KernelPolicy, false>
+{
+	static __device__ __forceinline__ void Invoke(
+		int 								*&d_selectors,
+		typename KernelPolicy::SizeT 		*&d_spine,
+		typename KernelPolicy::KeyType 		*&d_keys0,
+		typename KernelPolicy::KeyType 		*&d_keys1,
+		typename KernelPolicy::ValueType 	*&d_values0,
+		typename KernelPolicy::ValueType 	*&d_values1,
+		util::CtaWorkDistribution<typename KernelPolicy::SizeT> &work_decomposition,
+		typename KernelPolicy::SmemStorage	&smem_storage)
+	{
+		typedef typename KernelPolicy::KeyType 				KeyType;
+		typedef typename KernelPolicy::ValueType 			ValueType;
+		typedef typename KernelPolicy::SizeT 				SizeT;
+		typedef Cta<KernelPolicy> 							Cta;
+		typedef typename KernelPolicy::Grid::LanePartial	LanePartial;
+
+		LanePartial base_composite_counter = KernelPolicy::Grid::MyLanePartial(smem_storage.raking_lanes);
+		int *raking_segment = 0;
+
+		if (threadIdx.x < KernelPolicy::Grid::RAKING_THREADS) {
+
+			// initalize lane warpscans
+			int warpscan_lane = threadIdx.x >> KernelPolicy::Grid::LOG_RAKING_THREADS_PER_LANE;
+			int warpscan_tid = threadIdx.x & (KernelPolicy::Grid::RAKING_THREADS_PER_LANE - 1);
+			smem_storage.lanes_warpscan[warpscan_lane][0][warpscan_tid] = 0;
+
+			raking_segment = KernelPolicy::Grid::MyRakingSegment(smem_storage.raking_lanes);
+
+			// initialize bin warpscans
+			if (threadIdx.x < KernelPolicy::BINS) {
+
+				// Initialize bin_warpscan
+				smem_storage.bin_warpscan[0][threadIdx.x] = 0;
+
+				// Determine our threadblock's work range
+				work_decomposition.template GetCtaWorkLimits<
+					KernelPolicy::LOG_TILE_ELEMENTS,
+					KernelPolicy::LOG_SCHEDULE_GRANULARITY>(smem_storage.work_limits);
+			}
+		}
+
+		// Sync to acquire non_trivial_pass, selector, and work limits
+		__syncthreads();
+
+		if (KernelPolicy::CURRENT_PASS & 0x1) {
+
+			// d_keys1 --> d_keys0
+			Cta cta(
+				smem_storage,
+				d_keys1,
+				d_keys0,
+				d_values1,
+				d_values0,
+				d_spine,
+				base_composite_counter,
+				raking_segment);
+
+			cta.ProcessWorkRange(smem_storage.work_limits);
+
+		} else {
+
+			// d_keys0 --> d_keys1
+			Cta cta(
+				smem_storage,
+				d_keys0,
+				d_keys1,
+				d_values0,
+				d_values1,
+				d_spine,
+				base_composite_counter,
+				raking_segment);
+
+			cta.ProcessWorkRange(smem_storage.work_limits);
+		}
+	}
+};
+
+
+/**
+ * Radix sort downsweep scan kernel entry point
+ */
+template <typename KernelPolicy>
+__launch_bounds__ (KernelPolicy::THREADS, KernelPolicy::MIN_CTA_OCCUPANCY)
+__global__ 
+void Kernel(
+	int 								*d_selectors,
+	typename KernelPolicy::SizeT 		*d_spine,
+	typename KernelPolicy::KeyType 		*d_keys0,
+	typename KernelPolicy::KeyType 		*d_keys1,
+	typename KernelPolicy::ValueType 	*d_values0,
+	typename KernelPolicy::ValueType 	*d_values1,
+	util::CtaWorkDistribution<typename KernelPolicy::SizeT> work_decomposition)
+{
+	// Shared memory pool
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	DownsweepPass<KernelPolicy>::Invoke(
+		d_selectors,
+		d_spine,
+		d_keys0,
+		d_keys1,
+		d_values0,
+		d_values1,
+		work_decomposition,
+		smem_storage);
+}
+
+
+
+} // namespace downsweep
+} // namespace radix_sort
+} // namespace b40c
+

--- a/include/b40c/radix_sort/downsweep/kernel_policy.cuh
+++ b/include/b40c/radix_sort/downsweep/kernel_policy.cuh
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Configuration policy for radix sort downsweep scan kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/partition/downsweep/kernel_policy.cuh>
+
+namespace b40c {
+namespace radix_sort {
+namespace downsweep {
+
+
+/**
+ * A detailed radix sort downsweep kernel configuration policy type that specializes kernel
+ * code for a specific pass. It encapsulates tuning configuration
+ * policy details derived from TuningPolicy and PassPolicy.
+ */
+template <
+	typename 		TuningPolicy,
+	typename 		PassPolicy>
+struct KernelPolicy :
+	partition::downsweep::KernelPolicy<TuningPolicy>,
+	PassPolicy
+{
+};
+	
+
+
+} // namespace downsweep
+} // namespace partition
+} // namespace b40c
+

--- a/include/b40c/radix_sort/downsweep/tile.cuh
+++ b/include/b40c/radix_sort/downsweep/tile.cuh
@@ -1,0 +1,147 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Tile-processing functionality for radix sort downsweep scan kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/load_tile.cuh>
+#include <b40c/util/io/scatter_tile.cuh>
+
+#include <b40c/partition/downsweep/tile.cuh>
+#include <b40c/radix_sort/sort_utils.cuh>
+
+namespace b40c {
+namespace radix_sort {
+namespace downsweep {
+
+
+/**
+ * Tile
+ *
+ * Derives from partition::downsweep::Tile
+ */
+template <typename KernelPolicy>
+struct Tile :
+	partition::downsweep::Tile<
+		KernelPolicy,
+		Tile<KernelPolicy> >						// This class
+{
+	//---------------------------------------------------------------------
+	// Typedefs and Constants
+	//---------------------------------------------------------------------
+
+	typedef typename KernelPolicy::KeyType 					KeyType;
+	typedef typename KernelPolicy::ValueType 				ValueType;
+	typedef typename KernelPolicy::SizeT 					SizeT;
+
+
+	//---------------------------------------------------------------------
+	// Derived Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Returns the bin into which the specified key is to be placed.
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ int DecodeBin(KeyType key, Cta *cta)
+	{
+		int bin;
+		ExtractKeyBits<
+			KeyType,
+			KernelPolicy::CURRENT_BIT,
+			KernelPolicy::LOG_BINS>::Extract(bin, key);
+		return bin;
+	}
+
+
+	/**
+	 * Returns whether or not the key is valid.
+	 */
+	template <int CYCLE, int LOAD, int VEC>
+	__device__ __forceinline__ bool IsValid()
+	{
+		return true;
+	}
+
+
+	/**
+	 * Loads keys into the tile, applying bit-twiddling
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void LoadKeys(
+		Cta *cta,
+		SizeT cta_offset,
+		const SizeT &guarded_elements)
+	{
+		// Read tile of keys, use -1 if key is out-of-bounds
+		util::io::LoadTile<
+			KernelPolicy::LOG_LOADS_PER_TILE,
+			KernelPolicy::LOG_LOAD_VEC_SIZE,
+			KernelPolicy::THREADS,
+			KernelPolicy::READ_MODIFIER,
+			KernelPolicy::CHECK_ALIGNMENT>
+				::template LoadValid<KeyType, KernelPolicy::PreprocessTraits::Preprocess>(
+					(KeyType (*)[KernelPolicy::LOAD_VEC_SIZE]) this->keys,
+					cta->d_in_keys,
+					cta_offset,
+					guarded_elements,
+					(KeyType) -1);
+	}
+
+
+	/**
+	 * Scatter keys from the tile, applying bit-twiddling
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void ScatterKeys(
+		Cta *cta,
+		const SizeT &valid_elements)
+	{
+		// Scatter keys to global bin partitions
+		util::io::ScatterTile<
+			KernelPolicy::LOG_TILE_ELEMENTS_PER_THREAD,
+			0,
+			KernelPolicy::THREADS,
+			KernelPolicy::WRITE_MODIFIER>::template Scatter<
+				KeyType,
+				KernelPolicy::PostprocessTraits::Postprocess>(
+					cta->d_out_keys,
+					(KeyType (*)[1]) this->keys,
+					(SizeT (*)[1]) this->scatter_offsets,
+					valid_elements);
+	}
+};
+
+
+} // namespace downsweep
+} // namespace radix_sort
+} // namespace b40c
+

--- a/include/b40c/radix_sort/downsweep/tuning_policy.cuh
+++ b/include/b40c/radix_sort/downsweep/tuning_policy.cuh
@@ -1,0 +1,93 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Tuning policy for radix sort downsweep scan kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+#include <b40c/partition/downsweep/tuning_policy.cuh>
+
+namespace b40c {
+namespace radix_sort {
+namespace downsweep {
+
+
+/**
+ * Radix sort downsweep scan tuning policy.
+ * 
+ * See constraints in base class.
+ */
+template <
+	typename ProblemType,
+
+	int CUDA_ARCH,
+	bool CHECK_ALIGNMENT,
+	int LOG_BINS,
+	int LOG_SCHEDULE_GRANULARITY,
+	int MIN_CTA_OCCUPANCY,
+	int LOG_THREADS,
+	int LOG_LOAD_VEC_SIZE,
+	int LOG_LOADS_PER_CYCLE,
+	int LOG_CYCLES_PER_TILE,
+	int LOG_RAKING_THREADS,
+	util::io::ld::CacheModifier READ_MODIFIER,
+	util::io::st::CacheModifier WRITE_MODIFIER,
+	partition::downsweep::ScatterStrategy SCATTER_STRATEGY,
+	bool _EARLY_EXIT>
+
+struct TuningPolicy :
+	partition::downsweep::TuningPolicy <
+		ProblemType,
+		CUDA_ARCH,
+		CHECK_ALIGNMENT,
+		LOG_BINS,
+		LOG_SCHEDULE_GRANULARITY,
+		MIN_CTA_OCCUPANCY,
+		LOG_THREADS,
+		LOG_LOAD_VEC_SIZE,
+		LOG_LOADS_PER_CYCLE,
+		LOG_CYCLES_PER_TILE,
+		LOG_RAKING_THREADS,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		SCATTER_STRATEGY>
+{
+	enum {
+		EARLY_EXIT								= _EARLY_EXIT,
+	};
+};
+
+} // namespace downsweep
+} // namespace radix_sort
+} // namespace b40c
+

--- a/include/b40c/radix_sort/enactor.cuh
+++ b/include/b40c/radix_sort/enactor.cuh
@@ -1,0 +1,840 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Radix sorting enactor
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/enactor_base.cuh>
+#include <b40c/util/error_utils.cuh>
+#include <b40c/util/spine.cuh>
+#include <b40c/util/arch_dispatch.cuh>
+#include <b40c/util/multiple_buffering.cuh>
+
+#include <b40c/radix_sort/problem_type.cuh>
+#include <b40c/radix_sort/policy.cuh>
+#include <b40c/radix_sort/pass_policy.cuh>
+#include <b40c/radix_sort/autotuned_policy.cuh>
+#include <b40c/radix_sort/downsweep/kernel.cuh>
+#include <b40c/radix_sort/upsweep/kernel.cuh>
+
+#include <b40c/scan/spine/kernel.cuh>
+
+namespace b40c {
+namespace radix_sort {
+
+
+/**
+ * Radix sorting enactor class.
+ */
+class Enactor : public util::EnactorBase
+{
+protected:
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Temporary device storage needed for reducing partials produced
+	// by separate CTAs
+	util::Spine spine;
+
+	// Pair of "selector" device integers.  The first selects the incoming device
+	// vector for even passes, the second selects the odd.
+	int *d_selectors;
+
+
+	//-----------------------------------------------------------------------------
+	// Helper structures
+	//-----------------------------------------------------------------------------
+
+	template <
+		int _START_BIT,
+		int _NUM_BITS,
+		typename _ProblemType>
+	friend class Detail;
+
+
+	//-----------------------------------------------------------------------------
+	// Utility Routines
+	//-----------------------------------------------------------------------------
+
+    /**
+     * Pre-sorting logic.
+     */
+	template <typename Policy, typename Detail>
+    cudaError_t PreSort(Detail &detail);
+
+	/**
+     * Post-sorting logic.
+     */
+	template <typename Policy, typename Detail>
+    cudaError_t PostSort(Detail &detail, int num_passes);
+
+    /**
+	 * Performs a radix sorting operation
+	 */
+	template <typename Policy, typename Detail>
+	cudaError_t EnactSort(Detail &detail);
+
+	/**
+	 * Performs a radix sorting pass
+	 */
+	template <typename Policy, typename PassPolicy, typename Detail>
+	cudaError_t EnactPass(Detail &detail);
+
+
+public:
+
+	/**
+	 * Constructor
+	 */
+	Enactor() : d_selectors(NULL) {}
+
+
+	/**
+     * Destructor
+     */
+    virtual ~Enactor()
+    {
+   		if (d_selectors) {
+   			util::B40CPerror(cudaFree(d_selectors), "Enactor cudaFree d_selectors failed: ", __FILE__, __LINE__, ENACTOR_DEBUG);
+   		}
+    }
+
+
+	/**
+	 * Enacts a radix sorting operation on the specified device data.
+	 *
+	 * If left NULL, the non-selected problem storage arrays will be allocated
+	 * lazily upon the first sorting pass, and are the caller's responsibility
+	 * for freeing. After a sorting operation has completed, the selector member will
+	 * index the key (and value) pointers that contain the final sorted results.
+	 * (E.g., an odd number of sorting passes may leave the results in d_keys[1] if
+	 * the input started in d_keys[0].)
+	 *
+	 * @param problem_storage
+	 * 		Instance of b40c::util::DoubleBuffer type describing the details of the
+	 * 		problem to sort.
+	 * @param num_elements
+	 * 		The number of elements in problem_storage to sort (starting at offset 0)
+	 * @param max_grid_size
+	 * 		Optional upper-bound on the number of CTAs to launch.
+	 *
+	 * @return cudaSuccess on success, error enumeration otherwise
+	 */
+	template <
+		typename DoubleBuffer,
+		typename SizeT>
+	cudaError_t Sort(
+		DoubleBuffer &problem_storage,
+		SizeT num_elements,
+		int max_grid_size = 0);
+
+
+	/**
+	 * Enacts a sorting operation on the specified device data.  Uses the
+	 * specified problem size genre enumeration to select autotuning policy.
+	 *
+	 * (Using this entrypoint can save compile time by not compiling tuned
+	 * kernels for each problem size genre.)
+	 *
+	 * If left NULL, the non-selected problem storage arrays will be allocated
+	 * lazily upon the first sorting pass, and are the caller's responsibility
+	 * for freeing. After a sorting operation has completed, the selector member will
+	 * index the key (and value) pointers that contain the final sorted results.
+	 * (E.g., an odd number of sorting passes may leave the results in d_keys[1] if
+	 * the input started in d_keys[0].)
+	 *
+	 * @param problem_storage
+	 * 		Instance of b40c::util::DoubleBuffer type describing the details of the
+	 * 		problem to sort.
+	 * @param num_elements
+	 * 		The number of elements in problem_storage to sort (starting at offset 0)
+	 * @param max_grid_size
+	 * 		Optional upper-bound on the number of CTAs to launch.
+	 *
+	 * @return cudaSuccess on success, error enumeration otherwise
+	 */
+	template <
+		ProbSizeGenre PROB_SIZE_GENRE,
+		typename DoubleBuffer,
+		typename SizeT>
+	cudaError_t Sort(
+		DoubleBuffer &problem_storage,
+		SizeT num_elements,
+		int max_grid_size = 0);
+
+
+	/**
+	 * Enacts a sorting operation on the specified device data.  Uses the
+	 * specified problem size genre enumeration to select autotuning policy:
+	 *
+	 * 		b40c::radix_sort::SMALL_SIZE		// < 1M elements
+	 * 		b40c::radix_sort::LARGE_SIZE		// > 1M elements
+	 * 		b40c::radix_sort::UNKNOWN_SIZE		// Compiles both and selects appropriately
+	 *
+	 * (Using this entrypoint can save compile time by not compiling tuned
+	 * kernels for each problem size genre.)
+	 *
+	 * If left NULL, the non-selected problem storage arrays will be allocated
+	 * lazily upon the first sorting pass, and are the caller's responsibility
+	 * for freeing. After a sorting operation has completed, the selector member will
+	 * index the key (and value) pointers that contain the final sorted results.
+	 * (E.g., an odd number of sorting passes may leave the results in d_keys[1] if
+	 * the input started in d_keys[0].)
+	 *
+	 * @param problem_storage
+	 * 		Instance of b40c::util::DoubleBuffer type describing the details of the
+	 * 		problem to sort.
+	 * @param num_elements
+	 * 		The number of elements in problem_storage to sort (starting at offset 0)
+	 * @param max_grid_size
+	 * 		Optional upper-bound on the number of CTAs to launch.
+	 *
+	 * @return cudaSuccess on success, error enumeration otherwise
+	 */
+	template <
+		int START_BIT,
+		int NUM_BITS,
+		ProbSizeGenre PROB_SIZE_GENRE,
+		typename DoubleBuffer,
+		typename SizeT>
+	cudaError_t Sort(
+		DoubleBuffer &problem_storage,
+		SizeT num_elements,
+		int max_grid_size = 0);
+
+
+	/**
+	 * Enacts a scan on the specified device data.  Uses the specified
+	 * kernel configuration policy.  (Useful for auto-tuning.)
+	 *
+	 * If left NULL, the non-selected problem storage arrays will be allocated
+	 * lazily upon the first sorting pass, and are the caller's responsibility
+	 * for freeing. After a sorting operation has completed, the selector member will
+	 * index the key (and value) pointers that contain the final sorted results.
+	 * (E.g., an odd number of sorting passes may leave the results in d_keys[1] if
+	 * the input started in d_keys[0].)
+	 *
+	 * @param problem_storage
+	 * 		Instance of b40c::util::DoubleBuffer type describing the details of the
+	 * 		problem to sort.
+	 * @param num_elements
+	 * 		The number of elements in problem_storage to sort (starting at offset 0)
+	 * @param max_grid_size
+	 * 		Optional upper-bound on the number of CTAs to launch.
+	 *
+	 * @return cudaSuccess on success, error enumeration otherwise
+	 */
+	template <
+		int START_BIT,
+		int NUM_BITS,
+		typename Policy>
+	cudaError_t Sort(
+		util::DoubleBuffer<
+			typename Policy::OriginalKeyType,
+			typename Policy::ValueType> &problem_storage,
+		typename Policy::SizeT num_elements,
+		int max_grid_size = 0);
+
+};
+
+
+
+/******************************************************************************
+ * Helper structures
+ ******************************************************************************/
+
+/**
+ * Type for encapsulating operational details regarding an invocation
+ */
+template <
+	int _START_BIT,
+	int _NUM_BITS,
+	typename _ProblemType>
+struct Detail
+{
+	static const int START_BIT 		= _START_BIT;
+	static const int NUM_BITS 		= _NUM_BITS;
+
+	// Problem type
+	typedef _ProblemType 														ProblemType;
+	typedef typename ProblemType::OriginalKeyType								StorageKeyType;
+	typedef typename ProblemType::ValueType										StorageValueType;
+	typedef typename ProblemType::SizeT											SizeT;
+	typedef typename util::DoubleBuffer<StorageKeyType, StorageValueType> 	DoubleBuffer;
+
+	// Problem data
+	Enactor 			*enactor;
+	DoubleBuffer		&problem_storage;
+	SizeT				num_elements;
+	int			 		max_grid_size;
+
+	// Constructor
+	Detail(
+		Enactor *enactor,
+		DoubleBuffer &problem_storage,
+		SizeT num_elements,
+		int max_grid_size = 0) :
+			enactor(enactor),
+			num_elements(num_elements),
+			problem_storage(problem_storage),
+			max_grid_size(max_grid_size)
+	{}
+
+
+	template <typename Policy>
+	cudaError_t EnactSort()
+	{
+		return enactor->template EnactSort<Policy>(*this);
+	}
+
+	template <typename Policy, typename PassPolicy>
+	cudaError_t EnactPass()
+	{
+		return enactor->template EnactPass<Policy, PassPolicy>(*this);
+	}
+};
+
+
+/**
+ * Helper structure for resolving and enacting tuning configurations
+ *
+ * Default specialization for problem type genres
+ */
+template <ProbSizeGenre PROB_SIZE_GENRE>
+struct PolicyResolver
+{
+	/**
+	 * ArchDispatch call-back with static CUDA_ARCH
+	 */
+	template <int CUDA_ARCH, typename Detail>
+	static cudaError_t Enact(Detail &detail)
+	{
+		// Obtain tuned granularity type
+		typedef AutotunedPolicy<
+			typename Detail::ProblemType,
+			CUDA_ARCH,
+			PROB_SIZE_GENRE> AutotunedPolicy;
+
+		// Invoke base class enact with type
+		return detail.template EnactSort<AutotunedPolicy>();
+	}
+};
+
+
+/**
+ * Helper structure for resolving and enacting tuning configurations
+ *
+ * Specialization for UNKNOWN problem type to select other problem type genres
+ * based upon problem size, etc.
+ */
+template <>
+struct PolicyResolver <UNKNOWN_SIZE>
+{
+	/**
+	 * ArchDispatch call-back with static CUDA_ARCH
+	 */
+	template <int CUDA_ARCH, typename Detail>
+	static cudaError_t Enact(Detail &detail)
+	{
+		// Obtain large tuned granularity type
+		typedef AutotunedPolicy<
+			typename Detail::ProblemType,
+			CUDA_ARCH,
+			LARGE_SIZE> LargePolicy;
+
+		// Identify the maximum problem size for which we can saturate loads
+		int saturating_load = LargePolicy::Upsweep::TILE_ELEMENTS *
+			B40C_SM_CTAS(CUDA_ARCH) *
+			detail.enactor->SmCount();
+
+		if (detail.num_elements < saturating_load) {
+
+			// Invoke base class enact with small-problem config type
+			typedef AutotunedPolicy<
+				typename Detail::ProblemType,
+				CUDA_ARCH,
+				SMALL_SIZE> SmallPolicy;
+
+			return detail.template EnactSort<SmallPolicy>();
+		}
+
+		// Invoke base class enact with type
+		return detail.template EnactSort<LargePolicy>();
+	}
+};
+
+
+/**
+ * Iteration structure for unrolling sorting passes
+ */
+template <typename Policy>
+struct PassIteration
+{
+	/**
+	 * Middle sorting passes (i.e., neither first, nor last pass).  Does not apply
+	 * any pre/post bit-twiddling functors.
+	 */
+	template <
+		int CURRENT_PASS,
+		int LAST_PASS,
+		int CURRENT_BIT,
+		int RADIX_BITS = Policy::Upsweep::LOG_BINS>
+	struct Iterate
+	{
+		template <typename Detail>
+		static cudaError_t Invoke(Detail &detail)
+		{
+			typedef PassPolicy<
+				CURRENT_PASS,
+				CURRENT_BIT,
+				NopKeyConversion,
+				NopKeyConversion> PassPolicy;
+
+			cudaError_t retval = detail.template EnactPass<Policy, PassPolicy>();
+			if (retval) return retval;
+
+			return Iterate<
+				CURRENT_PASS + 1,
+				LAST_PASS,
+				CURRENT_BIT + RADIX_BITS,
+				RADIX_BITS>::Invoke(detail);
+		}
+	};
+
+	/**
+	 * First sorting pass (unless there's only one pass).  Applies the
+	 * appropriate pre-process bit-twiddling functor.
+	 */
+	template <
+		int LAST_PASS,
+		int CURRENT_BIT,
+		int RADIX_BITS>
+	struct Iterate <0, LAST_PASS, CURRENT_BIT, RADIX_BITS>
+	{
+		template <typename Detail>
+		static cudaError_t Invoke(Detail &detail)
+		{
+			typedef PassPolicy<
+				0,
+				CURRENT_BIT,
+				typename Policy::KeyTraits,
+				NopKeyConversion> PassPolicy;
+
+			cudaError_t retval = detail.template EnactPass<Policy, PassPolicy>();
+			if (retval) return retval;
+
+			return Iterate<
+				1,
+				LAST_PASS,
+				CURRENT_BIT + RADIX_BITS,
+				RADIX_BITS>::Invoke(detail);
+		}
+	};
+
+	/**
+	 * Last sorting pass (unless there's only one pass).  Applies the
+	 * appropriate post-process bit-twiddling functor.
+	 */
+	template <
+		int LAST_PASS,
+		int CURRENT_BIT,
+		int RADIX_BITS>
+	struct Iterate <LAST_PASS, LAST_PASS, CURRENT_BIT, RADIX_BITS>
+	{
+		template <typename Detail>
+		static cudaError_t Invoke(Detail &detail)
+		{
+			typedef PassPolicy<
+				LAST_PASS,
+				CURRENT_BIT,
+				NopKeyConversion,
+				typename Policy::KeyTraits> PassPolicy;
+
+			return detail.template EnactPass<Policy, PassPolicy>();
+		}
+	};
+
+	/**
+	 * Singular sorting pass (when there's only one pass).  Applies both
+	 * pre- and post-process bit-twiddling functors.
+	 */
+	template <
+		int CURRENT_BIT,
+		int RADIX_BITS>
+	struct Iterate <0, 0, CURRENT_BIT, RADIX_BITS>
+	{
+		template <typename Detail>
+		static cudaError_t Invoke(Detail &detail)
+		{
+			typedef PassPolicy<
+				0,
+				CURRENT_BIT,
+				typename Policy::KeyTraits,
+				typename Policy::KeyTraits> PassPolicy;
+
+			return detail.template EnactPass<Policy, PassPolicy>();
+		}
+	};
+};
+
+
+
+
+/******************************************************************************
+ * Enactor Implementation
+ ******************************************************************************/
+
+/**
+ * Performs a radix sorting pass
+ */
+template <
+	typename Policy,
+	typename PassPolicy,
+	typename Detail>
+cudaError_t Enactor::EnactPass(Detail &detail)
+{
+	// Tuning policy
+	typedef typename Policy::Upsweep 					Upsweep;
+	typedef typename Policy::Spine 						Spine;
+	typedef typename Policy::Downsweep 					Downsweep;
+
+	// Data types
+	typedef typename Policy::KeyType 					KeyType;	// Converted key type
+	typedef typename Policy::SizeT 						SizeT;
+
+	cudaError_t retval = cudaSuccess;
+	do {
+		if (ENACTOR_DEBUG) {
+			printf("Pass %d, Bit %d:\n", PassPolicy::CURRENT_PASS, PassPolicy::CURRENT_BIT);
+		}
+
+		// Kernel pointers
+		typename Policy::UpsweepKernelPtr 		UpsweepKernel = Policy::template UpsweepKernel<PassPolicy>();
+		typename Policy::SpineKernelPtr 		SpineKernel = Policy::SpineKernel();
+		typename Policy::DownsweepKernelPtr		DownsweepKernel = Policy::template DownsweepKernel<PassPolicy>();
+
+		// Max CTA occupancy for the actual target device
+		int max_cta_occupancy;
+		if (retval = MaxCtaOccupancy(
+			max_cta_occupancy,
+			UpsweepKernel,
+			Upsweep::THREADS,
+			DownsweepKernel,
+			Downsweep::THREADS)) break;
+
+		// Compute sweep grid size
+		int sweep_grid_size = GridSize(
+			Policy::OVERSUBSCRIBED_GRID_SIZE,
+			Upsweep::SCHEDULE_GRANULARITY,
+			max_cta_occupancy,
+			detail.num_elements,
+			detail.max_grid_size);
+
+		// Compute spine elements: BIN elements per CTA, rounded
+		// up to nearest spine tile size
+		SizeT spine_elements = sweep_grid_size << Downsweep::LOG_BINS;
+		spine_elements = ((spine_elements + Spine::TILE_ELEMENTS - 1) / Spine::TILE_ELEMENTS) * Spine::TILE_ELEMENTS;
+
+		// Make sure our spine is big enough
+		if (retval = spine.Setup<SizeT>(spine_elements)) break;
+
+		// Obtain a CTA work distribution
+		util::CtaWorkDistribution<SizeT> work;
+		work.template Init<Downsweep::LOG_SCHEDULE_GRANULARITY>(detail.num_elements, sweep_grid_size);
+
+		if (ENACTOR_DEBUG) {
+			PrintPassInfo<Upsweep, Spine, Downsweep>(work, spine_elements);
+			printf("\n");
+			fflush(stdout);
+		}
+
+		// Operational details
+		int dynamic_smem[3] = 	{0, 0, 0};
+		int grid_size[3] = 		{sweep_grid_size, 1, sweep_grid_size};
+
+		// Tuning option: make sure all kernels have the same overall smem allocation
+		if (Policy::UNIFORM_SMEM_ALLOCATION) if (retval = PadUniformSmem(dynamic_smem, UpsweepKernel, SpineKernel, DownsweepKernel)) break;
+
+		// Tuning option: make sure that all kernels launch the same number of CTAs)
+		if (Policy::UNIFORM_GRID_SIZE) grid_size[1] = grid_size[0];
+
+		// Upsweep reduction into spine
+		UpsweepKernel<<<grid_size[0], Upsweep::THREADS, dynamic_smem[0]>>>(
+			d_selectors,
+			(SizeT*) spine(),
+			(KeyType *) detail.problem_storage.d_keys[detail.problem_storage.selector],
+			(KeyType *) detail.problem_storage.d_keys[detail.problem_storage.selector ^ 1],
+			work);
+
+		if (ENACTOR_DEBUG && (retval = util::B40CPerror(cudaThreadSynchronize(), "Enactor UpsweepKernel failed ", __FILE__, __LINE__, ENACTOR_DEBUG))) break;
+
+		// Spine scan
+		SpineKernel<<<grid_size[1], Spine::THREADS, dynamic_smem[1]>>>(
+			(SizeT*) spine(), (SizeT*) spine(), spine_elements);
+
+		if (ENACTOR_DEBUG && (retval = util::B40CPerror(cudaThreadSynchronize(), "Enactor SpineKernel failed ", __FILE__, __LINE__, ENACTOR_DEBUG))) break;
+
+		// Downsweep scan from spine
+		DownsweepKernel<<<grid_size[2], Downsweep::THREADS, dynamic_smem[2]>>>(
+			d_selectors,
+			(SizeT *) spine(),
+			(KeyType *) detail.problem_storage.d_keys[detail.problem_storage.selector],
+			(KeyType *) detail.problem_storage.d_keys[detail.problem_storage.selector ^ 1],
+			detail.problem_storage.d_values[detail.problem_storage.selector],
+			detail.problem_storage.d_values[detail.problem_storage.selector ^ 1],
+			work);
+
+		if (ENACTOR_DEBUG && (retval = util::B40CPerror(cudaThreadSynchronize(), "Enactor DownsweepKernel failed ", __FILE__, __LINE__, ENACTOR_DEBUG))) break;
+
+	} while (0);
+
+	return retval;
+}
+
+
+/**
+ * Pre-sorting logic.
+ */
+template <typename Policy, typename Detail>
+cudaError_t Enactor::PreSort(Detail &detail)
+{
+	typedef typename Policy::KeyType 		KeyType;
+	typedef typename Policy::ValueType 		ValueType;
+	typedef typename Policy::SizeT 			SizeT;
+
+	cudaError_t retval = cudaSuccess;
+	do {
+		// Setup d_selectors if necessary
+		if (d_selectors == NULL) {
+			if (retval = util::B40CPerror(cudaMalloc((void**) &d_selectors, 2 * sizeof(int)),
+				"LsbSortEnactor cudaMalloc d_selectors failed", __FILE__, __LINE__, ENACTOR_DEBUG)) break;
+		}
+
+		// Setup pong-storage if necessary
+		if (detail.problem_storage.d_keys[0] == NULL) {
+			if (retval = util::B40CPerror(cudaMalloc((void**) &detail.problem_storage.d_keys[0], detail.num_elements * sizeof(KeyType)),
+				"LsbSortEnactor cudaMalloc detail.problem_storage.d_keys[0] failed", __FILE__, __LINE__, ENACTOR_DEBUG)) break;
+		}
+		if (detail.problem_storage.d_keys[1] == NULL) {
+			if (retval = util::B40CPerror(cudaMalloc((void**) &detail.problem_storage.d_keys[1], detail.num_elements * sizeof(KeyType)),
+				"LsbSortEnactor cudaMalloc detail.problem_storage.d_keys[1] failed", __FILE__, __LINE__, ENACTOR_DEBUG)) break;
+		}
+		if (!util::Equals<ValueType, util::NullType>::VALUE) {
+			if (detail.problem_storage.d_values[0] == NULL) {
+				if (retval = util::B40CPerror(cudaMalloc((void**) &detail.problem_storage.d_values[0], detail.num_elements * sizeof(ValueType)),
+					"LsbSortEnactor cudaMalloc detail.problem_storage.d_values[0] failed", __FILE__, __LINE__, ENACTOR_DEBUG)) break;
+			}
+			if (detail.problem_storage.d_values[1] == NULL) {
+				if (retval = util::B40CPerror(cudaMalloc((void**) &detail.problem_storage.d_values[1], detail.num_elements * sizeof(ValueType)),
+					"LsbSortEnactor cudaMalloc detail.problem_storage.d_values[1] failed", __FILE__, __LINE__, ENACTOR_DEBUG)) break;
+			}
+		}
+
+	} while (0);
+
+	return retval;
+}
+
+
+/**
+ * Post-sorting logic.
+ */
+template <typename Policy, typename Detail>
+cudaError_t Enactor::PostSort(Detail &detail, int num_passes)
+{
+	cudaError_t retval = cudaSuccess;
+
+	do {
+		if (!Policy::Upsweep::EARLY_EXIT) {
+
+			// We moved data between storage buffers at every pass
+			detail.problem_storage.selector = (detail.problem_storage.selector + num_passes) & 0x1;
+
+		} else {
+
+			// Save old selector
+			int old_selector = detail.problem_storage.selector;
+
+			// Copy out the selector from the last pass
+			if (retval = util::B40CPerror(cudaMemcpy(&detail.problem_storage.selector, &d_selectors[num_passes & 0x1], sizeof(int), cudaMemcpyDeviceToHost),
+				"LsbSortEnactor cudaMemcpy d_selector failed", __FILE__, __LINE__, ENACTOR_DEBUG)) break;
+
+			// Correct new selector if the original indicated that we started off from the alternate
+			detail.problem_storage.selector ^= old_selector;
+		}
+
+	} while (0);
+
+	return retval;
+}
+
+/**
+ * Enacts a sort on the specified device data.
+ */
+template <typename Policy, typename Detail>
+cudaError_t Enactor::EnactSort(Detail &detail)
+{
+	// Policy
+	typedef typename Policy::Upsweep 	Upsweep;
+	typedef typename Policy::Spine 		Spine;
+	typedef typename Policy::Downsweep 	Downsweep;
+
+	// Data types
+	typedef typename Policy::KeyType	KeyType;
+	typedef typename Policy::ValueType	ValueType;
+	typedef typename Policy::SizeT 		SizeT;
+
+	const int NUM_PASSES 				= (Detail::NUM_BITS + Downsweep::LOG_BINS - 1) / Downsweep::LOG_BINS;
+
+	cudaError_t retval = cudaSuccess;
+	do {
+
+		if (ENACTOR_DEBUG) {
+			printf("\n\n");
+			printf("Sorting: \t[radix_bits: %d, start_bit: %d, num_bits: %d, num_passes: %d]\n",
+				Downsweep::LOG_BINS,
+				Detail::START_BIT,
+				Detail::NUM_BITS,
+				NUM_PASSES);
+			fflush(stdout);
+		}
+
+		// Perform any preparation prior to sorting
+		if (retval = PreSort<Policy>(detail)) break;
+
+		// Perform sorting passes
+		if (retval = PassIteration<Policy>::template Iterate<
+				0,
+				NUM_PASSES - 1,
+				Detail::START_BIT,
+				Downsweep::LOG_BINS>::Invoke(detail)) break;
+
+		// Perform any cleanup after sorting
+		if (retval = PostSort<Policy>(detail, NUM_PASSES)) break;
+
+	} while (0);
+
+	return retval;
+}
+
+
+/**
+ * Enacts a sort on the specified device data.
+ */
+template <
+	int START_BIT,
+	int NUM_BITS,
+	typename Policy>
+cudaError_t Enactor::Sort(
+	util::DoubleBuffer<
+		typename Policy::OriginalKeyType,
+		typename Policy::ValueType> &problem_storage,
+	typename Policy::SizeT num_elements,
+	int max_grid_size)
+{
+	Detail<START_BIT, NUM_BITS, Policy> detail(
+		this,
+		problem_storage,
+		num_elements,
+		max_grid_size);
+
+	return detail.template EnactSort<Policy>();
+}
+
+/**
+ * Enacts a sort operation on the specified device data.
+ */
+template <
+	int START_BIT,
+	int NUM_BITS,
+	ProbSizeGenre PROB_SIZE_GENRE,
+	typename DoubleBuffer,
+	typename SizeT>
+cudaError_t Enactor::Sort(
+	DoubleBuffer &problem_storage,
+	SizeT num_elements,
+	int max_grid_size)
+{
+	typedef ProblemType<
+		typename DoubleBuffer::KeyType,
+		typename DoubleBuffer::ValueType,
+		SizeT> ProblemType;
+
+	Detail<
+		START_BIT,
+		NUM_BITS,
+		ProblemType> detail(this, problem_storage, num_elements, max_grid_size);
+
+	return util::ArchDispatch<
+		__B40C_CUDA_ARCH__,
+		PolicyResolver<PROB_SIZE_GENRE> >::Enact(detail, PtxVersion());
+}
+
+
+/**
+ * Enacts a sort operation on the specified device data.
+ */
+template <
+	ProbSizeGenre PROB_SIZE_GENRE,
+	typename DoubleBuffer,
+	typename SizeT>
+cudaError_t Enactor::Sort(
+	DoubleBuffer &problem_storage,
+	SizeT num_elements,
+	int max_grid_size)
+{
+	return Sort<0, sizeof(typename DoubleBuffer::KeyType) * 8, PROB_SIZE_GENRE>(
+		problem_storage, num_elements, max_grid_size);
+}
+
+
+/**
+ * Enacts a sort operation on the specified device data.
+ */
+template <
+	typename DoubleBuffer,
+	typename SizeT>
+cudaError_t Enactor::Sort(
+	DoubleBuffer &problem_storage,
+	SizeT num_elements,
+	int max_grid_size)
+{
+	return Sort<UNKNOWN_SIZE>(
+		problem_storage, num_elements, max_grid_size);
+}
+
+
+
+} // namespace radix_sort
+} // namespace b40c
+

--- a/include/b40c/radix_sort/pass_policy.cuh
+++ b/include/b40c/radix_sort/pass_policy.cuh
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Policy for a specific digit place pass
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace radix_sort {
+
+
+/**
+ * Policy for a specific digit place pass
+ */
+template <
+	int 			_CURRENT_PASS,
+	int 			_CURRENT_BIT,
+	typename 		_PreprocessTraits,
+	typename 		_PostprocessTraits>
+struct PassPolicy
+{
+	typedef _PreprocessTraits			PreprocessTraits;		// Key pre-processing actions
+	typedef _PostprocessTraits			PostprocessTraits;		// Key post-processing actions
+
+	enum {
+		CURRENT_PASS						= _CURRENT_PASS,
+		CURRENT_BIT							= _CURRENT_BIT,
+	};
+};
+		
+
+}// namespace radix_sort
+}// namespace b40c
+

--- a/include/b40c/radix_sort/policy.cuh
+++ b/include/b40c/radix_sort/policy.cuh
@@ -1,0 +1,192 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Unified radix sort policy
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+#include <b40c/partition/policy.cuh>
+
+#include <b40c/radix_sort/upsweep/tuning_policy.cuh>
+#include <b40c/radix_sort/upsweep/kernel_policy.cuh>
+#include <b40c/radix_sort/upsweep/kernel.cuh>
+#include <b40c/radix_sort/downsweep/tuning_policy.cuh>
+#include <b40c/radix_sort/downsweep/kernel_policy.cuh>
+#include <b40c/radix_sort/downsweep/kernel.cuh>
+
+#include <b40c/scan/problem_type.cuh>
+#include <b40c/scan/kernel_policy.cuh>
+#include <b40c/scan/spine/kernel.cuh>
+
+namespace b40c {
+namespace radix_sort {
+
+
+/**
+ * Unified radix sort policy type.
+ *
+ * In addition to kernel tuning parameters that guide the kernel compilation for
+ * upsweep, spine, and downsweep kernels, this type includes enactor tuning
+ * parameters that define kernel-dispatch policy.   By encapsulating all of the
+ * kernel tuning policies, we assure operational consistency over an entire
+ * partitioning pass.
+ */
+template <
+	// Problem Type
+	typename ProblemType,
+
+	// Common
+	int CUDA_ARCH,
+	int _RADIX_BITS,
+	int LOG_SCHEDULE_GRANULARITY,
+	util::io::ld::CacheModifier READ_MODIFIER,
+	util::io::st::CacheModifier WRITE_MODIFIER,
+	bool EARLY_EXIT,
+	bool _UNIFORM_SMEM_ALLOCATION,
+	bool _UNIFORM_GRID_SIZE,
+	bool _OVERSUBSCRIBED_GRID_SIZE,
+	
+	// Upsweep
+	int UPSWEEP_MIN_CTA_OCCUPANCY,
+	int UPSWEEP_LOG_THREADS,
+	int UPSWEEP_LOG_LOAD_VEC_SIZE,
+	int UPSWEEP_LOG_LOADS_PER_TILE,
+	
+	// Spine-scan
+	int SPINE_LOG_THREADS,
+	int SPINE_LOG_LOAD_VEC_SIZE,
+	int SPINE_LOG_LOADS_PER_TILE,
+	int SPINE_LOG_RAKING_THREADS,
+
+	// Downsweep
+	partition::downsweep::ScatterStrategy DOWNSWEEP_SCATTER_STRATEGY,
+	int DOWNSWEEP_MIN_CTA_OCCUPANCY,
+	int DOWNSWEEP_LOG_THREADS,
+	int DOWNSWEEP_LOG_LOAD_VEC_SIZE,
+	int DOWNSWEEP_LOG_LOADS_PER_CYCLE,
+	int DOWNSWEEP_LOG_CYCLES_PER_TILE,
+	int DOWNSWEEP_LOG_RAKING_THREADS>
+
+struct Policy :
+	partition::Policy<
+		ProblemType,
+		CUDA_ARCH,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		SPINE_LOG_THREADS,
+		SPINE_LOG_LOAD_VEC_SIZE,
+		SPINE_LOG_LOADS_PER_TILE,
+		SPINE_LOG_RAKING_THREADS>
+{
+	//---------------------------------------------------------------------
+	// Typedefs
+	//---------------------------------------------------------------------
+
+	typedef typename ProblemType::KeyType 		KeyType;
+	typedef typename ProblemType::ValueType		ValueType;
+	typedef typename ProblemType::SizeT 		SizeT;
+
+	typedef void (*UpsweepKernelPtr)(int*, SizeT*, KeyType*, KeyType*, util::CtaWorkDistribution<SizeT>);
+	typedef void (*DownsweepKernelPtr)(int*, SizeT*, KeyType*, KeyType*, ValueType*, ValueType*, util::CtaWorkDistribution<SizeT>);
+
+	static const bool CHECK_ALIGNMENT = true;
+
+	//---------------------------------------------------------------------
+	// Tuning Policies
+	//---------------------------------------------------------------------
+
+	typedef upsweep::TuningPolicy<
+		ProblemType,
+		CUDA_ARCH,
+		CHECK_ALIGNMENT,
+		_RADIX_BITS,
+		LOG_SCHEDULE_GRANULARITY,
+		UPSWEEP_MIN_CTA_OCCUPANCY,
+		UPSWEEP_LOG_THREADS,
+		UPSWEEP_LOG_LOAD_VEC_SIZE,
+		UPSWEEP_LOG_LOADS_PER_TILE,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		EARLY_EXIT>
+			Upsweep;
+
+	typedef downsweep::TuningPolicy<
+		ProblemType,
+		CUDA_ARCH,
+		CHECK_ALIGNMENT,
+		_RADIX_BITS,
+		LOG_SCHEDULE_GRANULARITY,
+		DOWNSWEEP_MIN_CTA_OCCUPANCY,
+		DOWNSWEEP_LOG_THREADS,
+		DOWNSWEEP_LOG_LOAD_VEC_SIZE,
+		DOWNSWEEP_LOG_LOADS_PER_CYCLE,
+		DOWNSWEEP_LOG_CYCLES_PER_TILE,
+		DOWNSWEEP_LOG_RAKING_THREADS,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		DOWNSWEEP_SCATTER_STRATEGY,
+		EARLY_EXIT>
+			Downsweep;
+
+	//---------------------------------------------------------------------
+	// Kernel function pointer retrieval
+	//---------------------------------------------------------------------
+
+	template <typename PassPolicy>
+	static UpsweepKernelPtr UpsweepKernel() {
+		return upsweep::Kernel<upsweep::KernelPolicy<typename Policy::Upsweep, PassPolicy> >;
+	}
+
+	template <typename PassPolicy>
+	static DownsweepKernelPtr DownsweepKernel() {
+		return downsweep::Kernel<downsweep::KernelPolicy<typename Policy::Downsweep, PassPolicy> >;
+	}
+
+
+	//---------------------------------------------------------------------
+	// Constants
+	//---------------------------------------------------------------------
+
+	enum {
+		RADIX_BITS					= _RADIX_BITS,
+		UNIFORM_SMEM_ALLOCATION 	= _UNIFORM_SMEM_ALLOCATION,
+		UNIFORM_GRID_SIZE 			= _UNIFORM_GRID_SIZE,
+		OVERSUBSCRIBED_GRID_SIZE	= _OVERSUBSCRIBED_GRID_SIZE,
+	};
+};
+		
+
+}// namespace radix_sort
+}// namespace b40c
+

--- a/include/b40c/radix_sort/problem_type.cuh
+++ b/include/b40c/radix_sort/problem_type.cuh
@@ -1,0 +1,67 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Partitioning problem type
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/partition/problem_type.cuh>
+#include <b40c/radix_sort/sort_utils.cuh>
+
+namespace b40c {
+namespace radix_sort {
+
+
+/**
+ * Type of radix sorting problem (i.e., data types to sort)
+ *
+ * Derives from partition::KeyType
+ */
+template <
+	typename _KeyType,
+	typename _ValueType,
+	typename _SizeT>
+struct ProblemType :
+	partition::ProblemType<
+		typename KeyTraits<_KeyType>::ConvertedKeyType,		// converted (unsigned) key type
+		_ValueType,
+		_SizeT>
+{
+	// The original type of data we are operating upon
+	typedef _KeyType OriginalKeyType;
+
+	// The key traits that describe any pre/post processing
+	typedef KeyTraits<_KeyType> KeyTraits;
+};
+		
+
+}// namespace radix_sort
+}// namespace b40c
+

--- a/include/b40c/radix_sort/sort_utils.cuh
+++ b/include/b40c/radix_sort/sort_utils.cuh
@@ -1,0 +1,190 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Types and subroutines utilities that are common across all B40C LSB radix 
+ * sorting kernels and host enactors  
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace radix_sort {
+
+
+/******************************************************************************
+ * Bit-field extraction kernel subroutines
+ ******************************************************************************/
+
+/**
+ * Extracts a bit field from source and places the zero or sign-extended result 
+ * in extract
+ */
+template <typename T, int BIT_START, int NUM_BITS> 
+struct ExtractKeyBits 
+{
+	__device__ __forceinline__ static void Extract(int &bits, T source)
+	{
+#if __CUDA_ARCH__ >= 200
+		asm("bfe.u32 %0, %1, %2, %3;" : "=r"(bits) : "r"((unsigned int) source), "r"(BIT_START), "r"(NUM_BITS));
+#else
+		const T MASK = (1 << NUM_BITS) - 1;
+		bits = (source >> BIT_START) & MASK;
+#endif
+	}
+};
+	
+/**
+ * Extracts a bit field from source and places the zero or sign-extended result 
+ * in extract
+ */
+template <int BIT_START, int NUM_BITS> 
+struct ExtractKeyBits<unsigned long long, BIT_START, NUM_BITS> 
+{
+	__device__ __forceinline__ static void Extract(int &bits, const unsigned long long &source) 
+	{
+		if (BIT_START >= 32) {											// For extraction on GT200, the compiler goes nuts and shoves hundreds of bytes to lmem unless we use different extractions for upper/lower
+			const unsigned long long MASK = (1 << NUM_BITS) - 1;
+			bits = (source >> BIT_START) & MASK;
+		} else {
+			const unsigned long long MASK = ((1ull << NUM_BITS) - 1) << BIT_START;
+			bits = (source & MASK) >> BIT_START;
+		}
+	}
+};
+	
+
+/******************************************************************************
+ * Traits for converting for converting signed and floating point types
+ * to unsigned types suitable for radix sorting
+ ******************************************************************************/
+
+struct NopKeyConversion
+{
+	static const bool MustApply = false;		// We may early-exit this pass
+
+	template <typename T>
+	__device__ __host__ __forceinline__ static void Preprocess(T &key) {}
+
+	template <typename T>
+	__device__ __host__ __forceinline__ static void Postprocess(T &key) {}
+};
+
+
+template <typename UnsignedBits> 
+struct UnsignedIntegerKeyConversion 
+{
+	typedef UnsignedBits ConvertedKeyType;
+	
+	static const bool MustApply = false;		// We may early-exit this pass
+
+	__device__ __host__ __forceinline__ static void Preprocess(UnsignedBits &converted_key) {}
+
+	__device__ __host__ __forceinline__ static void Postprocess(UnsignedBits &converted_key) {}  
+};
+
+
+template <typename UnsignedBits> 
+struct SignedIntegerKeyConversion 
+{
+	typedef UnsignedBits ConvertedKeyType;
+
+	static const bool MustApply = true;		// We must not early-exit this pass (conversion necessary)
+
+	__device__ __host__ __forceinline__ static void Preprocess(UnsignedBits &converted_key)
+	{
+		const UnsignedBits HIGH_BIT = ((UnsignedBits) 0x1) << ((sizeof(UnsignedBits) * 8) - 1);
+		converted_key ^= HIGH_BIT;
+	}
+
+	__device__ __host__ __forceinline__ static void Postprocess(UnsignedBits &converted_key)  
+	{
+		const UnsignedBits HIGH_BIT = ((UnsignedBits) 0x1) << ((sizeof(UnsignedBits) * 8) - 1);
+		converted_key ^= HIGH_BIT;	
+	}
+};
+
+
+template <typename UnsignedBits> 
+struct FloatingPointKeyConversion 
+{
+	typedef UnsignedBits ConvertedKeyType;
+
+	static const bool MustApply = true;		// We must not early-exit this pass (conversion necessary)
+
+	__device__ __host__ __forceinline__ static void Preprocess(UnsignedBits &converted_key)
+	{
+		const UnsignedBits HIGH_BIT = ((UnsignedBits) 0x1) << ((sizeof(UnsignedBits) * 8) - 1);
+		UnsignedBits mask = (converted_key & HIGH_BIT) ? (UnsignedBits) -1 : HIGH_BIT;
+		converted_key ^= mask;
+	}
+
+	__device__ __host__ __forceinline__ static void Postprocess(UnsignedBits &converted_key) 
+	{
+		const UnsignedBits HIGH_BIT = ((UnsignedBits) 0x1) << ((sizeof(UnsignedBits) * 8) - 1);
+		UnsignedBits mask = (converted_key & HIGH_BIT) ? HIGH_BIT : (UnsignedBits) -1; 
+		converted_key ^= mask;
+    }
+};
+
+
+
+
+// Default unsigned types
+template <typename T> struct KeyTraits : UnsignedIntegerKeyConversion<T> {};
+
+// char
+template <> struct KeyTraits<char> : SignedIntegerKeyConversion<unsigned char> {};
+
+// signed char
+template <> struct KeyTraits<signed char> : SignedIntegerKeyConversion<unsigned char> {};
+
+// short
+template <> struct KeyTraits<short> : SignedIntegerKeyConversion<unsigned short> {};
+
+// int
+template <> struct KeyTraits<int> : SignedIntegerKeyConversion<unsigned int> {};
+
+// long
+template <> struct KeyTraits<long> : SignedIntegerKeyConversion<unsigned long> {};
+
+// long long
+template <> struct KeyTraits<long long> : SignedIntegerKeyConversion<unsigned long long> {};
+
+// float
+template <> struct KeyTraits<float> : FloatingPointKeyConversion<unsigned int> {};
+
+// double
+template <> struct KeyTraits<double> : FloatingPointKeyConversion<unsigned long long> {};
+
+
+
+
+} // namespace radix_sort
+} // namespace b40c
+

--- a/include/b40c/radix_sort/upsweep/cta.cuh
+++ b/include/b40c/radix_sort/upsweep/cta.cuh
@@ -1,0 +1,88 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * CTA-processing functionality for radix sort upsweep reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/partition/upsweep/cta.cuh>
+
+#include <b40c/radix_sort/upsweep/tile.cuh>
+
+namespace b40c {
+namespace radix_sort {
+namespace upsweep {
+
+/**
+ * Radix sort upsweep reduction CTA
+ *
+ * Derives from partition::upsweep::Cta
+ */
+template <typename KernelPolicy>
+struct Cta :
+	partition::upsweep::Cta<
+		KernelPolicy,
+		Cta<KernelPolicy>,			// This class
+		Tile>						// radix_sort::upsweep::Tile
+{
+	//---------------------------------------------------------------------
+	// Typedefs and Constants
+	//---------------------------------------------------------------------
+
+	// Base class type
+	typedef partition::upsweep::Cta<KernelPolicy, Cta, Tile> Base;
+
+	typedef typename KernelPolicy::KeyType 					KeyType;
+	typedef typename KernelPolicy::SizeT 					SizeT;
+	typedef typename KernelPolicy::SmemStorage				SmemStorage;
+
+
+	//---------------------------------------------------------------------
+	// Methods
+	//---------------------------------------------------------------------
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ Cta(
+		SmemStorage 	&smem_storage,
+		KeyType 		*d_in_keys,
+		SizeT 			*d_spine) :
+			Base(smem_storage, d_in_keys, d_spine)
+	{}
+
+};
+
+
+
+} // namespace upsweep
+} // namespace radix_sort
+} // namespace b40c
+

--- a/include/b40c/radix_sort/upsweep/kernel.cuh
+++ b/include/b40c/radix_sort/upsweep/kernel.cuh
@@ -1,0 +1,113 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Radix sort upsweep reduction kernel
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/cta_work_distribution.cuh>
+
+#include <b40c/radix_sort/upsweep/cta.cuh>
+
+namespace b40c {
+namespace radix_sort {
+namespace upsweep {
+
+
+/**
+ * Radix sort upsweep reduction pass
+ */
+template <typename KernelPolicy>
+__device__ __forceinline__ void UpsweepPass(
+	int 									*&d_selectors,
+	typename KernelPolicy::SizeT 			*&d_spine,
+	typename KernelPolicy::KeyType 			*&d_in_keys,
+	typename KernelPolicy::KeyType 			*&d_out_keys,
+	util::CtaWorkDistribution<typename KernelPolicy::SizeT> &work_decomposition,
+	typename KernelPolicy::SmemStorage		&smem_storage)
+{
+	typedef Cta<KernelPolicy> 						Cta;
+	typedef typename KernelPolicy::KeyType 			KeyType;
+	typedef typename KernelPolicy::SizeT 			SizeT;
+	
+	// Determine where to read our input
+
+	bool selector = ((KernelPolicy::EARLY_EXIT) && ((KernelPolicy::CURRENT_PASS != 0) && (d_selectors[KernelPolicy::CURRENT_PASS & 0x1]))) ||
+		(KernelPolicy::CURRENT_PASS & 0x1);
+	KeyType *d_keys = (selector) ? d_out_keys : d_in_keys;
+
+	// Determine our threadblock's work range
+	util::CtaWorkLimits<SizeT> work_limits;
+	work_decomposition.template GetCtaWorkLimits<
+		KernelPolicy::LOG_TILE_ELEMENTS,
+		KernelPolicy::LOG_SCHEDULE_GRANULARITY>(work_limits);
+
+	// CTA processing abstraction
+	Cta cta(
+		smem_storage,
+		d_keys,
+		d_spine);
+	
+	// Accumulate digit counts for all tiles
+	cta.ProcessWorkRange(work_limits);
+}
+
+
+/**
+ * Radix sort upsweep reduction kernel entry point
+ */
+template <typename KernelPolicy>
+__launch_bounds__ (KernelPolicy::THREADS, KernelPolicy::MIN_CTA_OCCUPANCY)
+__global__
+void Kernel(
+	int 								*d_selectors,
+	typename KernelPolicy::SizeT 		*d_spine,
+	typename KernelPolicy::KeyType 		*d_in_keys,
+	typename KernelPolicy::KeyType 		*d_out_keys,
+	util::CtaWorkDistribution<typename KernelPolicy::SizeT> work_decomposition)
+{
+	// Shared memory pool
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	UpsweepPass<KernelPolicy>(
+		d_selectors,
+		d_spine,
+		d_in_keys,
+		d_out_keys,
+		work_decomposition,
+		smem_storage);
+}
+
+
+} // namespace upsweep
+} // namespace radix_sort
+} // namespace b40c
+

--- a/include/b40c/radix_sort/upsweep/kernel_policy.cuh
+++ b/include/b40c/radix_sort/upsweep/kernel_policy.cuh
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Configuration policy for partitioning upsweep reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/partition/upsweep/kernel_policy.cuh>
+
+namespace b40c {
+namespace radix_sort {
+namespace upsweep {
+
+
+/**
+ * A detailed radix sort upsweep kernel configuration policy type that specializes kernel
+ * code for a specific pass. It encapsulates tuning configuration
+ * policy details derived from TuningPolicy and PassPolicy.
+ */
+template <
+	typename 		TuningPolicy,
+	typename 		PassPolicy>
+struct KernelPolicy :
+	partition::upsweep::KernelPolicy<TuningPolicy>,
+	PassPolicy
+{
+};
+	
+
+
+} // namespace upsweep
+} // namespace radix_sort
+} // namespace b40c
+

--- a/include/b40c/radix_sort/upsweep/tile.cuh
+++ b/include/b40c/radix_sort/upsweep/tile.cuh
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Tile-processing functionality for radix sort upsweep reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/partition/upsweep/tile.cuh>
+
+namespace b40c {
+namespace radix_sort {
+namespace upsweep {
+
+
+/**
+ * Tile
+ *
+ * Derives from partition::upsweep::Tile
+ */
+template <
+	int LOG_LOADS_PER_TILE,
+	int LOG_LOAD_VEC_SIZE,
+	typename KernelPolicy>
+struct Tile :
+	partition::upsweep::Tile<
+		LOG_LOADS_PER_TILE,
+		LOG_LOAD_VEC_SIZE,
+		KernelPolicy,
+		Tile<LOG_LOADS_PER_TILE, LOG_LOAD_VEC_SIZE, KernelPolicy> >					// This class
+{
+	//---------------------------------------------------------------------
+	// Typedefs and Constants
+	//---------------------------------------------------------------------
+
+	typedef typename KernelPolicy::KeyType 		KeyType;
+	typedef typename KernelPolicy::SizeT 		SizeT;
+
+
+	//---------------------------------------------------------------------
+	// Derived Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Returns the bin into which the specified key is to be placed
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ int DecodeBin(KeyType key, Cta *cta)
+	{
+		int bin;
+		ExtractKeyBits<
+			KeyType,
+			KernelPolicy::CURRENT_BIT,
+			KernelPolicy::LOG_BINS>::Extract(bin, key);
+		return bin;
+	}
+
+
+	/**
+	 * Returns whether or not the key is valid.
+	 *
+	 * Can be overloaded.
+	 */
+	template <int LOAD, int VEC>
+	__device__ __forceinline__ bool IsValid()
+	{
+		return true;
+	}
+
+
+	/**
+	 * Loads keys into the tile
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void LoadKeys(
+		Cta *cta,
+		SizeT cta_offset)
+	{
+		// Read tile of keys
+		util::io::LoadTile<
+			LOG_LOADS_PER_TILE,
+			LOG_LOAD_VEC_SIZE,
+			KernelPolicy::THREADS,
+			KernelPolicy::READ_MODIFIER,
+			KernelPolicy::CHECK_ALIGNMENT>::template LoadValid<
+				KeyType,
+				KernelPolicy::PreprocessTraits::Preprocess>(
+					(KeyType (*)[Tile::LOAD_VEC_SIZE]) this->keys,
+					cta->d_in_keys,
+					cta_offset);
+	}
+
+	/**
+	 * Stores keys from the tile (not necessary)
+	 */
+	template <typename Cta>
+	__device__ __forceinline__ void StoreKeys(
+		Cta *cta,
+		SizeT cta_offset) {}
+};
+
+
+
+} // namespace upsweep
+} // namespace radix_sort
+} // namespace b40c

--- a/include/b40c/radix_sort/upsweep/tuning_policy.cuh
+++ b/include/b40c/radix_sort/upsweep/tuning_policy.cuh
@@ -1,0 +1,86 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Tuning policy for radix sort upsweep reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+#include <b40c/partition/upsweep/tuning_policy.cuh>
+
+namespace b40c {
+namespace radix_sort {
+namespace upsweep {
+
+/**
+ * Radix sort upsweep reduction tuning policy.
+ *
+ * See constraints in base class.
+ */
+template <
+	typename ProblemType,
+
+	int CUDA_ARCH,
+	bool CHECK_ALIGNMENT,
+	int LOG_BINS,
+	int LOG_SCHEDULE_GRANULARITY,
+	int MIN_CTA_OCCUPANCY,
+	int LOG_THREADS,
+	int LOG_LOAD_VEC_SIZE,
+	int LOG_LOADS_PER_TILE,
+	util::io::ld::CacheModifier READ_MODIFIER,
+	util::io::st::CacheModifier WRITE_MODIFIER,
+	bool _EARLY_EXIT>
+
+struct TuningPolicy :
+	partition::upsweep::TuningPolicy <
+		ProblemType,
+		CUDA_ARCH,
+		CHECK_ALIGNMENT,
+		LOG_BINS,
+		LOG_SCHEDULE_GRANULARITY,
+		MIN_CTA_OCCUPANCY,
+		LOG_THREADS,
+		LOG_LOAD_VEC_SIZE,
+		LOG_LOADS_PER_TILE,
+		READ_MODIFIER,
+		WRITE_MODIFIER>
+{
+	enum {
+		EARLY_EXIT								= _EARLY_EXIT,
+	};
+};
+
+} // namespace upsweep
+} // namespace radix_sort
+} // namespace b40c
+

--- a/include/b40c/reduction/autotuned_policy.cuh
+++ b/include/b40c/reduction/autotuned_policy.cuh
@@ -1,0 +1,553 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Autotuned reduction policy
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/cta_work_progress.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+#include <b40c/reduction/spine/kernel.cuh>
+#include <b40c/reduction/upsweep/kernel.cuh>
+#include <b40c/reduction/policy.cuh>
+
+namespace b40c {
+namespace reduction {
+
+
+/******************************************************************************
+ * Genre enumerations to classify problems by
+ ******************************************************************************/
+
+/**
+ * Enumeration of problem-size genres that we may have tuned for
+ */
+enum ProbSizeGenre
+{
+	UNKNOWN_SIZE = -1,			// Not actually specialized on: the enactor should use heuristics to select another size genre
+	SMALL_SIZE,					// Tuned @ 128KB input
+	LARGE_SIZE					// Tuned @ 128MB input
+};
+
+
+/**
+ * Enumeration of architecture-family genres that we have tuned for below
+ */
+enum ArchGenre
+{
+	SM20 	= 200,
+	SM13	= 130,
+	SM10	= 100
+};
+
+
+/**
+ * Enumeration of type size genres
+ */
+enum TypeSizeGenre
+{
+	TINY_TYPE,
+	SMALL_TYPE,
+	MEDIUM_TYPE,
+	LARGE_TYPE
+};
+
+
+/**
+ * Autotuning policy genre, to be specialized
+ */
+template <
+	// Problem and machine types
+	typename ProblemType,
+	int CUDA_ARCH,
+
+	// Genres to specialize upon
+	ProbSizeGenre PROB_SIZE_GENRE,
+	ArchGenre ARCH_GENRE,
+	TypeSizeGenre TYPE_SIZE_GENRE,
+	TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre;
+
+
+/******************************************************************************
+ * Classifiers for identifying classification genres
+ ******************************************************************************/
+
+/**
+ * Classifies a given CUDA_ARCH into an architecture-family genre
+ */
+template <int CUDA_ARCH>
+struct ArchClassifier
+{
+	static const ArchGenre GENRE 			=	(CUDA_ARCH < SM13) ? SM10 :
+												(CUDA_ARCH < SM20) ? SM13 : SM20;
+};
+
+
+/**
+ * Classifies the problem type(s) into a type-size genre
+ */
+template <typename ProblemType>
+struct TypeSizeClassifier
+{
+	static const int ROUNDED_SIZE			= 1 << util::Log2<sizeof(typename ProblemType::T)>::VALUE;	// Round up to the nearest arch subword
+
+	static const TypeSizeGenre GENRE =		(ROUNDED_SIZE < 2) ? TINY_TYPE :
+											(ROUNDED_SIZE < 4) ? SMALL_TYPE :
+											(ROUNDED_SIZE < 8) ? MEDIUM_TYPE : LARGE_TYPE;
+};
+
+
+/**
+ * Classifies the pointer type into a type-size genre
+ */
+template <typename ProblemType>
+struct PointerSizeClassifier
+{
+	static const TypeSizeGenre GENRE 		= (sizeof(typename ProblemType::SizeT) < 8) ? MEDIUM_TYPE : LARGE_TYPE;
+};
+
+
+/**
+ * Autotuning policy classifier
+ */
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	ProbSizeGenre PROB_SIZE_GENRE>
+struct AutotunedClassifier :
+	AutotunedGenre<
+		ProblemType,
+		CUDA_ARCH,
+		PROB_SIZE_GENRE,
+		ArchClassifier<CUDA_ARCH>::GENRE,
+		TypeSizeClassifier<ProblemType>::GENRE,
+		PointerSizeClassifier<ProblemType>::GENRE>
+{};
+
+
+/******************************************************************************
+ * Autotuned genre specializations
+ ******************************************************************************/
+
+//-----------------------------------------------------------------------------
+// SM2.0 specializations(s)
+//-----------------------------------------------------------------------------
+
+// Large problems, 8B+ data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM20, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, true, false, false, false, 8,
+	  7, 0, 2,
+	  8, 1, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 4B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM20, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, true, false, false, false, 8,
+	  7, 1, 2,
+	  7, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 2B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM20, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, true, false, false, false, 8,
+	  7, 2, 2,
+	  5, 1, 2>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 1B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM20, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, false, true, 8,
+	  7, 2, 2,
+	  5, 2, 2>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+
+
+
+// Small problems 8B+
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM20, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  5, 1, 1,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 4B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM20, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  5, 0, 2,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 2B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM20, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  5, 1, 2,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 1B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM20, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  6, 2, 1,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+
+
+//-----------------------------------------------------------------------------
+// SM1.3 specializations(s)
+//-----------------------------------------------------------------------------
+
+// Large problems, 8B+
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM13, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, true, 0,
+	  6, 0, 1,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 4B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM13, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, true, 0,
+	  7, 0, 1,
+	  8, 2, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 2B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM13, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, true, 0,
+	  9, 1, 2,
+	  7, 2, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 1B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM13, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, true, 0,
+	  7, 2, 2,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+
+
+// Small problems 8B+
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM13, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  5, 0, 2,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 4B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM13, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  6, 0, 2,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 2B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM13, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  6, 1, 2,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 1B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM13, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  6, 2, 2,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+
+
+//-----------------------------------------------------------------------------
+// SM1.0 specializations(s)
+//-----------------------------------------------------------------------------
+
+// Large problems, 8B+
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM10, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, true, 0,
+	  5, 0, 1,
+	  5, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 4B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM10, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, true, 0,
+	  6, 0, 2,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 2B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM10, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, true, 0,
+	  6, 1, 2,
+	  6, 2, 1>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 1B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM10, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, true, 0,
+	  6, 2, 2,
+	  6, 2, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+
+
+// Small problems 8B+
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM10, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  7, 0, 2,
+	  5, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 4B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM10, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  8, 0, 2,
+	  5, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 2B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM10, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  5, 2, 1,
+	  6, 0, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 1B
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM10, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, false, 0,
+	  6, 2, 0,
+	  6, 1, 0>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+
+
+
+/******************************************************************************
+ * Reduction kernel entry points that can derive a tuned granularity type
+ * implicitly from the PROB_SIZE_GENRE template parameter.  (As opposed to having
+ * the granularity type passed explicitly.)
+ *
+ * TODO: Section can be removed if CUDA Runtime is fixed to
+ * properly support template specialization around kernel call sites.
+ ******************************************************************************/
+
+/**
+ * Tuned upsweep reduction kernel entry point
+ */
+template <typename ProblemType, int PROB_SIZE_GENRE>
+__launch_bounds__ (
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Policy::Upsweep::THREADS),
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Policy::Upsweep::MIN_CTA_OCCUPANCY))
+__global__ void TunedUpsweepKernel(
+	typename ProblemType::T 								*d_in,
+	typename ProblemType::T 								*d_spine,
+	typename ProblemType::ReductionOp 						reduction_op,
+	util::CtaWorkDistribution<typename ProblemType::SizeT> 	work_decomposition,
+	util::CtaWorkProgress									work_progress)
+{
+	// Load the kernel policy type identified by the enum for this architecture
+	typedef typename AutotunedClassifier<
+		ProblemType,
+		__B40C_CUDA_ARCH__,
+		(ProbSizeGenre) PROB_SIZE_GENRE>::Upsweep KernelPolicy;
+
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	upsweep::UpsweepPass<KernelPolicy, KernelPolicy::WORK_STEALING>::Invoke(
+		d_in,
+		d_spine,
+		reduction_op,
+		work_decomposition,
+		work_progress,
+		smem_storage);
+}
+
+
+/**
+ * Tuned spine reduction kernel entry point
+ */
+template <typename ProblemType, int PROB_SIZE_GENRE>
+__launch_bounds__ (
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Policy::Spine::THREADS),
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Policy::Spine::MIN_CTA_OCCUPANCY))
+__global__ void TunedSpineKernel(
+	typename ProblemType::T 			*d_spine,
+	typename ProblemType::T 			*d_out,
+	typename ProblemType::SizeT 		spine_elements,
+	typename ProblemType::ReductionOp 	reduction_op)
+{
+	// Load the kernel policy type identified by the enum for this architecture
+	typedef typename AutotunedClassifier<
+		ProblemType,
+		__B40C_CUDA_ARCH__,
+		(ProbSizeGenre) PROB_SIZE_GENRE>::Spine KernelPolicy;
+
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	spine::SpinePass<KernelPolicy>(
+		d_spine,
+		d_out,
+		spine_elements,
+		reduction_op,
+		smem_storage);
+}
+
+
+
+/******************************************************************************
+ * Autotuned policy
+ *******************************************************************************/
+
+/**
+ * Autotuned policy type
+ */
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	ProbSizeGenre PROB_SIZE_GENRE>
+struct AutotunedPolicy :
+	AutotunedClassifier<
+		ProblemType,
+		CUDA_ARCH,
+		PROB_SIZE_GENRE>
+{
+	//---------------------------------------------------------------------
+	// Typedefs
+	//---------------------------------------------------------------------
+
+	typedef typename ProblemType::T 			T;
+	typedef typename ProblemType::SizeT 		SizeT;
+	typedef typename ProblemType::ReductionOp 	ReductionOp;
+
+	typedef void (*UpsweepKernelPtr)(T*, T*, ReductionOp, util::CtaWorkDistribution<SizeT>, util::CtaWorkProgress);
+	typedef void (*SpineKernelPtr)(T*, T*, SizeT, ReductionOp);
+	typedef void (*SingleKernelPtr)(T*, T*, SizeT, ReductionOp);
+
+	//---------------------------------------------------------------------
+	// Kernel function pointer retrieval
+	//---------------------------------------------------------------------
+
+	static UpsweepKernelPtr UpsweepKernel() {
+		return TunedUpsweepKernel<ProblemType, PROB_SIZE_GENRE>;
+	}
+
+	static SpineKernelPtr SpineKernel() {
+		return TunedSpineKernel<ProblemType, PROB_SIZE_GENRE>;
+	}
+
+	static SingleKernelPtr SingleKernel() {
+		return TunedSpineKernel<ProblemType, PROB_SIZE_GENRE>;
+	}
+};
+
+
+}// namespace reduction
+}// namespace b40c
+

--- a/include/b40c/reduction/cta.cuh
+++ b/include/b40c/reduction/cta.cuh
@@ -1,0 +1,264 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * CTA-processing abstraction for reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+#include <b40c/util/io/load_tile.cuh>
+
+#include <b40c/util/reduction/serial_reduce.cuh>
+#include <b40c/util/reduction/tree_reduce.cuh>
+
+namespace b40c {
+namespace reduction {
+
+
+/**
+ * Reduction CTA
+ */
+template <typename KernelPolicy>
+struct Cta
+{
+	//---------------------------------------------------------------------
+	// Typedefs
+	//---------------------------------------------------------------------
+
+	typedef typename KernelPolicy::T 			T;
+	typedef typename KernelPolicy::SizeT 		SizeT;
+	typedef typename KernelPolicy::SmemStorage	SmemStorage;
+	typedef typename KernelPolicy::ReductionOp	ReductionOp;
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// The value we will accumulate (in each thread)
+	T 				carry;
+
+	// Input and output device pointers
+	T* 				d_in;
+	T* 				d_out;
+
+	// Shared memory storage for the CTA
+	SmemStorage 	&smem_storage;
+
+	// Reduction operator
+	ReductionOp		reduction_op;
+
+
+	//---------------------------------------------------------------------
+	// Methods
+	//---------------------------------------------------------------------
+
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ Cta(
+		SmemStorage &smem_storage,
+		T *d_in,
+		T *d_out,
+		ReductionOp reduction_op) :
+
+			smem_storage(smem_storage),
+			d_in(d_in),
+			d_out(d_out),
+			reduction_op(reduction_op)
+	{}
+
+
+	/**
+	 * Process a single, full tile
+	 *
+	 * Each thread reduces only the strided values it loads.
+	 */
+	template <bool FIRST_TILE>
+	__device__ __forceinline__ void ProcessFullTile(
+		SizeT cta_offset)
+	{
+		// Tile of elements
+		T data[KernelPolicy::LOADS_PER_TILE][KernelPolicy::LOAD_VEC_SIZE];
+
+		// Load tile
+		util::io::LoadTile<
+			KernelPolicy::LOG_LOADS_PER_TILE,
+			KernelPolicy::LOG_LOAD_VEC_SIZE,
+			KernelPolicy::THREADS,
+			KernelPolicy::READ_MODIFIER,
+			KernelPolicy::CHECK_ALIGNMENT>::LoadValid(
+				data, d_in, cta_offset);
+
+		// Reduce the data we loaded for this tile
+		T tile_partial = util::reduction::SerialReduce<KernelPolicy::TILE_ELEMENTS_PER_THREAD>::Invoke(
+			(T*) data,
+			reduction_op);
+
+		// Reduce into carry
+		if (FIRST_TILE) {
+			carry = tile_partial;
+		} else {
+			carry = reduction_op(carry, tile_partial);
+		}
+	}
+
+
+	/**
+	 * Process a single, partial tile
+	 *
+	 * Each thread reduces only the strided values it loads.
+	 */
+	template <bool FIRST_TILE>
+	__device__ __forceinline__ void ProcessPartialTile(
+		SizeT cta_offset,
+		SizeT out_of_bounds)
+	{
+		T datum;
+		cta_offset += threadIdx.x;
+
+		if (FIRST_TILE) {
+			if (cta_offset < out_of_bounds) {
+				util::io::ModifiedLoad<KernelPolicy::READ_MODIFIER>::Ld(carry, d_in + cta_offset);
+				cta_offset += KernelPolicy::THREADS;
+			}
+		}
+
+		// Process loads singly
+		while (cta_offset < out_of_bounds) {
+			util::io::ModifiedLoad<KernelPolicy::READ_MODIFIER>::Ld(datum, d_in + cta_offset);
+			carry = reduction_op(carry, datum);
+			cta_offset += KernelPolicy::THREADS;
+		}
+	}
+
+
+	/**
+	 * Unguarded collective reduction across all threads, stores final reduction
+	 * to output.  Used to collectively reduce each thread's aggregate after
+	 * striding through the input.
+	 *
+	 * All threads assumed to have valid carry data.
+	 */
+	__device__ __forceinline__ void OutputToSpine()
+	{
+		carry = util::reduction::TreeReduce<
+			KernelPolicy::LOG_THREADS,
+			false>::Invoke(								// No need to return aggregate reduction in all threads
+				carry,
+				smem_storage.ReductionTree(),
+				reduction_op);
+
+		// Write output
+		if (threadIdx.x == 0) {
+			util::io::ModifiedStore<KernelPolicy::WRITE_MODIFIER>::St(
+				carry, d_out + blockIdx.x);
+		}
+	}
+
+
+	/**
+	 * Guarded collective reduction across all threads, stores final reduction
+	 * to output. Used to collectively reduce each thread's aggregate after striding through
+	 * the input.
+	 *
+	 * Only threads with ranks less than num_elements are assumed to have valid
+	 * carry data.
+	 */
+	__device__ __forceinline__ void OutputToSpine(int num_elements)
+	{
+		carry = util::reduction::TreeReduce<
+			KernelPolicy::LOG_THREADS,
+			false>::Invoke(								// No need to return aggregate reduction in all threads
+				carry,
+				smem_storage.ReductionTree(),
+				num_elements,
+				reduction_op);
+
+		// Write output
+		if (threadIdx.x == 0) {
+			util::io::ModifiedStore<KernelPolicy::WRITE_MODIFIER>::St(
+				carry, d_out + blockIdx.x);
+		}
+	}
+
+
+	/**
+	 * Process work range of tiles
+	 */
+	__device__ __forceinline__ void ProcessWorkRange(
+		util::CtaWorkLimits<SizeT> &work_limits)
+	{
+		// Make sure we get a local copy of the cta's offset (work_limits may be in smem)
+		SizeT cta_offset = work_limits.offset;
+
+		if (cta_offset < work_limits.guarded_offset) {
+
+			// Process at least one full tile of tile_elements
+			ProcessFullTile<true>(cta_offset);
+			cta_offset += KernelPolicy::TILE_ELEMENTS;
+
+			// Process more full tiles (not first tile)
+			while (cta_offset < work_limits.guarded_offset) {
+				ProcessFullTile<false>(cta_offset);
+				cta_offset += KernelPolicy::TILE_ELEMENTS;
+			}
+
+			// Clean up last partial tile with guarded-io (not first tile)
+			if (work_limits.guarded_elements) {
+				ProcessPartialTile<false>(
+					cta_offset,
+					work_limits.out_of_bounds);
+			}
+
+			// Collectively reduce accumulated carry from each thread into output
+			// destination (all thread have valid reduction partials)
+			OutputToSpine();
+
+		} else {
+
+			// Clean up last partial tile with guarded-io (first tile)
+			ProcessPartialTile<true>(
+				cta_offset,
+				work_limits.out_of_bounds);
+
+			// Collectively reduce accumulated carry from each thread into output
+			// destination (not every thread may have a valid reduction partial)
+			OutputToSpine(work_limits.elements);
+		}
+	}
+
+};
+
+
+} // namespace reduction
+} // namespace b40c
+

--- a/include/b40c/reduction/enactor.cuh
+++ b/include/b40c/reduction/enactor.cuh
@@ -1,0 +1,500 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Reduction enactor
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/enactor_base.cuh>
+#include <b40c/util/error_utils.cuh>
+#include <b40c/util/spine.cuh>
+#include <b40c/util/cta_work_progress.cuh>
+#include <b40c/util/arch_dispatch.cuh>
+
+#include <b40c/reduction/problem_type.cuh>
+#include <b40c/reduction/autotuned_policy.cuh>
+#include <b40c/reduction/upsweep/kernel.cuh>
+#include <b40c/reduction/spine/kernel.cuh>
+
+namespace b40c {
+namespace reduction {
+
+
+/**
+ * Reduction enactor class.
+ */
+class Enactor : public util::EnactorBase
+{
+protected:
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Temporary device storage needed for managing work-stealing progress
+	// within a kernel invocation.
+	util::CtaWorkProgressLifetime work_progress;
+
+	// Temporary device storage needed for reducing partials produced
+	// by separate CTAs
+	util::Spine spine;
+
+
+	//-----------------------------------------------------------------------------
+	// Helper structures
+	//-----------------------------------------------------------------------------
+
+	template <typename ProblemType>
+	friend class Detail;
+
+
+	//-----------------------------------------------------------------------------
+	// Utility Routines
+	//-----------------------------------------------------------------------------
+
+    /**
+	 * Performs a reduction pass
+	 */
+	template <typename Policy, typename Detail>
+	cudaError_t EnactPass(Detail &detail);
+
+
+public:
+
+	/**
+	 * Constructor
+	 */
+	Enactor() {}
+
+
+	/**
+	 * Enacts a reduction operation on the specified device data.  Uses
+	 * a heuristic for selecting an autotuning policy based upon problem size.
+	 *
+	 * @param d_dest
+	 * 		Pointer to result location
+	 * @param d_src
+	 * 		Pointer to array of elements to be reduced
+	 * @param num_elements
+	 * 		Number of elements to reduce
+	 * @param reduction_op
+	 * 		The function or functor type for binary reduction, i.e., a type instance
+	 * 		that implements "T (const T&, const T&)"
+	 * @param max_grid_size
+	 * 		Optional upper-bound on the number of CTAs to launch.
+	 *
+	 * @return cudaSuccess on success, error enumeration otherwise
+	 */
+	template <
+		typename T,
+		typename SizeT,
+		typename ReductionOp>
+	cudaError_t Reduce(
+		T *d_dest,
+		T *d_src,
+		SizeT num_elements,
+		ReductionOp reduction_op,
+		int max_grid_size = 0);
+
+
+	/**
+	 * Enacts a reduction operation on the specified device data.  Uses the
+	 * specified problem size genre enumeration to select autotuning policy.
+	 *
+	 * (Using this entrypoint can save compile time by not compiling tuned
+	 * kernels for each problem size genre.)
+	 *
+	 * @param d_dest
+	 * 		Pointer to result location
+	 * @param d_src
+	 * 		Pointer to array of elements to be reduced
+	 * @param num_elements
+	 * 		Number of elements to reduce
+	 * @param reduction_op
+	 * 		The function or functor type for binary reduction, i.e., a type instance
+	 * 		that implements "T (const T&, const T&)"
+	 * @param max_grid_size
+	 * 		Optional upper-bound on the number of CTAs to launch.
+	 *
+	 * @return cudaSuccess on success, error enumeration otherwise
+	 */
+	template <
+		ProbSizeGenre PROB_SIZE_GENRE,
+		typename T,
+		typename SizeT,
+		typename ReductionOp>
+	cudaError_t Reduce(
+		T *d_dest,
+		T *d_src,
+		SizeT num_elements,
+		ReductionOp reduction_op,
+		int max_grid_size = 0);
+
+
+	/**
+	 * Enacts a reduction on the specified device data.  Uses the specified
+	 * kernel configuration policy.  (Useful for auto-tuning.)
+	 *
+	 * @param d_dest
+	 * 		Pointer to result location
+	 * @param d_src
+	 * 		Pointer to array of elements to be reduced
+	 * @param num_elements
+	 * 		Number of elements to reduce
+	 * @param reduction_op
+	 * 		The function or functor type for binary reduction, i.e., a type instance
+	 * 		that implements "T (const T&, const T&)"
+	 * @param max_grid_size
+	 * 		Optional upper-bound on the number of CTAs to launch.
+	 * @return cudaSuccess on success, error enumeration otherwise
+	 */
+	template <typename Policy>
+	cudaError_t Reduce(
+		typename Policy::T *d_dest,
+		typename Policy::T *d_src,
+		typename Policy::SizeT num_elements,
+		typename Policy::ReductionOp reduction_op,
+		int max_grid_size = 0);
+};
+
+
+
+/******************************************************************************
+ * Helper structures
+ ******************************************************************************/
+
+/**
+ * Type for encapsulating operational details regarding an invocation
+ */
+template <typename ProblemType>
+struct Detail : ProblemType
+{
+	typedef typename ProblemType::T 			T;
+	typedef typename ProblemType::SizeT 		SizeT;
+	typedef typename ProblemType::ReductionOp 	ReductionOp;
+
+	Enactor 		*enactor;
+	T 				*d_dest;
+	T 				*d_src;
+	SizeT 			num_elements;
+	ReductionOp		reduction_op;
+	int 			max_grid_size;
+
+	// Constructor
+	Detail(
+		Enactor 		*enactor,
+		T 				*d_dest,
+		T 				*d_src,
+		SizeT 			num_elements,
+		ReductionOp 	reduction_op,
+		int max_grid_size = 0) :
+
+			enactor(enactor),
+			d_dest(d_dest),
+			d_src(d_src),
+			num_elements(num_elements),
+			reduction_op(reduction_op),
+			max_grid_size(max_grid_size)
+	{}
+
+	template <typename Policy>
+	cudaError_t EnactPass()
+	{
+		return enactor->template EnactPass<Policy>(*this);
+	}
+};
+
+
+/**
+ * Helper structure for resolving and enacting autotuned policy
+ */
+template <ProbSizeGenre PROB_SIZE_GENRE>
+struct PolicyResolver
+{
+	/**
+	 * ArchDispatch call-back with static CUDA_ARCH
+	 */
+	template <int CUDA_ARCH, typename Detail>
+	static cudaError_t Enact(Detail &detail)
+	{
+		// Obtain tuned granularity type
+		typedef AutotunedPolicy<
+			Detail,
+			CUDA_ARCH,
+			PROB_SIZE_GENRE> AutotunedPolicy;
+
+		// Invoke enactor with type
+		return detail.template EnactPass<AutotunedPolicy>();
+	}
+};
+
+
+/**
+ * Helper structure for resolving and enacting autotuned policy
+ *
+ * Specialization for UNKNOWN problem size genre to select other problem size
+ * genres based upon problem size, machine width, etc.
+ */
+template <>
+struct PolicyResolver <UNKNOWN_SIZE>
+{
+	/**
+	 * ArchDispatch call-back with static CUDA_ARCH
+	 */
+	template <int CUDA_ARCH, typename Detail>
+	static cudaError_t Enact(Detail &detail)
+	{
+		// Obtain large tuned granularity type
+		typedef AutotunedPolicy<
+			Detail,
+			CUDA_ARCH,
+			LARGE_SIZE> LargePolicy;
+
+		// Identify the maximum problem size for which we can saturate loads
+		int saturating_load = LargePolicy::Upsweep::TILE_ELEMENTS *
+			B40C_SM_CTAS(CUDA_ARCH) *
+			detail.enactor->SmCount();
+
+		if (detail.num_elements < saturating_load) {
+
+			// Invoke enactor with small-problem config type
+			typedef AutotunedPolicy<
+				Detail,
+				CUDA_ARCH,
+				SMALL_SIZE> SmallPolicy;
+
+			return detail.template EnactPass<SmallPolicy>();
+		}
+
+		// Invoke enactor with type
+		return detail.template EnactPass<LargePolicy>();
+	}
+};
+
+
+/******************************************************************************
+ * Enactor Implementation
+ ******************************************************************************/
+
+/**
+ * Performs a reduction pass
+ */
+template <typename Policy, typename DetailType>
+cudaError_t Enactor::EnactPass(DetailType &detail)
+{
+	typedef typename Policy::T 				T;
+	typedef typename Policy::SizeT			SizeT;
+
+	typedef typename Policy::Upsweep 		Upsweep;
+	typedef typename Policy::Spine 			Spine;
+	typedef typename Policy::Single			Single;
+
+	cudaError_t retval = cudaSuccess;
+	do {
+
+		// Make sure we have a valid policy
+		if (!Policy::VALID) {
+			retval = util::B40CPerror(cudaErrorInvalidConfiguration, "Enactor invalid policy", __FILE__, __LINE__);
+			break;
+		}
+
+		// Kernels
+		typename Policy::UpsweepKernelPtr UpsweepKernel = Policy::UpsweepKernel();
+
+		// Max CTA occupancy for the actual target device
+		int max_cta_occupancy;
+		if (retval = MaxCtaOccupancy(max_cta_occupancy, UpsweepKernel, Upsweep::THREADS)) break;
+
+		// Compute sweep grid size
+		int sweep_grid_size = GridSize(
+			Policy::OVERSUBSCRIBED_GRID_SIZE,
+			Upsweep::SCHEDULE_GRANULARITY,
+			max_cta_occupancy,
+			detail.num_elements,
+			detail.max_grid_size);
+
+		// Use single-CTA kernel instead of multi-pass if problem is small enough
+		if (detail.num_elements <= Single::TILE_ELEMENTS * 3) {
+			sweep_grid_size = 1;
+		}
+
+		// Compute spine elements: one element per CTA, rounded
+		// up to nearest spine tile size
+		int spine_elements = sweep_grid_size;
+
+		// Obtain a CTA work distribution
+		util::CtaWorkDistribution<SizeT> work;
+		work.template Init<Upsweep::LOG_SCHEDULE_GRANULARITY>(detail.num_elements, sweep_grid_size);
+
+		if (ENACTOR_DEBUG) {
+			if (sweep_grid_size > 1) {
+				PrintPassInfo<Upsweep, Spine>(work, spine_elements);
+			} else {
+				PrintPassInfo<Single>(work);
+			}
+		}
+
+		if (work.grid_size == 1) {
+
+			// Single-CTA, single-grid operation
+			typename Policy::SingleKernelPtr SingleKernel = Policy::SingleKernel();
+
+			SingleKernel<<<1, Single::THREADS, 0>>>(
+				detail.d_src,
+				detail.d_dest,
+				work.num_elements,
+				detail.reduction_op);
+
+			if (ENACTOR_DEBUG && (retval = util::B40CPerror(cudaThreadSynchronize(), "Enactor SingleKernel failed ", __FILE__, __LINE__, ENACTOR_DEBUG))) break;
+
+		} else {
+
+			// Upsweep-downsweep operation
+			typename Policy::SpineKernelPtr SpineKernel = Policy::SpineKernel();
+
+			// If we're work-stealing, make sure our work progress is set up
+			// for the next pass
+			if (Policy::Upsweep::WORK_STEALING) {
+				if (retval = work_progress.Setup()) break;
+			}
+
+			// Make sure our spine is big enough
+			if (retval = spine.Setup<T>(spine_elements)) break;
+
+			int dynamic_smem[2] = 	{0, 0};
+			int grid_size[2] = 		{work.grid_size, 1};
+
+			// Tuning option: make sure all kernels have the same overall smem allocation
+			if (Policy::UNIFORM_SMEM_ALLOCATION) if (retval = PadUniformSmem(dynamic_smem, UpsweepKernel, SpineKernel)) break;
+
+			// Tuning option: make sure that all kernels launch the same number of CTAs)
+			if (Policy::UNIFORM_GRID_SIZE) grid_size[1] = grid_size[0];
+
+			// Upsweep reduction into spine
+			UpsweepKernel<<<grid_size[0], Upsweep::THREADS, dynamic_smem[0]>>>(
+				detail.d_src,
+				(T*) spine(),
+				detail.reduction_op,
+				work,
+				work_progress);
+
+			if (ENACTOR_DEBUG && (retval = util::B40CPerror(cudaThreadSynchronize(), "Enactor UpsweepKernel failed ", __FILE__, __LINE__, ENACTOR_DEBUG))) break;
+
+			// Spine reduction
+			SpineKernel<<<grid_size[1], Spine::THREADS, dynamic_smem[1]>>>(
+				(T*) spine(),
+				detail.d_dest,
+				spine_elements,
+				detail.reduction_op);
+
+			if (ENACTOR_DEBUG && (retval = util::B40CPerror(cudaThreadSynchronize(), "Enactor SpineKernel failed ", __FILE__, __LINE__, ENACTOR_DEBUG))) break;
+		}
+	} while (0);
+
+	// Cleanup
+	if (retval) {
+		// We had an error, which means that the device counters may not be
+		// properly initialized for the next pass: reset them.
+		work_progress.HostReset();
+	}
+
+	return retval;
+}
+
+
+/**
+ * Enacts a reduction on the specified device data.
+ */
+template <typename Policy>
+cudaError_t Enactor::Reduce(
+	typename Policy::T *d_dest,
+	typename Policy::T *d_src,
+	typename Policy::SizeT num_elements,
+	typename Policy::ReductionOp reduction_op,
+	int max_grid_size)
+{
+	Detail<Policy> detail(
+		this, d_dest, d_src, num_elements, reduction_op, max_grid_size);
+
+	return EnactPass<Policy>(detail);
+}
+
+
+/**
+ * Enacts a reduction operation on the specified device data.
+ */
+template <
+	ProbSizeGenre PROB_SIZE_GENRE,
+	typename T,
+	typename SizeT,
+	typename ReductionOp>
+cudaError_t Enactor::Reduce(
+	T *d_dest,
+	T *d_src,
+	SizeT num_elements,
+	ReductionOp reduction_op,
+	int max_grid_size)
+{
+	typedef ProblemType<
+		T,
+		SizeT,
+		ReductionOp> ProblemType;
+
+	Detail<ProblemType> detail(
+		this, d_dest, d_src, num_elements, reduction_op, max_grid_size);
+
+	return util::ArchDispatch<
+		__B40C_CUDA_ARCH__,
+		PolicyResolver<PROB_SIZE_GENRE> >::Enact(detail, PtxVersion());
+}
+
+
+/**
+ * Enacts a reduction operation on the specified device data.
+ */
+template <
+	typename T,
+	typename SizeT,
+	typename ReductionOp>
+cudaError_t Enactor::Reduce(
+	T *d_dest,
+	T *d_src,
+	SizeT num_elements,
+	ReductionOp reduction_op,
+	int max_grid_size)
+{
+	return Reduce<UNKNOWN_SIZE>(
+		d_dest, d_src, num_elements, reduction_op, max_grid_size);
+}
+
+
+}// namespace reduction
+}// namespace b40c
+

--- a/include/b40c/reduction/kernel_policy.cuh
+++ b/include/b40c/reduction/kernel_policy.cuh
@@ -1,0 +1,136 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Configuration policy for reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+namespace b40c {
+namespace reduction {
+
+
+/**
+ * A detailed kernel configuration policy type that specializes kernel
+ * code for a specific reduction pass. It encapsulates our
+ * kernel-tuning parameters (they are reflected via the static fields).
+ *
+ * The kernel is specialized for problem-type, SM-version, etc. by declaring
+ * it with different performance-tuned parameterizations of this type.  By
+ * incorporating this type into the kernel code itself, we guide the compiler in
+ * expanding/unrolling the kernel code for specific architectures and problem
+ * types.
+ */
+template <
+	// ProblemType type parameters
+	typename ProblemType,
+
+	// Machine parameters
+	int CUDA_ARCH,
+	bool _CHECK_ALIGNMENT,
+
+	// Tunable parameters
+	int _MIN_CTA_OCCUPANCY,
+	int _LOG_THREADS,
+	int _LOG_LOAD_VEC_SIZE,
+	int _LOG_LOADS_PER_TILE,
+	util::io::ld::CacheModifier _READ_MODIFIER,
+	util::io::st::CacheModifier _WRITE_MODIFIER,
+	bool _WORK_STEALING,
+	int _LOG_SCHEDULE_GRANULARITY>
+
+struct KernelPolicy : ProblemType
+{
+	typedef typename ProblemType::T T;
+
+	static const util::io::ld::CacheModifier READ_MODIFIER 		= _READ_MODIFIER;
+	static const util::io::st::CacheModifier WRITE_MODIFIER 	= _WRITE_MODIFIER;
+
+	static const bool WORK_STEALING		= _WORK_STEALING;
+
+	enum {
+
+		LOG_THREADS 					= _LOG_THREADS,
+		THREADS							= 1 << LOG_THREADS,
+
+		LOG_LOAD_VEC_SIZE  				= _LOG_LOAD_VEC_SIZE,
+		LOAD_VEC_SIZE					= 1 << LOG_LOAD_VEC_SIZE,
+
+		LOG_LOADS_PER_TILE 				= _LOG_LOADS_PER_TILE,
+		LOADS_PER_TILE					= 1 << LOG_LOADS_PER_TILE,
+
+		LOG_LOAD_STRIDE					= LOG_THREADS + LOG_LOAD_VEC_SIZE,
+		LOAD_STRIDE						= 1 << LOG_LOAD_STRIDE,
+
+		LOG_WARPS						= LOG_THREADS - B40C_LOG_WARP_THREADS(CUDA_ARCH),
+		WARPS							= 1 << LOG_WARPS,
+
+		LOG_TILE_ELEMENTS_PER_THREAD	= LOG_LOAD_VEC_SIZE + LOG_LOADS_PER_TILE,
+		TILE_ELEMENTS_PER_THREAD		= 1 << LOG_TILE_ELEMENTS_PER_THREAD,
+
+		LOG_TILE_ELEMENTS 				= LOG_TILE_ELEMENTS_PER_THREAD + LOG_THREADS,
+		TILE_ELEMENTS					= 1 << LOG_TILE_ELEMENTS,
+
+		LOG_SCHEDULE_GRANULARITY		= _LOG_SCHEDULE_GRANULARITY,
+		SCHEDULE_GRANULARITY			= 1 << LOG_SCHEDULE_GRANULARITY,
+
+		CHECK_ALIGNMENT					= _CHECK_ALIGNMENT
+	};
+
+	/**
+	 * Shared memory structure
+	 */
+	struct SmemStorage
+	{
+		T reduction_tree[THREADS];
+
+		// Accessors
+		__device__ __forceinline__ T* ReductionTree() { return reduction_tree; }
+	};
+
+	enum {
+		// Total number of smem quads needed by this kernel
+		THREAD_OCCUPANCY				= B40C_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
+		SMEM_OCCUPANCY					= B40C_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+
+		MAX_CTA_OCCUPANCY  				= B40C_MIN(B40C_SM_CTAS(CUDA_ARCH), B40C_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY)),
+		MIN_CTA_OCCUPANCY				= _MIN_CTA_OCCUPANCY,
+
+		VALID							= (MAX_CTA_OCCUPANCY > 0),
+	};
+};
+
+} // namespace reduction
+} // namespace b40c
+

--- a/include/b40c/reduction/policy.cuh
+++ b/include/b40c/reduction/policy.cuh
@@ -1,0 +1,211 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Unified reduction policy
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/cta_work_progress.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+#include <b40c/reduction/kernel_policy.cuh>
+#include <b40c/reduction/upsweep/kernel.cuh>
+#include <b40c/reduction/spine/kernel.cuh>
+
+namespace b40c {
+namespace reduction {
+
+
+/**
+ * Unified reduction policy type.
+ *
+ * In addition to kernel tuning parameters that guide the kernel compilation for
+ * upsweep and spine kernels, this type includes enactor tuning parameters that
+ * define kernel-dispatch policy.  By encapsulating all of the kernel tuning policies,
+ * we assure operational consistency across all kernels.
+ */
+template <
+	// ProblemType type parameters
+	typename ProblemType,
+
+	// Machine parameters
+	int CUDA_ARCH,
+
+	// Common tunable params
+	util::io::ld::CacheModifier READ_MODIFIER,
+	util::io::st::CacheModifier WRITE_MODIFIER,
+	bool WORK_STEALING,
+	bool _UNIFORM_SMEM_ALLOCATION,
+	bool _UNIFORM_GRID_SIZE,
+	bool _OVERSUBSCRIBED_GRID_SIZE,
+
+	// Upsweep tunable params
+	int UPSWEEP_MIN_CTA_OCCUPANCY,
+	int UPSWEEP_LOG_THREADS,
+	int UPSWEEP_LOG_LOAD_VEC_SIZE,
+	int UPSWEEP_LOG_LOADS_PER_TILE,
+
+	// Spine tunable params
+	int SPINE_LOG_THREADS,
+	int SPINE_LOG_LOAD_VEC_SIZE,
+	int SPINE_LOG_LOADS_PER_TILE>
+
+struct Policy : ProblemType
+{
+	//---------------------------------------------------------------------
+	// Typedefs
+	//---------------------------------------------------------------------
+
+	typedef typename ProblemType::T 				T;
+	typedef typename ProblemType::SizeT 			SizeT;
+	typedef typename ProblemType::ReductionOp 		ReductionOp;
+
+	typedef void (*UpsweepKernelPtr)(T*, T*, ReductionOp, util::CtaWorkDistribution<SizeT>, util::CtaWorkProgress);
+	typedef void (*SpineKernelPtr)(T*, T*, SizeT, ReductionOp);
+	typedef void (*SingleKernelPtr)(T*, T*, SizeT, ReductionOp);
+
+	//---------------------------------------------------------------------
+	// Kernel Policies
+	//---------------------------------------------------------------------
+
+	/**
+	 * Kernel config for the upsweep reduction kernel
+	 */
+	typedef KernelPolicy <
+		ProblemType,
+		CUDA_ARCH,
+		true,								// Check alignment
+		UPSWEEP_MIN_CTA_OCCUPANCY,
+		UPSWEEP_LOG_THREADS,
+		UPSWEEP_LOG_LOAD_VEC_SIZE,
+		UPSWEEP_LOG_LOADS_PER_TILE,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		WORK_STEALING,
+		UPSWEEP_LOG_LOADS_PER_TILE + UPSWEEP_LOG_LOAD_VEC_SIZE + UPSWEEP_LOG_THREADS >
+			Upsweep;
+
+	/**
+	 * Kernel config for the spine reduction kernel
+	 */
+	typedef KernelPolicy <
+		ProblemType,
+		CUDA_ARCH,
+		false,								// Do not check alignment
+		1,									// Only a single-CTA grid
+		SPINE_LOG_THREADS,
+		SPINE_LOG_LOAD_VEC_SIZE,
+		SPINE_LOG_LOADS_PER_TILE,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		false,								// Workstealing makes no sense in a single-CTA grid
+		SPINE_LOG_LOADS_PER_TILE + SPINE_LOG_LOAD_VEC_SIZE + SPINE_LOG_THREADS>
+			Spine;
+
+	/**
+	 * Kernel config for a one-level pass using the spine reduction kernel
+	 */
+	typedef KernelPolicy <
+		ProblemType,
+		CUDA_ARCH,
+		true,								// Check alignment
+		1,									// Only a single-CTA grid
+		SPINE_LOG_THREADS,
+		SPINE_LOG_LOAD_VEC_SIZE,
+		SPINE_LOG_LOADS_PER_TILE,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		false,								// Workstealing makes no sense in a single-CTA grid
+		SPINE_LOG_LOADS_PER_TILE + SPINE_LOG_LOAD_VEC_SIZE + SPINE_LOG_THREADS>
+			Single;
+
+
+	//---------------------------------------------------------------------
+	// Kernel function pointer retrieval
+	//---------------------------------------------------------------------
+
+	static UpsweepKernelPtr UpsweepKernel() {
+		return upsweep::Kernel<Upsweep>;
+	}
+
+	static SpineKernelPtr SpineKernel() {
+		return spine::Kernel<Spine>;
+	}
+
+	static SingleKernelPtr SingleKernel() {
+		return spine::Kernel<Single>;
+	}
+
+	//---------------------------------------------------------------------
+	// Constants
+	//---------------------------------------------------------------------
+
+	enum {
+		UNIFORM_SMEM_ALLOCATION 	= _UNIFORM_SMEM_ALLOCATION,
+		UNIFORM_GRID_SIZE 			= _UNIFORM_GRID_SIZE,
+		OVERSUBSCRIBED_GRID_SIZE	= _OVERSUBSCRIBED_GRID_SIZE,
+		VALID 						= Upsweep::VALID & Spine::VALID
+	};
+
+
+	static void Print()
+	{
+		// ProblemType type parameters
+		printf("%d, ", sizeof(T));
+		printf("%d, ", sizeof(SizeT));
+		printf("%d, ", CUDA_ARCH);
+
+		// Common tunable params
+		printf("%s, ", CacheModifierToString(READ_MODIFIER));
+		printf("%s, ", CacheModifierToString(WRITE_MODIFIER));
+		printf("%s, ", (WORK_STEALING) ? "true" : "false");
+		printf("%s ", (_UNIFORM_SMEM_ALLOCATION) ? "true" : "false");
+		printf("%s ", (_UNIFORM_GRID_SIZE) ? "true" : "false");
+		printf("%s ", (_OVERSUBSCRIBED_GRID_SIZE) ? "true" : "false");
+
+		// Upsweep tunable params
+		printf("%d, ", UPSWEEP_MIN_CTA_OCCUPANCY);
+		printf("%d, ", UPSWEEP_LOG_THREADS);
+		printf("%d, ", UPSWEEP_LOG_LOAD_VEC_SIZE);
+		printf("%d, ", UPSWEEP_LOG_LOADS_PER_TILE);
+
+		// Spine tunable params
+		printf("%d, ", SPINE_LOG_THREADS);
+		printf("%d, ", SPINE_LOG_LOAD_VEC_SIZE);
+		printf("%d, ", SPINE_LOG_LOADS_PER_TILE);
+	}
+};
+		
+
+}// namespace reduction
+}// namespace b40c
+

--- a/include/b40c/reduction/problem_type.cuh
+++ b/include/b40c/reduction/problem_type.cuh
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Reduction problem type
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace reduction {
+
+
+/**
+ * Type of reduction problem
+ */
+template <
+	typename _T,
+	typename _SizeT,
+	typename _ReductionOp>
+struct ProblemType
+{
+	// The type of data we are operating upon
+	typedef _T T;
+
+	// The integer type we should use to index into data arrays (e.g., size_t, uint32, uint64, etc)
+	typedef _SizeT SizeT;
+
+	// The function or functor type for binary reduction (implements "T op(const T&, const T&)")
+	typedef _ReductionOp ReductionOp;
+};
+		
+
+}// namespace reduction
+}// namespace b40c
+

--- a/include/b40c/reduction/spine/kernel.cuh
+++ b/include/b40c/reduction/spine/kernel.cuh
@@ -1,0 +1,112 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Spine reduction kernel
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/reduction/cta.cuh>
+
+namespace b40c {
+namespace reduction {
+namespace spine {
+
+
+/**
+ * Spine reduction pass
+ */
+template <typename KernelPolicy>
+__device__ __forceinline__ void SpinePass(
+	typename KernelPolicy::T 			*d_in,
+	typename KernelPolicy::T 			*d_spine,
+	typename KernelPolicy::SizeT 		spine_elements,
+	typename KernelPolicy::ReductionOp	reduction_op,
+	typename KernelPolicy::SmemStorage	&smem_storage)
+{
+	typedef Cta<KernelPolicy> 				Cta;
+	typedef typename KernelPolicy::T 		T;
+	typedef typename KernelPolicy::SizeT 	SizeT;
+
+	// Exit if we're not the first CTA
+	if (blockIdx.x > 0) return;
+
+	// CTA processing abstraction
+	Cta cta(
+		smem_storage,
+		d_in,
+		d_spine,
+		reduction_op);
+
+	// Number of elements in (the last) partially-full tile (requires guarded loads)
+	SizeT guarded_elements = spine_elements & (KernelPolicy::TILE_ELEMENTS - 1);
+
+	// Offset of final, partially-full tile (requires guarded loads)
+	SizeT guarded_offset = spine_elements - guarded_elements;
+
+	util::CtaWorkLimits<SizeT> work_limits(
+		0,					// Offset at which this CTA begins processing
+		spine_elements,		// Total number of elements for this CTA to process
+		guarded_offset, 	// Offset of final, partially-full tile (requires guarded loads)
+		guarded_elements,	// Number of elements in partially-full tile
+		spine_elements,		// Offset at which this CTA is out-of-bounds
+		true);				// If this block is the last block in the grid with any work
+
+	cta.ProcessWorkRange(work_limits);
+}
+
+
+/**
+ * Spine reduction kernel entry point
+ */
+template <typename KernelPolicy>
+__launch_bounds__ (KernelPolicy::THREADS, KernelPolicy::MIN_CTA_OCCUPANCY)
+__global__ 
+void Kernel(
+	typename KernelPolicy::T 				*d_in,
+	typename KernelPolicy::T 				*d_spine,
+	typename KernelPolicy::SizeT 			spine_elements,
+	typename KernelPolicy::ReductionOp		reduction_op)
+
+{
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	SpinePass<KernelPolicy>(
+		d_in,
+		d_spine,
+		spine_elements,
+		reduction_op,
+		smem_storage);
+}
+
+} // namespace spine
+} // namespace reduction
+} // namespace b40c
+

--- a/include/b40c/reduction/upsweep/kernel.cuh
+++ b/include/b40c/reduction/upsweep/kernel.cuh
@@ -1,0 +1,205 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Upsweep reduction kernel
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/cta_work_progress.cuh>
+
+#include <b40c/reduction/cta.cuh>
+
+namespace b40c {
+namespace reduction {
+namespace upsweep {
+
+
+/**
+ * Atomically steal work from a global work progress construct
+ */
+template <typename SizeT>
+__device__ __forceinline__ SizeT StealWork(
+	util::CtaWorkProgress &work_progress,
+	int count)
+{
+	__shared__ SizeT s_offset;		// The offset at which this CTA performs tile processing, shared by all
+
+	// Thread zero atomically steals work from the progress counter
+	if (threadIdx.x == 0) {
+		s_offset = work_progress.Steal<SizeT>(count);
+	}
+
+	__syncthreads();		// Protect offset
+
+	return s_offset;
+}
+
+
+/**
+ * Upsweep reduction pass (non-workstealing specialization)
+ */
+template <typename KernelPolicy, bool WORK_STEALING = KernelPolicy::WORK_STEALING>
+struct UpsweepPass
+{
+	static __device__ __forceinline__ void Invoke(
+		typename KernelPolicy::T 									*d_in,
+		typename KernelPolicy::T 									*d_out,
+		typename KernelPolicy::ReductionOp							reduction_op,
+		util::CtaWorkDistribution<typename KernelPolicy::SizeT> 	&work_decomposition,
+		util::CtaWorkProgress 										&work_progress,
+		typename KernelPolicy::SmemStorage							&smem_storage)
+	{
+		typedef Cta<KernelPolicy> 				Cta;
+		typedef typename KernelPolicy::SizeT 	SizeT;
+
+		// CTA processing abstraction
+		Cta cta(
+			smem_storage,
+			d_in,
+			d_out,
+			reduction_op);
+
+		// Determine our threadblock's work range
+		util::CtaWorkLimits<SizeT> work_limits;
+		work_decomposition.template GetCtaWorkLimits<
+			KernelPolicy::LOG_TILE_ELEMENTS,
+			KernelPolicy::LOG_SCHEDULE_GRANULARITY>(work_limits);
+
+		cta.ProcessWorkRange(work_limits);
+	}
+};
+
+
+/**
+ * Upsweep reduction pass (workstealing specialization)
+ */
+template <typename KernelPolicy>
+struct UpsweepPass <KernelPolicy, true>
+{
+	static __device__ __forceinline__ void Invoke(
+		typename KernelPolicy::T 									*d_in,
+		typename KernelPolicy::T 									*d_out,
+		typename KernelPolicy::ReductionOp							reduction_op,
+		util::CtaWorkDistribution<typename KernelPolicy::SizeT> 	&work_decomposition,
+		util::CtaWorkProgress 										&work_progress,
+		typename KernelPolicy::SmemStorage							&smem_storage)
+	{
+		typedef Cta<KernelPolicy> 				Cta;
+		typedef typename KernelPolicy::SizeT 	SizeT;
+
+		// CTA processing abstraction
+		Cta cta(
+			smem_storage,
+			d_in,
+			d_out,
+			reduction_op);
+
+		// First CTA resets the work progress for the next pass
+		if ((blockIdx.x == 0) && (threadIdx.x == 0)) {
+			work_progress.template PrepResetSteal<SizeT>();
+		}
+
+		// Total number of elements in full tiles
+		SizeT unguarded_elements = work_decomposition.num_elements & (~(KernelPolicy::TILE_ELEMENTS - 1));
+
+		// Each CTA needs to process at least one partial block of
+		// input (otherwise our spine scan will be invalid)
+
+		SizeT offset = blockIdx.x << KernelPolicy::LOG_TILE_ELEMENTS;
+		if (offset < unguarded_elements) {
+
+			// Process our one full tile (first tile seen)
+			cta.template ProcessFullTile<true>(offset);
+
+			// Determine the swath we just did
+			SizeT swath = work_decomposition.grid_size << KernelPolicy::LOG_TILE_ELEMENTS;
+
+			// Worksteal subsequent full tiles, if any
+			while ((offset = StealWork<SizeT>(
+				work_progress,
+				KernelPolicy::TILE_ELEMENTS) + swath) < unguarded_elements)
+			{
+				cta.template ProcessFullTile<false>(offset);
+			}
+
+			// If the problem is big enough for the last CTA to be in this if-then-block,
+			// have it do the remaining guarded work (not first tile)
+			if (blockIdx.x == gridDim.x - 1) {
+				cta.template ProcessPartialTile<false>(unguarded_elements, work_decomposition.num_elements);
+			}
+
+			// Collectively reduce accumulated carry from each thread into output
+			// destination (all thread have valid reduction partials)
+			cta.OutputToSpine();
+
+		} else {
+
+			// Last CTA does any extra, guarded work (first tile seen)
+			cta.template ProcessPartialTile<true>(unguarded_elements, work_decomposition.num_elements);
+
+			// Collectively reduce accumulated carry from each thread into output
+			// destination (not every thread may have a valid reduction partial)
+			cta.OutputToSpine(work_decomposition.num_elements - unguarded_elements);
+		}
+	}
+};
+
+
+/**
+ * Upsweep reduction kernel entry point
+ */
+template <typename KernelPolicy>
+__launch_bounds__ (KernelPolicy::THREADS, KernelPolicy::MIN_CTA_OCCUPANCY)
+__global__
+void Kernel(
+	typename KernelPolicy::T 									*d_in,
+	typename KernelPolicy::T 									*d_spine,
+	typename KernelPolicy::ReductionOp							reduction_op,
+	util::CtaWorkDistribution<typename KernelPolicy::SizeT> 	work_decomposition,
+	util::CtaWorkProgress										work_progress)
+{
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	UpsweepPass<KernelPolicy>::Invoke(
+		d_in,
+		d_spine,
+		reduction_op,
+		work_decomposition,
+		work_progress,
+		smem_storage);
+}
+
+
+} // namespace upsweep
+} // namespace reduction
+} // namespace b40c
+

--- a/include/b40c/scan/autotuned_policy.cuh
+++ b/include/b40c/scan/autotuned_policy.cuh
@@ -1,0 +1,641 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Autotuned scan policy
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+#include <b40c/scan/upsweep/kernel.cuh>
+#include <b40c/scan/spine/kernel.cuh>
+#include <b40c/scan/downsweep/kernel.cuh>
+#include <b40c/scan/policy.cuh>
+
+namespace b40c {
+namespace scan {
+
+
+/******************************************************************************
+ * Genre enumerations to classify problems by
+ ******************************************************************************/
+
+/**
+ * Enumeration of problem-size genres that we may have tuned for
+ */
+enum ProbSizeGenre
+{
+	UNKNOWN_SIZE = -1,			// Not actually specialized on: the enactor should use heuristics to select another size genre
+	SMALL_SIZE,					// Tuned @ 128KB input
+	LARGE_SIZE					// Tuned @ 128MB input
+};
+
+
+/**
+ * Enumeration of architecture-family genres that we have tuned for below
+ */
+enum ArchGenre
+{
+	SM20 	= 200,
+	SM13	= 130,
+	SM10	= 100
+};
+
+
+/**
+ * Enumeration of type size genres
+ */
+enum TypeSizeGenre
+{
+	TINY_TYPE,
+	SMALL_TYPE,
+	MEDIUM_TYPE,
+	LARGE_TYPE
+};
+
+
+/**
+ * Autotuning policy genre, to be specialized
+ */
+template <
+	// Problem and machine types
+	typename ProblemType,
+	int CUDA_ARCH,
+
+	// Genres to specialize upon
+	ProbSizeGenre PROB_SIZE_GENRE,
+	ArchGenre ARCH_GENRE,
+	TypeSizeGenre TYPE_SIZE_GENRE,
+	TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre;
+
+
+/******************************************************************************
+ * Classifiers for identifying classification genres
+ ******************************************************************************/
+
+/**
+ * Classifies a given CUDA_ARCH into an architecture-family genre
+ */
+template <int CUDA_ARCH>
+struct ArchClassifier
+{
+	static const ArchGenre GENRE 			=	(CUDA_ARCH < SM13) ? SM10 :			// Haven't tuned for SM1.0 yet
+												(CUDA_ARCH < SM20) ? SM13 : SM20;
+};
+
+
+/**
+ * Classifies the problem type(s) into a type-size genre
+ */
+template <typename ProblemType>
+struct TypeSizeClassifier
+{
+	static const int ROUNDED_SIZE			= 1 << util::Log2<sizeof(typename ProblemType::T)>::VALUE;	// Round up to the nearest arch subword
+
+	static const TypeSizeGenre GENRE =		(ROUNDED_SIZE < 2) ? TINY_TYPE :
+											(ROUNDED_SIZE < 4) ? SMALL_TYPE :
+											(ROUNDED_SIZE < 8) ? MEDIUM_TYPE : LARGE_TYPE;
+};
+
+
+/**
+ * Classifies the pointer type into a type-size genre
+ */
+template <typename ProblemType>
+struct PointerSizeClassifier
+{
+	static const TypeSizeGenre GENRE 		= (sizeof(typename ProblemType::SizeT) < 8) ? MEDIUM_TYPE : LARGE_TYPE;
+};
+
+
+/**
+ * Autotuning policy classifier
+ */
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	ProbSizeGenre PROB_SIZE_GENRE>
+struct AutotunedClassifier :
+	AutotunedGenre<
+		ProblemType,
+		CUDA_ARCH,
+		PROB_SIZE_GENRE,
+		ArchClassifier<CUDA_ARCH>::GENRE,
+		TypeSizeClassifier<ProblemType>::GENRE,
+		PointerSizeClassifier<ProblemType>::GENRE>
+{};
+
+
+/******************************************************************************
+ * Autotuned genre specializations
+ ******************************************************************************/
+
+//-----------------------------------------------------------------------------
+// SM2.0 specializations(s)
+//-----------------------------------------------------------------------------
+
+// Large problems, 1B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM20, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, true, 11,
+	  0, 7, 2, 2, 5,
+	  7, 0, 2, 5,
+	  0, 7, 2, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 2B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM20, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, true, 10,
+	  0, 6, 2, 2, 5,
+	  6, 2, 2, 5,
+	  0, 6, 2, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 4B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM20, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, true, 9,
+      0, 5, 2, 2, 5,
+      6, 0, 0, 5,
+      0, 7, 1, 1, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// All other large problems (tuned at 8B)
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM20, LARGE_TYPE, POINTER_SIZE_GENRE>
+    : Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, false, 8,
+      0, 6, 1, 1, 5,
+      6, 0, 0, 5,
+      0, 7, 1, 0, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+
+// Small problems, 1B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM20, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, false, 11,
+	  0, 7, 2, 2, 5,
+	  6, 0, 0, 5,
+	  0, 7, 2, 1, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 2B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM20, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, false, 10,
+	  0, 6, 2, 2, 5,
+	  6, 0, 0, 5,
+	  0, 6, 2, 1, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 4B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM20, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, true, 9,
+	  0, 5, 2, 2, 5,
+	  6, 0, 0, 5,
+	  0, 7, 1, 1, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// All other small problems (tuned at 8B)
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM20, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM20, util::io::ld::NONE, util::io::st::NONE, false, false, false, 8,
+	  0, 6, 1, 1, 5,
+	  6, 0, 0, 5,
+	  0, 7, 1, 0, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+
+//-----------------------------------------------------------------------------
+// SM1.3 specializations(s)
+//-----------------------------------------------------------------------------
+
+// Large problems, 1B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM13, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, true, 11,
+	  0, 7, 2, 2, 5,
+	  6, 2, 1, 5,
+	  0, 7, 2, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 2B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM13, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, true, 10,
+	  0, 6, 1, 2, 5,
+	  8, 0, 0, 5,
+	  0, 6, 2, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 4B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM13, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, true, 9,
+	  0, 8, 0, 1, 5,
+	  8, 0, 0, 5,
+	  0, 8, 1, 0, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// All other Large problems
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM13, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, true, 8,
+	  0, 6, 0, 2, 5,
+	  6, 2, 0, 5,
+	  0, 7, 0, 1, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+
+
+// Small problems, 1B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM13, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, 10,
+	  0, 6, 2, 2, 5,
+	  7, 0, 0, 5,
+	  0, 6, 2, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 2B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM13, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, 9,
+	  0, 6, 2, 0, 5,
+	  6, 1, 0, 5,
+	  0, 6, 2, 1, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 4B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM13, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, 9,
+	  0, 7, 0, 2, 5,
+	  6, 0, 0, 5,
+	  0, 7, 0, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// All other Small problems
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM13, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM13, util::io::ld::NONE, util::io::st::NONE, false, false, false, 8,
+	  0, 6, 0, 2, 5,
+	  6, 0, 0, 5,
+	  0, 6, 1, 1, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+
+
+//-----------------------------------------------------------------------------
+// SM1.0 specializations(s)
+//-----------------------------------------------------------------------------
+
+// Large problems, 1B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM10, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, true, 10,
+	  0, 6, 2, 2, 5,
+	  7, 1, 0, 5,
+	  0, 6, 2, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 2B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM10, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, true, 10,
+	  0, 6, 1, 2, 5,
+	  8, 0, 1, 5,
+	  0, 7, 2, 1, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// Large problems, 4B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM10, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, true, 9,
+	  0, 7, 0, 1, 5,
+	  7, 0, 0, 5,
+	  0, 8, 1, 0, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+// All other Large problems
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, LARGE_SIZE, SM10, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, true, 8,
+	  0, 6, 0, 1, 5,
+	  8, 0, 0, 5,
+	  0, 7, 1, 0, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = LARGE_SIZE;
+};
+
+
+
+// Small problems, 1B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM10, TINY_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, 11,
+	  0, 7, 2, 2, 5,
+	  6, 0, 0, 5,
+	  0, 5, 2, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 2B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM10, SMALL_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, 11,
+	  0, 7, 2, 2, 5,
+	  5, 1, 0, 5,
+	  0, 5, 2, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// Small problems, 4B data
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM10, MEDIUM_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, 9,
+	  0, 7, 0, 2, 5,
+	  6, 0, 0, 5,
+	  0, 5, 1, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+// All other Small problems
+template <typename ProblemType, int CUDA_ARCH, TypeSizeGenre POINTER_SIZE_GENRE>
+struct AutotunedGenre<ProblemType, CUDA_ARCH, SMALL_SIZE, SM10, LARGE_TYPE, POINTER_SIZE_GENRE>
+	: Policy<ProblemType, SM10, util::io::ld::NONE, util::io::st::NONE, false, false, false, 8,
+	  0, 6, 0, 2, 5,
+	  6, 0, 0, 5,
+	  0, 5, 0, 2, 5>
+{
+	static const ProbSizeGenre PROB_SIZE_GENRE = SMALL_SIZE;
+};
+
+
+
+
+
+
+
+/******************************************************************************
+ * Scan kernel entry points that can derive a tuned granularity type
+ * implicitly from the PROB_SIZE_GENRE template parameter.  (As opposed to having
+ * the granularity type passed explicitly.)
+ *
+ * TODO: Section can be removed if CUDA Runtime is fixed to
+ * properly support template specialization around kernel call sites.
+ ******************************************************************************/
+
+/**
+ * Tuned upsweep reduction kernel entry point
+ */
+template <typename ProblemType, int PROB_SIZE_GENRE>
+__launch_bounds__ (
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Upsweep::THREADS),
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Upsweep::MIN_CTA_OCCUPANCY))
+__global__ void TunedUpsweepKernel(
+	typename ProblemType::T 									*d_in,
+	typename ProblemType::T 									*d_spine,
+	typename ProblemType::ReductionOp 							scan_op,
+	typename ProblemType::IdentityOp 							identity_op,
+	util::CtaWorkDistribution<typename ProblemType::SizeT> 		work_decomposition)
+{
+	// Load the kernel policy type identified by the enum for this architecture
+	typedef typename AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Upsweep KernelPolicy;
+
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	upsweep::UpsweepPass<KernelPolicy>::Invoke(
+		d_in,
+		d_spine,
+		scan_op,
+		identity_op,
+		work_decomposition,
+		smem_storage);
+}
+
+/**
+ * Tuned spine scan kernel entry point
+ */
+template <typename ProblemType, int PROB_SIZE_GENRE>
+__launch_bounds__ (
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Spine::THREADS),
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Spine::MIN_CTA_OCCUPANCY))
+__global__ void TunedSpineKernel(
+	typename ProblemType::T				*d_in,
+	typename ProblemType::T				*d_out,
+	typename ProblemType::SizeT 		spine_elements,
+	typename ProblemType::ReductionOp 	scan_op,
+	typename ProblemType::IdentityOp 	identity_op)
+{
+	// Load the kernel policy type identified by the enum for this architecture
+	typedef typename AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Spine KernelPolicy;
+
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	spine::SpinePass<KernelPolicy>(
+		d_in,
+		d_out,
+		spine_elements,
+		scan_op,
+		identity_op,
+		smem_storage);
+}
+
+
+/**
+ * Tuned downsweep scan kernel entry point
+ */
+template <typename ProblemType, int PROB_SIZE_GENRE>
+__launch_bounds__ (
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Downsweep::THREADS),
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Downsweep::MIN_CTA_OCCUPANCY))
+__global__ void TunedDownsweepKernel(
+	typename ProblemType::T 				*d_in,
+	typename ProblemType::T 				*d_out,
+	typename ProblemType::T 				*d_spine,
+	typename ProblemType::ReductionOp 		scan_op,
+	typename ProblemType::IdentityOp 		identity_op,
+	util::CtaWorkDistribution<typename ProblemType::SizeT> work_decomposition)
+{
+	// Load the kernel policy type identified by the enum for this architecture
+	typedef typename AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Downsweep KernelPolicy;
+
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	downsweep::DownsweepPass<KernelPolicy>(
+		d_in,
+		d_out,
+		d_spine,
+		scan_op,
+		identity_op,
+		work_decomposition,
+		smem_storage);
+}
+
+
+/**
+ * Tuned single scan kernel entry point
+ */
+template <typename ProblemType, int PROB_SIZE_GENRE>
+__launch_bounds__ (
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Single::THREADS),
+	(AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Single::MIN_CTA_OCCUPANCY))
+__global__ void TunedSingleKernel(
+	typename ProblemType::T				*d_in,
+	typename ProblemType::T				*d_out,
+	typename ProblemType::SizeT 		spine_elements,
+	typename ProblemType::ReductionOp 	scan_op,
+	typename ProblemType::IdentityOp 	identity_op)
+{
+	// Load the kernel policy type identified by the enum for this architecture
+	typedef typename AutotunedClassifier<ProblemType, __B40C_CUDA_ARCH__, (ProbSizeGenre) PROB_SIZE_GENRE>::Single KernelPolicy;
+
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	spine::SpinePass<KernelPolicy>(
+		d_in,
+		d_out,
+		spine_elements,
+		scan_op,
+		identity_op,
+		smem_storage);
+}
+
+
+/******************************************************************************
+ * Autotuned policy
+ *******************************************************************************/
+
+/**
+ * Autotuned policy type
+ */
+template <
+	typename ProblemType,
+	int CUDA_ARCH,
+	ProbSizeGenre PROB_SIZE_GENRE>
+struct AutotunedPolicy :
+	AutotunedClassifier<
+		ProblemType,
+		CUDA_ARCH,
+		PROB_SIZE_GENRE>
+{
+	//---------------------------------------------------------------------
+	// Typedefs
+	//---------------------------------------------------------------------
+
+	typedef typename ProblemType::T 			T;
+	typedef typename ProblemType::SizeT 		SizeT;
+	typedef typename ProblemType::ReductionOp 	ReductionOp;
+	typedef typename ProblemType::IdentityOp 	IdentityOp;
+
+	typedef void (*UpsweepKernelPtr)(T*, T*, ReductionOp, IdentityOp, util::CtaWorkDistribution<SizeT>);
+	typedef void (*SpineKernelPtr)(T*, T*, SizeT, ReductionOp, IdentityOp);
+	typedef void (*DownsweepKernelPtr)(T*, T*, T*, ReductionOp, IdentityOp, util::CtaWorkDistribution<SizeT>);
+	typedef void (*SingleKernelPtr)(T*, T*, SizeT, ReductionOp, IdentityOp);
+
+	//---------------------------------------------------------------------
+	// Kernel function pointer retrieval
+	//---------------------------------------------------------------------
+
+	static UpsweepKernelPtr UpsweepKernel() {
+		return TunedUpsweepKernel<ProblemType, PROB_SIZE_GENRE>;
+	}
+
+	static SpineKernelPtr SpineKernel() {
+		return TunedSpineKernel<ProblemType, PROB_SIZE_GENRE>;
+	}
+
+	static DownsweepKernelPtr DownsweepKernel() {
+		return TunedDownsweepKernel<ProblemType, PROB_SIZE_GENRE>;
+	}
+
+	static SingleKernelPtr SingleKernel() {
+		return TunedSingleKernel<ProblemType, PROB_SIZE_GENRE>;
+	}
+};
+
+
+
+
+}// namespace scan
+}// namespace b40c
+

--- a/include/b40c/scan/downsweep/cta.cuh
+++ b/include/b40c/scan/downsweep/cta.cuh
@@ -1,0 +1,203 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * CTA-processing functionality for scan kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+#include <b40c/util/io/load_tile.cuh>
+#include <b40c/util/io/store_tile.cuh>
+
+#include <b40c/util/scan/cooperative_scan.cuh>
+
+namespace b40c {
+namespace scan {
+namespace downsweep {
+
+
+/**
+ * Scan downsweep scan CTA
+ */
+template <typename KernelPolicy>
+struct Cta
+{
+	//---------------------------------------------------------------------
+	// Typedefs
+	//---------------------------------------------------------------------
+
+	typedef typename KernelPolicy::T 			T;
+	typedef typename KernelPolicy::SizeT 		SizeT;
+	typedef typename KernelPolicy::ReductionOp 	ReductionOp;
+	typedef typename KernelPolicy::IdentityOp 	IdentityOp;
+
+	typedef typename KernelPolicy::RakingDetails 	RakingDetails;
+	typedef typename KernelPolicy::SmemStorage	SmemStorage;
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Running partial accumulated by the CTA over its tile-processing
+	// lifetime (managed in each raking thread)
+	T carry;
+
+	// Input and output device pointers
+	T *d_in;
+	T *d_out;
+
+	// Scan operator
+	ReductionOp scan_op;
+
+	// Operational details for raking scan grid
+	RakingDetails raking_details;
+
+
+	//---------------------------------------------------------------------
+	// Methods
+	//---------------------------------------------------------------------
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ Cta(
+		SmemStorage 		&smem_storage,
+		T 					*d_in,
+		T 					*d_out,
+		ReductionOp 		scan_op,
+		IdentityOp 			identity_op) :
+
+			raking_details(
+				smem_storage.RakingElements(),
+				smem_storage.warpscan,
+				identity_op()),
+			d_in(d_in),
+			d_out(d_out),
+			scan_op(scan_op),
+			carry(identity_op()) {}			// Seed carry with identity
+
+	/**
+	 * Constructor with spine partial for seeding with
+	 */
+	__device__ __forceinline__ Cta(
+		SmemStorage 		&smem_storage,
+		T 					*d_in,
+		T 					*d_out,
+		ReductionOp 		scan_op,
+		IdentityOp 			identity_op,
+		T 					spine_partial) :
+
+			raking_details(
+				smem_storage.RakingElements(),
+				smem_storage.warpscan,
+				identity_op()),
+			d_in(d_in),
+			d_out(d_out),
+			scan_op(scan_op),
+			carry(spine_partial) {}			// Seed carry with spine partial
+
+
+	/**
+	 * Process a single tile
+	 */
+	__device__ __forceinline__ void ProcessTile(
+		SizeT cta_offset,
+		const SizeT &guarded_elements = KernelPolicy::TILE_ELEMENTS)
+	{
+		// Tile of scan elements
+		T partials[KernelPolicy::LOADS_PER_TILE][KernelPolicy::LOAD_VEC_SIZE];
+
+		// Load tile
+		util::io::LoadTile<
+			KernelPolicy::LOG_LOADS_PER_TILE,
+			KernelPolicy::LOG_LOAD_VEC_SIZE,
+			KernelPolicy::THREADS,
+			KernelPolicy::READ_MODIFIER,
+			KernelPolicy::CHECK_ALIGNMENT>::LoadValid(
+				partials,
+				d_in,
+				cta_offset,
+				guarded_elements);
+
+		// Scan tile with carry update in raking threads
+		util::scan::CooperativeTileScan<
+			KernelPolicy::LOAD_VEC_SIZE,
+			KernelPolicy::EXCLUSIVE>::ScanTileWithCarry(
+				raking_details,
+				partials,
+				carry,
+				scan_op);
+
+		// Store tile
+		util::io::StoreTile<
+			KernelPolicy::LOG_LOADS_PER_TILE,
+			KernelPolicy::LOG_LOAD_VEC_SIZE,
+			KernelPolicy::THREADS,
+			KernelPolicy::WRITE_MODIFIER,
+			KernelPolicy::CHECK_ALIGNMENT>::Store(
+				partials,
+				d_out,
+				cta_offset,
+				guarded_elements);
+	}
+
+
+	/**
+	 * Process work range of tiles
+	 */
+	__device__ __forceinline__ void ProcessWorkRange(
+		util::CtaWorkLimits<SizeT> &work_limits)
+	{
+		// Make sure we get a local copy of the cta's offset (work_limits may be in smem)
+		SizeT cta_offset = work_limits.offset;
+
+		// Process full tiles of tile_elements
+		while (cta_offset < work_limits.guarded_offset) {
+
+			ProcessTile(cta_offset);
+			cta_offset += KernelPolicy::TILE_ELEMENTS;
+		}
+
+		// Clean up last partial tile with guarded-io
+		if (work_limits.guarded_elements) {
+			ProcessTile(
+				cta_offset,
+				work_limits.guarded_elements);
+		}
+	}
+
+};
+
+
+} // namespace downsweep
+} // namespace scan
+} // namespace b40c
+

--- a/include/b40c/scan/downsweep/kernel.cuh
+++ b/include/b40c/scan/downsweep/kernel.cuh
@@ -1,0 +1,116 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Scan downsweep scan kernel
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/srts_details.cuh>
+
+#include <b40c/scan/downsweep/cta.cuh>
+
+namespace b40c {
+namespace scan {
+namespace downsweep {
+
+
+/**
+ * Scan downsweep scan pass
+ */
+template <typename KernelPolicy>
+__device__ __forceinline__ void DownsweepPass(
+	typename KernelPolicy::T 									*d_in,
+	typename KernelPolicy::T 									*d_out,
+	typename KernelPolicy::T 									*d_spine,
+	typename KernelPolicy::ReductionOp 							scan_op,
+	typename KernelPolicy::IdentityOp 							identity_op,
+	util::CtaWorkDistribution<typename KernelPolicy::SizeT> 	&work_decomposition,
+	typename KernelPolicy::SmemStorage							&smem_storage)
+{
+	typedef Cta<KernelPolicy> 				Cta;
+	typedef typename KernelPolicy::T 		T;
+	typedef typename KernelPolicy::SizeT 	SizeT;
+
+	// Obtain exclusive spine partial
+	T spine_partial;
+	util::io::ModifiedLoad<KernelPolicy::READ_MODIFIER>::Ld(
+		spine_partial, d_spine + blockIdx.x);
+
+	// CTA processing abstraction
+	Cta cta(
+		smem_storage,
+		d_in,
+		d_out,
+		scan_op,
+		identity_op,
+		spine_partial);
+
+	// Determine our threadblock's work range
+	util::CtaWorkLimits<SizeT> work_limits;
+	work_decomposition.template GetCtaWorkLimits<
+		KernelPolicy::LOG_TILE_ELEMENTS,
+		KernelPolicy::LOG_SCHEDULE_GRANULARITY>(work_limits);
+
+	cta.ProcessWorkRange(work_limits);
+}
+
+
+/**
+ * Scan downsweep scan kernel entry point
+ */
+template <typename KernelPolicy>
+__launch_bounds__ (KernelPolicy::THREADS, KernelPolicy::MIN_CTA_OCCUPANCY)
+__global__
+void Kernel(
+	typename KernelPolicy::T 				*d_in,
+	typename KernelPolicy::T 				*d_out,
+	typename KernelPolicy::T 				*d_spine,
+	typename KernelPolicy::ReductionOp 		scan_op,
+	typename KernelPolicy::IdentityOp 		identity_op,
+	util::CtaWorkDistribution<typename KernelPolicy::SizeT> work_decomposition)
+{
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	DownsweepPass<KernelPolicy>(
+		d_in,
+		d_out,
+		d_spine,
+		scan_op,
+		identity_op,
+		work_decomposition,
+		smem_storage);
+}
+
+} // namespace downsweep
+} // namespace scan
+} // namespace b40c
+

--- a/include/b40c/scan/enactor.cuh
+++ b/include/b40c/scan/enactor.cuh
@@ -1,0 +1,561 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Scan enactor
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/enactor_base.cuh>
+#include <b40c/util/error_utils.cuh>
+#include <b40c/util/spine.cuh>
+#include <b40c/util/arch_dispatch.cuh>
+
+#include <b40c/scan/problem_type.cuh>
+#include <b40c/scan/policy.cuh>
+#include <b40c/scan/autotuned_policy.cuh>
+#include <b40c/scan/downsweep/kernel.cuh>
+#include <b40c/scan/spine/kernel.cuh>
+#include <b40c/scan/upsweep/kernel.cuh>
+
+namespace b40c {
+namespace scan {
+
+
+/**
+ * Scan enactor class.
+ */
+class Enactor : public util::EnactorBase
+{
+protected:
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Temporary device storage needed for reducing partials produced
+	// by separate CTAs
+	util::Spine spine;
+
+
+	//-----------------------------------------------------------------------------
+	// Helper structures
+	//-----------------------------------------------------------------------------
+
+	template <typename ProblemType>
+	friend class Detail;
+
+
+	//-----------------------------------------------------------------------------
+	// Utility Routines
+	//-----------------------------------------------------------------------------
+
+    /**
+	 * Performs a scan pass
+	 */
+	template <typename Policy, typename Detail>
+	cudaError_t EnactPass(Detail &detail);
+
+
+public:
+
+	/**
+	 * Constructor
+	 */
+	Enactor() {}
+
+
+	/**
+	 * Enacts a scan operation on the specified device data.  Uses
+	 * a heuristic for selecting an autotuning policy based upon problem size.
+	 *
+	 * @param d_dest
+	 * 		Pointer to result location
+	 * @param d_src
+	 * 		Pointer to array of elements to be scanned
+	 * @param num_elements
+	 * 		Number of elements in d_src
+	 * @param scan_op
+	 * 		The function or functor type for binary scan, i.e., a type instance
+	 * 		that implements "T (const T&, const T&)"
+	 * @param identity_op
+	 * 		The function or functor type for the scan identity, i.e., a type instance
+	 * 		that implements "T ()"
+	 * @param max_grid_size
+	 * 		Optional upper-bound on the number of CTAs to launch.
+	 *
+	 * @return cudaSuccess on success, error enumeration otherwise
+	 */
+	template <
+		bool EXCLUSIVE,				// Whether or not to perform an exclusive (vs. inclusive) prefix scan
+		bool COMMUTATIVE,		// Whether or not the associative scan operator is non-commuatative (the commutative-only implementation is generally faster)
+		typename T,
+		typename SizeT,
+		typename ReductionOp,
+		typename IdentityOp>
+	cudaError_t Scan(
+		T *d_dest,
+		T *d_src,
+		SizeT num_elements,
+		ReductionOp scan_op,
+		IdentityOp identity_op,
+		int max_grid_size = 0);
+
+
+	/**
+	 * Enacts a scan operation on the specified device data.  Uses the
+	 * specified problem size genre enumeration to select autotuning policy.
+	 *
+	 * (Using this entrypoint can save compile time by not compiling tuned
+	 * kernels for each problem size genre.)
+	 *
+	 * @param d_dest
+	 * 		Pointer to result location
+	 * @param d_src
+	 * 		Pointer to array of elements to be scanned
+	 * @param num_elements
+	 * 		Number of elements in d_src
+	 * @param scan_op
+	 * 		The function or functor type for binary scan, i.e., a type instance
+	 * 		that implements "T (const T&, const T&)"
+	 * @param identity_op
+	 * 		The function or functor type for the scan identity, i.e., a type instance
+	 * 		that implements "T ()"
+	 * @param max_grid_size
+	 * 		Optional upper-bound on the number of CTAs to launch.
+	 *
+	 * @return cudaSuccess on success, error enumeration otherwise
+	 */
+	template <
+		bool EXCLUSIVE,				// Whether or not to perform an exclusive (vs. inclusive) prefix scan
+		bool COMMUTATIVE,		// Whether or not the associative scan operator is non-commuatative (the commutative-only implementation is generally faster)
+		ProbSizeGenre PROB_SIZE_GENRE,
+		typename T,
+		typename SizeT,
+		typename ReductionOp,
+		typename IdentityOp>
+	cudaError_t Scan(
+		T *d_dest,
+		T *d_src,
+		SizeT num_elements,
+		ReductionOp scan_op,
+		IdentityOp identity_op,
+		int max_grid_size = 0);
+
+
+	/**
+	 * Enacts a scan on the specified device data.  Uses the specified
+	 * kernel configuration policy.  (Useful for auto-tuning.)
+	 *
+	 * @param d_dest
+	 * 		Pointer to result location
+	 * @param d_src
+	 * 		Pointer to array of elements to be scanned
+	 * @param num_elements
+	 * 		Number of elements in d_src
+	 * @param scan_op
+	 * 		The function or functor type for binary scan, i.e., a type instance
+	 * 		that implements "T (const T&, const T&)"
+	 * @param identity_op
+	 * 		The function or functor type for the scan identity, i.e., a type instance
+	 * 		that implements "T ()"
+	 * @param max_grid_size
+	 * 		Optional upper-bound on the number of CTAs to launch.
+	 * @return cudaSuccess on success, error enumeration otherwise
+	 */
+	template <typename Policy>
+	cudaError_t Scan(
+		typename Policy::T *d_dest,
+		typename Policy::T *d_src,
+		typename Policy::SizeT num_elements,
+		typename Policy::ReductionOp scan_op,
+		typename Policy::IdentityOp identity_op,
+		int max_grid_size = 0);
+};
+
+
+
+/******************************************************************************
+ * Helper structures
+ ******************************************************************************/
+
+/**
+ * Type for encapsulating operational details regarding an invocation
+ */
+template <typename ProblemType>
+struct Detail : ProblemType
+{
+	typedef typename ProblemType::T 			T;
+	typedef typename ProblemType::SizeT 		SizeT;
+	typedef typename ProblemType::ReductionOp 	ReductionOp;
+	typedef typename ProblemType::IdentityOp 	IdentityOp;
+
+	Enactor 		*enactor;
+	T 				*d_dest;
+	T 				*d_src;
+	SizeT 			num_elements;
+	ReductionOp		scan_op;
+	IdentityOp		identity_op;
+	int 			max_grid_size;
+
+	// Constructor
+	Detail(
+		Enactor 		*enactor,
+		T 				*d_dest,
+		T 				*d_src,
+		SizeT 			num_elements,
+		ReductionOp		scan_op,
+		IdentityOp		identity_op,
+		int 			max_grid_size = 0) :
+			enactor(enactor),
+			d_dest(d_dest),
+			d_src(d_src),
+			num_elements(num_elements),
+			scan_op(scan_op),
+			identity_op(identity_op),
+			max_grid_size(max_grid_size)
+	{}
+
+	template <typename Policy>
+	cudaError_t EnactPass()
+	{
+		return enactor->template EnactPass<Policy>(*this);
+	}
+};
+
+
+/**
+ * Helper structure for resolving and enacting tuning configurations
+ *
+ * Default specialization for problem type genres
+ */
+template <ProbSizeGenre PROB_SIZE_GENRE>
+struct PolicyResolver
+{
+	/**
+	 * ArchDispatch call-back with static CUDA_ARCH
+	 */
+	template <int CUDA_ARCH, typename Detail>
+	static cudaError_t Enact(Detail &detail)
+	{
+		// Obtain tuned granularity type
+		typedef AutotunedPolicy<
+			Detail,
+			CUDA_ARCH,
+			PROB_SIZE_GENRE> AutotunedPolicy;
+
+		// Invoke enactor with type
+		return detail.template EnactPass<AutotunedPolicy>();
+	}
+};
+
+
+/**
+ * Helper structure for resolving and enacting tuning configurations
+ *
+ * Specialization for UNKNOWN problem type to select other problem type genres
+ * based upon problem size, etc.
+ */
+template <>
+struct PolicyResolver <UNKNOWN_SIZE>
+{
+	/**
+	 * ArchDispatch call-back with static CUDA_ARCH
+	 */
+	template <int CUDA_ARCH, typename Detail>
+	static cudaError_t Enact(Detail &detail)
+	{
+		// Obtain large tuned granularity type
+		typedef AutotunedPolicy<
+			Detail,
+			CUDA_ARCH,
+			LARGE_SIZE> LargePolicy;
+
+		// Identify the maximum problem size for which we can saturate loads
+		int saturating_load = LargePolicy::Upsweep::TILE_ELEMENTS *
+			B40C_SM_CTAS(CUDA_ARCH) *
+			detail.enactor->SmCount();
+
+		if (detail.num_elements < saturating_load) {
+
+			// Invoke enactor with small-problem config type
+			typedef AutotunedPolicy<
+				Detail,
+				CUDA_ARCH,
+				SMALL_SIZE> SmallPolicy;
+
+			return detail.template EnactPass<SmallPolicy>();
+		}
+
+		// Invoke enactor with type
+		return detail.template EnactPass<LargePolicy>();
+	}
+};
+
+
+/******************************************************************************
+ * Enactor Implementation
+ ******************************************************************************/
+
+
+/**
+ * Performs a scan pass
+ */
+template <typename Policy, typename DetailType>
+cudaError_t Enactor::EnactPass(DetailType &detail)
+{
+	typedef typename Policy::T 				T;
+	typedef typename Policy::SizeT 			SizeT;
+	typedef typename Policy::ReductionOp 	ReductionOp;
+	typedef typename Policy::IdentityOp 	IdentityOp;
+
+	typedef typename Policy::Upsweep 	Upsweep;
+	typedef typename Policy::Spine 		Spine;
+	typedef typename Policy::Downsweep 	Downsweep;
+	typedef typename Policy::Single 	Single;
+
+	cudaError_t retval = cudaSuccess;
+	do {
+
+		// Make sure we have a valid policy
+		if (!Policy::VALID) {
+			retval = util::B40CPerror(cudaErrorInvalidConfiguration, "Enactor invalid policy", __FILE__, __LINE__);
+			break;
+		}
+
+		// Kernels
+		typename Policy::UpsweepKernelPtr UpsweepKernel = Policy::UpsweepKernel();
+		typename Policy::DownsweepKernelPtr DownsweepKernel = Policy::DownsweepKernel();
+
+		// Max CTA occupancy for the actual target device
+		int max_cta_occupancy;
+		if (retval = MaxCtaOccupancy(
+			max_cta_occupancy,
+			UpsweepKernel,
+			Upsweep::THREADS,
+			DownsweepKernel,
+			Downsweep::THREADS)) break;
+
+		// Compute sweep grid size
+		int sweep_grid_size = GridSize(
+			Policy::OVERSUBSCRIBED_GRID_SIZE,
+			Upsweep::SCHEDULE_GRANULARITY,
+			max_cta_occupancy,
+			detail.num_elements,
+			detail.max_grid_size);
+
+		// Use single-CTA kernel instead of multi-pass if problem is small enough
+		if (detail.num_elements <= Single::TILE_ELEMENTS * 3) {
+			sweep_grid_size = 1;
+		}
+
+		// Compute spine elements: one element per CTA, rounded
+		// up to nearest spine tile size
+		int spine_elements = ((sweep_grid_size + Spine::TILE_ELEMENTS - 1) / Spine::TILE_ELEMENTS) * Spine::TILE_ELEMENTS;
+
+		// Obtain a CTA work distribution
+		util::CtaWorkDistribution<SizeT> work;
+		work.template Init<Downsweep::LOG_SCHEDULE_GRANULARITY>(detail.num_elements, sweep_grid_size);
+
+		if (ENACTOR_DEBUG) {
+			if (sweep_grid_size > 1) {
+				PrintPassInfo<Upsweep, Spine, Downsweep>(work, spine_elements);
+			} else {
+				PrintPassInfo<Single>(work);
+			}
+		}
+
+		if (work.grid_size == 1) {
+
+			// Single-CTA, single-grid operation
+			typename Policy::SingleKernelPtr SingleKernel = Policy::SingleKernel();
+
+			SingleKernel<<<1, Single::THREADS, 0>>>(
+				detail.d_src,
+				detail.d_dest,
+				work.num_elements,
+				detail.scan_op,
+				detail.identity_op);
+
+			if (ENACTOR_DEBUG && (retval = util::B40CPerror(cudaThreadSynchronize(), "Enactor SingleKernel failed ", __FILE__, __LINE__, ENACTOR_DEBUG))) break;
+
+		} else {
+
+			// Upsweep-downsweep operation
+			typename Policy::SpineKernelPtr SpineKernel = Policy::SpineKernel();
+
+			// Make sure our spine is big enough
+			if (retval = spine.Setup<T>(spine_elements)) break;
+
+			int dynamic_smem[3] = 	{0, 0, 0};
+			int grid_size[3] = 		{work.grid_size, 1, work.grid_size};
+
+			// Tuning option: make sure all kernels have the same overall smem allocation
+			if (Policy::UNIFORM_SMEM_ALLOCATION) if (retval = PadUniformSmem(dynamic_smem, UpsweepKernel, SpineKernel, DownsweepKernel)) break;
+
+			// Tuning option: make sure that all kernels launch the same number of CTAs)
+			if (Policy::UNIFORM_GRID_SIZE) grid_size[1] = grid_size[0];
+
+			// Upsweep into spine
+			UpsweepKernel<<<grid_size[0], Upsweep::THREADS, dynamic_smem[0]>>>(
+				detail.d_src,
+				(T*) spine(),
+				detail.scan_op,
+				detail.identity_op,
+				work);
+
+			if (ENACTOR_DEBUG && (retval = util::B40CPerror(cudaThreadSynchronize(), "Enactor UpsweepKernel failed ", __FILE__, __LINE__, ENACTOR_DEBUG))) break;
+
+			// Spine scan
+			SpineKernel<<<grid_size[1], Spine::THREADS, dynamic_smem[1]>>>(
+				(T*) spine(),
+				(T*) spine(),
+				spine_elements,
+				detail.scan_op,
+				detail.identity_op);
+
+			if (ENACTOR_DEBUG && (retval = util::B40CPerror(cudaThreadSynchronize(), "Enactor SpineKernel failed ", __FILE__, __LINE__, ENACTOR_DEBUG))) break;
+
+			// Downsweep from spine
+			DownsweepKernel<<<grid_size[2], Downsweep::THREADS, dynamic_smem[2]>>>(
+				detail.d_src,
+				detail.d_dest,
+				(T*) spine(),
+				detail.scan_op,
+				detail.identity_op,
+				work);
+
+			if (ENACTOR_DEBUG && (retval = util::B40CPerror(cudaThreadSynchronize(), "Enactor DownsweepKernel failed ", __FILE__, __LINE__, ENACTOR_DEBUG))) break;
+		}
+	} while (0);
+
+	return retval;
+}
+
+
+/**
+ * Enacts a scan on the specified device data.
+ */
+template <typename Policy>
+cudaError_t Enactor::Scan(
+	typename Policy::T *d_dest,
+	typename Policy::T *d_src,
+	typename Policy::SizeT num_elements,
+	typename Policy::ReductionOp scan_op,
+	typename Policy::IdentityOp identity_op,
+	int max_grid_size)
+{
+	Detail<Policy> detail(
+		this,
+		d_dest,
+		d_src,
+		num_elements,
+		scan_op,
+		identity_op,
+		max_grid_size);
+
+	return EnactPass<Policy>(detail);
+}
+
+
+/**
+ * Enacts a scan operation on the specified device data.
+ */
+template <
+	bool EXCLUSIVE,
+	bool COMMUTATIVE,
+	ProbSizeGenre PROB_SIZE_GENRE,
+	typename T,
+	typename SizeT,
+	typename ReductionOp,
+	typename IdentityOp>
+cudaError_t Enactor::Scan(
+	T *d_dest,
+	T *d_src,
+	SizeT num_elements,
+	ReductionOp scan_op,
+	IdentityOp identity_op,
+	int max_grid_size)
+{
+	typedef ProblemType<
+		T,
+		SizeT,
+		ReductionOp,
+		IdentityOp,
+		EXCLUSIVE,
+		COMMUTATIVE> ProblemType;
+
+	Detail<ProblemType> detail(
+		this,
+		d_dest,
+		d_src,
+		num_elements,
+		scan_op,
+		identity_op,
+		max_grid_size);
+
+	return util::ArchDispatch<
+		__B40C_CUDA_ARCH__,
+		PolicyResolver<PROB_SIZE_GENRE> >::Enact(detail, PtxVersion());
+}
+
+
+/**
+ * Enacts a scan operation on the specified device data.
+ */
+template <
+	bool EXCLUSIVE,
+	bool COMMUTATIVE,
+	typename T,
+	typename SizeT,
+	typename ReductionOp,
+	typename IdentityOp>
+cudaError_t Enactor::Scan(
+	T *d_dest,
+	T *d_src,
+	SizeT num_elements,
+	ReductionOp scan_op,
+	IdentityOp identity_op,
+	int max_grid_size)
+{
+	return Scan<EXCLUSIVE, COMMUTATIVE, UNKNOWN_SIZE>(
+		d_dest,
+		d_src,
+		num_elements,
+		scan_op,
+		identity_op,
+		max_grid_size);
+}
+
+
+
+
+} // namespace scan 
+} // namespace b40c
+

--- a/include/b40c/scan/kernel_policy.cuh
+++ b/include/b40c/scan/kernel_policy.cuh
@@ -1,0 +1,161 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Configuration policy for scan kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/srts_grid.cuh>
+#include <b40c/util/srts_details.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+namespace b40c {
+namespace scan {
+
+
+/**
+ * A detailed kernel configuration policy type that specializes kernel
+ * code for a specific pass. It encapsulates our
+ * kernel-tuning parameters (they are reflected via the static fields).
+ *
+ * The kernel is specialized for problem-type, SM-version, etc. by declaring
+ * it with different performance-tuned parameterizations of this type.  By
+ * incorporating this type into the kernel code itself, we guide the compiler in
+ * expanding/unrolling the kernel code for specific architectures and problem
+ * types.
+ */
+template <
+	// ProblemType type parameters
+	typename ProblemType,
+
+	// Machine parameters
+	int CUDA_ARCH,
+	bool _CHECK_ALIGNMENT,
+
+	// Tunable parameters
+	int _MIN_CTA_OCCUPANCY,
+	int _LOG_THREADS,
+	int _LOG_LOAD_VEC_SIZE,
+	int _LOG_LOADS_PER_TILE,
+	int _LOG_RAKING_THREADS,
+	util::io::ld::CacheModifier _READ_MODIFIER,
+	util::io::st::CacheModifier _WRITE_MODIFIER,
+	int _LOG_SCHEDULE_GRANULARITY>
+
+struct KernelPolicy : ProblemType
+{
+	typedef typename ProblemType::T T;
+
+	static const util::io::ld::CacheModifier READ_MODIFIER 		= _READ_MODIFIER;
+	static const util::io::st::CacheModifier WRITE_MODIFIER 	= _WRITE_MODIFIER;
+
+	enum {
+		LOG_THREADS 					= _LOG_THREADS,
+		THREADS							= 1 << LOG_THREADS,
+
+		LOG_LOAD_VEC_SIZE  				= _LOG_LOAD_VEC_SIZE,
+		LOAD_VEC_SIZE					= 1 << LOG_LOAD_VEC_SIZE,
+
+		LOG_LOADS_PER_TILE 				= _LOG_LOADS_PER_TILE,
+		LOADS_PER_TILE					= 1 << LOG_LOADS_PER_TILE,
+
+		LOG_LOAD_STRIDE					= LOG_THREADS + LOG_LOAD_VEC_SIZE,
+		LOAD_STRIDE						= 1 << LOG_LOAD_STRIDE,
+
+		LOG_RAKING_THREADS				= _LOG_RAKING_THREADS,
+		RAKING_THREADS					= 1 << LOG_RAKING_THREADS,
+
+		LOG_WARPS						= LOG_THREADS - B40C_LOG_WARP_THREADS(CUDA_ARCH),
+		WARPS							= 1 << LOG_WARPS,
+
+		LOG_TILE_ELEMENTS_PER_THREAD	= LOG_LOAD_VEC_SIZE + LOG_LOADS_PER_TILE,
+		TILE_ELEMENTS_PER_THREAD		= 1 << LOG_TILE_ELEMENTS_PER_THREAD,
+
+		LOG_TILE_ELEMENTS 				= LOG_TILE_ELEMENTS_PER_THREAD + LOG_THREADS,
+		TILE_ELEMENTS					= 1 << LOG_TILE_ELEMENTS,
+
+		LOG_SCHEDULE_GRANULARITY		= _LOG_SCHEDULE_GRANULARITY,
+		SCHEDULE_GRANULARITY			= 1 << LOG_SCHEDULE_GRANULARITY,
+
+		CHECK_ALIGNMENT					= _CHECK_ALIGNMENT
+	};
+
+
+	// Raking grid type
+	typedef util::RakingGrid<
+		CUDA_ARCH,
+		T,										// Partial type
+		LOG_THREADS,							// Depositing threads (the CTA size)
+		LOG_LOADS_PER_TILE,						// Lanes (the number of loads)
+		LOG_RAKING_THREADS,						// Raking threads
+		true>									// There are prefix dependences between lanes
+			RakingGrid;
+
+
+	// Operational details type for raking grid type
+	typedef util::RakingDetails<RakingGrid> RakingDetails;
+
+
+	/**
+	 * Shared memory structure
+	 */
+	struct SmemStorage
+	{
+		T 			warpscan[2][B40C_WARP_THREADS(CUDA_ARCH)];
+
+		__align__(16)
+		union {																			// Repurposable storage (complexity added b/c non-default-constructible types are not allowed in C++ unions)
+			char	raking_elements[sizeof(T[RakingGrid::TOTAL_RAKING_ELEMENTS])];		// Raking raking elements
+			char	reduction_tree[sizeof(T[THREADS])];									// Binary reduction tree
+		} pool;
+
+		// Accessors
+		__device__ __forceinline__ T* RakingElements() { return (T*) pool.raking_elements; }
+		__device__ __forceinline__ T* ReductionTree() { return (T*) pool.reduction_tree; }
+
+	};
+
+
+	enum {
+		THREAD_OCCUPANCY				= B40C_SM_THREADS(CUDA_ARCH) >> LOG_THREADS,
+		SMEM_OCCUPANCY					= B40C_SMEM_BYTES(CUDA_ARCH) / sizeof(SmemStorage),
+
+		MAX_CTA_OCCUPANCY  				= B40C_MIN(B40C_SM_CTAS(CUDA_ARCH), B40C_MIN(THREAD_OCCUPANCY, SMEM_OCCUPANCY)),
+		MIN_CTA_OCCUPANCY 				= _MIN_CTA_OCCUPANCY,
+
+		VALID							= (MAX_CTA_OCCUPANCY > 0)
+	};
+};
+
+} // namespace scan
+} // namespace b40c
+

--- a/include/b40c/scan/policy.cuh
+++ b/include/b40c/scan/policy.cuh
@@ -1,0 +1,255 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Unified scan policy
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+#include <b40c/reduction/kernel_policy.cuh>
+
+#include <b40c/scan/kernel_policy.cuh>
+#include <b40c/scan/upsweep/kernel.cuh>
+#include <b40c/scan/spine/kernel.cuh>
+#include <b40c/scan/downsweep/kernel.cuh>
+
+namespace b40c {
+namespace scan {
+
+
+/**
+ * Unified scan policy type.
+ *
+ * In addition to kernel tuning parameters that guide the kernel compilation for
+ * upsweep, spine, and downsweep kernels, this type includes enactor tuning
+ * parameters that define kernel-dispatch policy.   By encapsulating all of the
+ * kernel tuning policies, we assure operational consistency across all kernels.
+ */
+template <
+	// ProblemType type parameters
+	typename ProblemType,
+
+	// Machine parameters
+	int CUDA_ARCH,
+
+	// Common tunable params
+	util::io::ld::CacheModifier READ_MODIFIER,
+	util::io::st::CacheModifier WRITE_MODIFIER,
+	bool _UNIFORM_SMEM_ALLOCATION,
+	bool _UNIFORM_GRID_SIZE,
+	bool _OVERSUBSCRIBED_GRID_SIZE,
+	int LOG_SCHEDULE_GRANULARITY,
+
+	// Upsweep tunable params
+	int UPSWEEP_MIN_CTA_OCCUPANCY,
+	int UPSWEEP_LOG_THREADS,
+	int UPSWEEP_LOG_LOAD_VEC_SIZE,
+	int UPSWEEP_LOG_LOADS_PER_TILE,
+	int UPSWEEP_LOG_RAKING_THREADS,
+
+	// Spine tunable params
+	int SPINE_LOG_THREADS,
+	int SPINE_LOG_LOAD_VEC_SIZE,
+	int SPINE_LOG_LOADS_PER_TILE,
+	int SPINE_LOG_RAKING_THREADS,
+
+	// Downsweep tunable params
+	int DOWNSWEEP_MIN_CTA_OCCUPANCY,
+	int DOWNSWEEP_LOG_THREADS,
+	int DOWNSWEEP_LOG_LOAD_VEC_SIZE,
+	int DOWNSWEEP_LOG_LOADS_PER_TILE,
+	int DOWNSWEEP_LOG_RAKING_THREADS>
+
+struct Policy : ProblemType
+{
+	//---------------------------------------------------------------------
+	// Typedefs
+	//---------------------------------------------------------------------
+
+	typedef typename ProblemType::T T;
+	typedef typename ProblemType::SizeT SizeT;
+	typedef typename ProblemType::ReductionOp ReductionOp;
+	typedef typename ProblemType::IdentityOp IdentityOp;
+
+	typedef void (*UpsweepKernelPtr)(T*, T*, ReductionOp, IdentityOp, util::CtaWorkDistribution<SizeT>);
+	typedef void (*SpineKernelPtr)(T*, T*, SizeT, ReductionOp, IdentityOp);
+	typedef void (*DownsweepKernelPtr)(T*, T*, T*, ReductionOp, IdentityOp, util::CtaWorkDistribution<SizeT>);
+	typedef void (*SingleKernelPtr)(T*, T*, SizeT, ReductionOp, IdentityOp);
+
+	//---------------------------------------------------------------------
+	// Kernel Policies
+	//---------------------------------------------------------------------
+
+	// Kernel config for the upsweep reduction kernel
+	typedef KernelPolicy <
+		ProblemType,
+		CUDA_ARCH,
+		true,								// Check alignment
+		UPSWEEP_MIN_CTA_OCCUPANCY,
+		UPSWEEP_LOG_THREADS,
+		UPSWEEP_LOG_LOAD_VEC_SIZE,
+		UPSWEEP_LOG_LOADS_PER_TILE,
+		UPSWEEP_LOG_RAKING_THREADS,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		LOG_SCHEDULE_GRANULARITY>
+			Upsweep;
+
+	// Problem type for spine scan (ensures exclusive scan)
+	typedef scan::ProblemType<
+		T,
+		SizeT,
+		ReductionOp,
+		IdentityOp,
+		true,								// Exclusive
+		ProblemType::COMMUTATIVE> SpineProblemType;
+
+	// Kernel config for the spine scan kernel
+	typedef KernelPolicy <
+		SpineProblemType,
+		CUDA_ARCH,
+		false,								// Do not check alignment
+		1,									// Only a single-CTA grid
+		SPINE_LOG_THREADS,
+		SPINE_LOG_LOAD_VEC_SIZE,
+		SPINE_LOG_LOADS_PER_TILE,
+		SPINE_LOG_RAKING_THREADS,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		SPINE_LOG_LOADS_PER_TILE + SPINE_LOG_LOAD_VEC_SIZE + SPINE_LOG_THREADS>
+			Spine;
+
+	// Kernel config for the downsweep scan kernel
+	typedef KernelPolicy <
+		ProblemType,
+		CUDA_ARCH,
+		true,								// Check alignment
+		DOWNSWEEP_MIN_CTA_OCCUPANCY,
+		DOWNSWEEP_LOG_THREADS,
+		DOWNSWEEP_LOG_LOAD_VEC_SIZE,
+		DOWNSWEEP_LOG_LOADS_PER_TILE,
+		DOWNSWEEP_LOG_RAKING_THREADS,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		LOG_SCHEDULE_GRANULARITY>
+			Downsweep;
+
+	// Kernel config for a one-level pass using the spine scan kernel
+	typedef KernelPolicy <
+		ProblemType,
+		CUDA_ARCH,
+		true,								// Check alignment
+		1,									// Only a single-CTA grid
+		SPINE_LOG_THREADS,
+		SPINE_LOG_LOAD_VEC_SIZE,
+		SPINE_LOG_LOADS_PER_TILE,
+		SPINE_LOG_RAKING_THREADS,
+		READ_MODIFIER,
+		WRITE_MODIFIER,
+		SPINE_LOG_LOADS_PER_TILE + SPINE_LOG_LOAD_VEC_SIZE + SPINE_LOG_THREADS>
+			Single;
+
+	//---------------------------------------------------------------------
+	// Kernel function pointer retrieval
+	//---------------------------------------------------------------------
+
+	static UpsweepKernelPtr UpsweepKernel() {
+		return upsweep::Kernel<Upsweep>;
+	}
+
+	static SpineKernelPtr SpineKernel() {
+		return spine::Kernel<Spine>;
+	}
+
+	static DownsweepKernelPtr DownsweepKernel() {
+		return downsweep::Kernel<Downsweep>;
+	}
+
+	static SingleKernelPtr SingleKernel() {
+		return spine::Kernel<Single>;
+	}
+
+
+	//---------------------------------------------------------------------
+	// Constants
+	//---------------------------------------------------------------------
+
+	enum {
+		UNIFORM_SMEM_ALLOCATION 	= _UNIFORM_SMEM_ALLOCATION,
+		UNIFORM_GRID_SIZE 			= _UNIFORM_GRID_SIZE,
+		OVERSUBSCRIBED_GRID_SIZE	= _OVERSUBSCRIBED_GRID_SIZE,
+		VALID 						= Upsweep::VALID && Spine::VALID && Downsweep::VALID && Single::VALID &&
+										(Upsweep::LOG_TILE_ELEMENTS <= LOG_SCHEDULE_GRANULARITY),
+	};
+
+	static void Print()
+	{
+		// ProblemType type parameters
+		printf("%d, ", sizeof(T));
+		printf("%d, ", sizeof(SizeT));
+		printf("%d, ", CUDA_ARCH);
+
+		// Common tunable params
+		printf("%s, ", CacheModifierToString(READ_MODIFIER));
+		printf("%s, ", CacheModifierToString(WRITE_MODIFIER));
+		printf("%s ", (_UNIFORM_SMEM_ALLOCATION) ? "true" : "false");
+		printf("%s ", (_UNIFORM_GRID_SIZE) ? "true" : "false");
+		printf("%s ", (_OVERSUBSCRIBED_GRID_SIZE) ? "true" : "false");
+		printf("%d, ", LOG_SCHEDULE_GRANULARITY);
+
+		// Upsweep tunable params
+		printf("%d, ", UPSWEEP_MIN_CTA_OCCUPANCY);
+		printf("%d, ", UPSWEEP_LOG_THREADS);
+		printf("%d, ", UPSWEEP_LOG_LOAD_VEC_SIZE);
+		printf("%d, ", UPSWEEP_LOG_LOADS_PER_TILE);
+		printf("%d, ", UPSWEEP_LOG_RAKING_THREADS);
+
+		// Spine tunable params
+		printf("%d, ", SPINE_LOG_THREADS);
+		printf("%d, ", SPINE_LOG_LOAD_VEC_SIZE);
+		printf("%d, ", SPINE_LOG_LOADS_PER_TILE);
+		printf("%d, ", SPINE_LOG_RAKING_THREADS);
+
+		// Upsweep tunable params
+		printf("%d, ", DOWNSWEEP_MIN_CTA_OCCUPANCY);
+		printf("%d, ", DOWNSWEEP_LOG_THREADS);
+		printf("%d, ", DOWNSWEEP_LOG_LOAD_VEC_SIZE);
+		printf("%d, ", DOWNSWEEP_LOG_LOADS_PER_TILE);
+		printf("%d, ", DOWNSWEEP_LOG_RAKING_THREADS);
+	}
+};
+		
+
+}// namespace scan
+}// namespace b40c
+

--- a/include/b40c/scan/problem_type.cuh
+++ b/include/b40c/scan/problem_type.cuh
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Scan problem type
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/reduction/problem_type.cuh>
+
+namespace b40c {
+namespace scan {
+
+
+/**
+ * Type of scan problem
+ */
+template <
+	typename T,
+	typename SizeT,
+	typename ReductionOp,
+	typename _IdentityOp,
+	bool _EXCLUSIVE,				// Whether or not to perform an exclusive (vs. inclusive) prefix scan
+	bool _COMMUTATIVE>				// Whether or not the associative scan operator is commutative vs. non-commuatative (the commutative-only implementation is generally faster)
+struct ProblemType :
+	reduction::ProblemType<T, SizeT, ReductionOp>	// Inherit from reduction problem type
+{
+	enum {
+		EXCLUSIVE 			= _EXCLUSIVE,
+		COMMUTATIVE 		= _COMMUTATIVE,
+	};
+
+	typedef _IdentityOp IdentityOp;					// Identity operator type
+};
+
+
+} // namespace scan
+} // namespace b40c
+

--- a/include/b40c/scan/spine/kernel.cuh
+++ b/include/b40c/scan/spine/kernel.cuh
@@ -1,0 +1,113 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Spine kernel
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/scan/downsweep/cta.cuh>
+
+namespace b40c {
+namespace scan {
+namespace spine {
+
+
+/**
+ * Spine scan pass
+ */
+template <typename KernelPolicy>
+__device__ __forceinline__ void SpinePass(
+	typename KernelPolicy::T 				*d_in,
+	typename KernelPolicy::T 				*d_out,
+	typename KernelPolicy::SizeT 			spine_elements,
+	typename KernelPolicy::ReductionOp 		scan_op,
+	typename KernelPolicy::IdentityOp 		identity_op,
+	typename KernelPolicy::SmemStorage		&smem_storage)
+{
+	typedef downsweep::Cta<KernelPolicy> 		Cta;
+	typedef typename KernelPolicy::SizeT 		SizeT;
+
+	// Exit if we're not the first CTA
+	if (blockIdx.x > 0) return;
+
+	// CTA processing abstraction
+	Cta cta(
+		smem_storage,
+		d_in,
+		d_out,
+		scan_op,
+		identity_op);
+
+	// Number of elements in (the last) partially-full tile (requires guarded loads)
+	SizeT guarded_elements = spine_elements & (KernelPolicy::TILE_ELEMENTS - 1);
+
+	// Offset of final, partially-full tile (requires guarded loads)
+	SizeT guarded_offset = spine_elements - guarded_elements;
+
+	util::CtaWorkLimits<SizeT> work_limits(
+		0,					// Offset at which this CTA begins processing
+		spine_elements,		// Total number of elements for this CTA to process
+		guarded_offset, 	// Offset of final, partially-full tile (requires guarded loads)
+		guarded_elements,	// Number of elements in partially-full tile
+		spine_elements,		// Offset at which this CTA is out-of-bounds
+		true);				// If this block is the last block in the grid with any work
+
+	cta.ProcessWorkRange(work_limits);
+}
+
+
+/**
+ * Spine scan kernel entry point
+ */
+template <typename KernelPolicy>
+__launch_bounds__ (KernelPolicy::THREADS, KernelPolicy::MIN_CTA_OCCUPANCY)
+__global__ 
+void Kernel(
+	typename KernelPolicy::T			*d_in,
+	typename KernelPolicy::T			*d_out,
+	typename KernelPolicy::SizeT 		spine_elements,
+	typename KernelPolicy::ReductionOp 	scan_op,
+	typename KernelPolicy::IdentityOp 	identity_op)
+{
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	SpinePass<KernelPolicy>(
+		d_in,
+		d_out,
+		spine_elements,
+		scan_op,
+		identity_op,
+		smem_storage);
+}
+
+} // namespace spine
+} // namespace scan
+} // namespace b40c
+

--- a/include/b40c/scan/upsweep/cta.cuh
+++ b/include/b40c/scan/upsweep/cta.cuh
@@ -1,0 +1,190 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * CTA-processing functionality for scan upsweep reduction kernels
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+#include <b40c/util/io/load_tile.cuh>
+
+#include <b40c/util/reduction/cooperative_reduction.cuh>
+
+namespace b40c {
+namespace scan {
+namespace upsweep {
+
+
+/**
+ * Scan scan upsweep reduction CTA
+ */
+template <typename KernelPolicy>
+struct Cta
+{
+	//---------------------------------------------------------------------
+	// Typedefs
+	//---------------------------------------------------------------------
+
+	typedef typename KernelPolicy::T 					T;
+	typedef typename KernelPolicy::SizeT 				SizeT;
+	typedef typename KernelPolicy::ReductionOp 			ReductionOp;
+	typedef typename KernelPolicy::IdentityOp 			IdentityOp;
+
+	typedef typename KernelPolicy::RakingDetails 			RakingDetails;
+	typedef typename KernelPolicy::SmemStorage			SmemStorage;
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Running partial accumulated by the CTA over its tile-processing
+	// lifetime (managed in each raking thread)
+	T carry;
+
+	// Input and output device pointers
+	T *d_in;
+	T *d_spine;
+
+	// Scan operator
+	ReductionOp scan_op;
+
+	// Operational details for raking scan grid
+	RakingDetails raking_details;
+
+
+
+	//---------------------------------------------------------------------
+	// Methods
+	//---------------------------------------------------------------------
+
+	/**
+	 * Constructor
+	 */
+	template <typename SmemStorage>
+	__device__ __forceinline__ Cta(
+		SmemStorage 		&smem_storage,
+		T 					*d_in,
+		T 					*d_spine,
+		ReductionOp 		scan_op,
+		IdentityOp 			identity_op) :
+
+			raking_details(
+				smem_storage.raking_elements,
+				smem_storage.warpscan,
+				identity_op()),
+			d_in(d_in),
+			d_spine(d_spine),
+			scan_op(scan_op),
+			carry(scan_op())
+	{}
+
+
+	/**
+	 * Process a single tile
+	 */
+	__device__ __forceinline__ void ProcessTile(
+		SizeT cta_offset,
+		SizeT guarded_elements = KernelPolicy::TILE_ELEMENTS)
+	{
+		// Tile of scan elements
+		T	partials[KernelPolicy::LOADS_PER_TILE][KernelPolicy::LOAD_VEC_SIZE];
+
+		// Load tile of partials
+		util::io::LoadTile<
+			KernelPolicy::LOG_LOADS_PER_TILE,
+			KernelPolicy::LOG_LOAD_VEC_SIZE,
+			KernelPolicy::THREADS,
+			KernelPolicy::READ_MODIFIER,
+			KernelPolicy::CHECK_ALIGNMENT>::LoadValid(
+				partials,
+				d_in,
+				cta_offset,
+				guarded_elements);
+
+		// SOA-reduce tile of tuple pairs
+		util::reduction::CooperativeTileReduction<
+			KernelPolicy::LOAD_VEC_SIZE>::template ReduceTileWithCarry<true>(		// Maintain carry in thread RakingSoaDetails::CUMULATIVE_THREAD
+				raking_details,
+				partials,
+				carry,																// Seed with carry
+				scan_op);
+
+		// Barrier to protect raking_details before next tile
+		__syncthreads();
+	}
+
+
+	/**
+	 * Stores final reduction to output
+	 */
+	__device__ __forceinline__ void OutputToSpine()
+	{
+		// Write output
+		if (threadIdx.x == RakingDetails::CUMULATIVE_THREAD) {
+
+			util::io::ModifiedStore<KernelPolicy::WRITE_MODIFIER>::St(
+				carry, d_spine + blockIdx.x);
+		}
+	}
+
+
+	/**
+	 * Process work range of tiles
+	 */
+	__device__ __forceinline__ void ProcessWorkRange(
+		util::CtaWorkLimits<SizeT> &work_limits)
+	{
+		// Make sure we get a local copy of the cta's offset (work_limits may be in smem)
+		SizeT cta_offset = work_limits.offset;
+
+		// Process full tiles of tile_elements
+		while (cta_offset < work_limits.guarded_offset) {
+			ProcessTile(cta_offset);
+			cta_offset += KernelPolicy::TILE_ELEMENTS;
+		}
+
+		// Clean up last partial tile with guarded-io
+		if (work_limits.guarded_elements) {
+			ProcessTile(
+				cta_offset,
+				work_limits.guarded_elements);
+		}
+
+		// Produce output in spine
+		OutputToSpine();
+	}
+};
+
+
+} // namespace upsweep
+} // namespace scan
+} // namespace b40c
+

--- a/include/b40c/scan/upsweep/kernel.cuh
+++ b/include/b40c/scan/upsweep/kernel.cuh
@@ -1,0 +1,163 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Upsweep kernel
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/cta_work_progress.cuh>
+
+#include <b40c/reduction/cta.cuh>
+#include <b40c/scan/upsweep/cta.cuh>
+
+namespace b40c {
+namespace scan {
+namespace upsweep {
+
+
+/**
+ * Upsweep reduction pass (specialized to support non-commutative operators)
+ */
+template <
+	typename KernelPolicy,
+	bool COMMUTATIVE = KernelPolicy::COMMUTATIVE>
+struct UpsweepPass
+{
+	static __device__ __forceinline__ void Invoke(
+		typename KernelPolicy::T 									*d_in,
+		typename KernelPolicy::T 									*d_out,
+		typename KernelPolicy::ReductionOp 							scan_op,
+		typename KernelPolicy::IdentityOp 							identity_op,
+		util::CtaWorkDistribution<typename KernelPolicy::SizeT> 	&work_decomposition,
+		typename KernelPolicy::SmemStorage							&smem_storage)
+	{
+		typedef Cta<KernelPolicy>					Cta;
+		typedef typename KernelPolicy::SizeT 		SizeT;
+
+		// CTA processing abstraction
+		Cta cta(
+			smem_storage,
+			d_in,
+			d_out,
+			scan_op,
+			identity_op);
+
+		// Determine our threadblock's work range
+		util::CtaWorkLimits<SizeT> work_limits;
+		work_decomposition.template GetCtaWorkLimits<
+			KernelPolicy::LOG_TILE_ELEMENTS,
+			KernelPolicy::LOG_SCHEDULE_GRANULARITY>(work_limits);
+
+		// Quit if we're the last threadblock (no need for it in upsweep).
+		if (work_limits.last_block) {
+			return;
+		}
+
+		cta.ProcessWorkRange(work_limits);
+	}
+};
+
+
+/**
+ * Upsweep reduction pass (specialized for commutative operators)
+ */
+template <typename KernelPolicy>
+struct UpsweepPass<KernelPolicy, true>
+{
+	static __device__ __forceinline__ void Invoke(
+		typename KernelPolicy::T 									*d_in,
+		typename KernelPolicy::T 									*d_out,
+		typename KernelPolicy::ReductionOp 							scan_op,
+		typename KernelPolicy::IdentityOp 							identity_op,
+		util::CtaWorkDistribution<typename KernelPolicy::SizeT> 	&work_decomposition,
+		typename KernelPolicy::SmemStorage							&smem_storage)
+	{
+		typedef reduction::Cta<KernelPolicy>		Cta;
+		typedef typename KernelPolicy::SizeT 		SizeT;
+
+		// CTA processing abstraction
+		Cta cta(
+			smem_storage,
+			d_in,
+			d_out,
+			scan_op);
+
+		// Determine our threadblock's work range
+		util::CtaWorkLimits<SizeT> work_limits;
+		work_decomposition.template GetCtaWorkLimits<
+			KernelPolicy::LOG_TILE_ELEMENTS,
+			KernelPolicy::LOG_SCHEDULE_GRANULARITY>(work_limits);
+
+		// Quit if we're the last threadblock (no need for it in upsweep).
+		if (work_limits.last_block) {
+			return;
+		}
+
+		cta.ProcessWorkRange(work_limits);
+	}
+};
+
+
+
+/******************************************************************************
+ * Upsweep Reduction Kernel Entrypoint
+ ******************************************************************************/
+
+/**
+ * Upsweep reduction kernel entry point
+ */
+template <typename KernelPolicy>
+__launch_bounds__ (KernelPolicy::THREADS, KernelPolicy::MIN_CTA_OCCUPANCY)
+__global__
+void Kernel(
+	typename KernelPolicy::T 									*d_in,
+	typename KernelPolicy::T 									*d_spine,
+	typename KernelPolicy::ReductionOp 							scan_op,
+	typename KernelPolicy::IdentityOp 							identity_op,
+	util::CtaWorkDistribution<typename KernelPolicy::SizeT> 	work_decomposition)
+{
+	// Shared storage for the kernel
+	__shared__ typename KernelPolicy::SmemStorage smem_storage;
+
+	UpsweepPass<KernelPolicy>::Invoke(
+		d_in,
+		d_spine,
+		scan_op,
+		identity_op,
+		work_decomposition,
+		smem_storage);
+}
+
+
+} // namespace upsweep
+} // namespace scan
+} // namespace b40c
+

--- a/include/b40c/util/arch_dispatch.cuh
+++ b/include/b40c/util/arch_dispatch.cuh
@@ -1,0 +1,96 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Base class for dynamic architecture dispatch
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Specialization for the device compilation-path.
+ *
+ * Dispatches to the static method Dispatch::Enact templated by the static CUDA_ARCH.
+ * This path drives the actual compilation of kernels, allowing invocation sites to be
+ * specialized in type and number by CUDA_ARCH.
+ */
+template <int CUDA_ARCH, typename Dispatch>
+struct ArchDispatch
+{
+	template<typename Detail>
+	static cudaError_t Enact(Detail &detail, int dummy)
+	{
+		return Dispatch::template Enact<CUDA_ARCH, Detail>(detail);
+	}
+};
+
+
+/**
+ * Specialization specialization for the host compilation-path.
+ *
+ * Dispatches to the static method Dispatch::Enact templated by the dynamic
+ * ptx_version.  This path does not drive the compilation of kernels.
+ */
+template <typename Dispatch>
+struct ArchDispatch<0, Dispatch>
+{
+	template<typename Detail>
+	static cudaError_t Enact(Detail &detail, int ptx_version)
+	{
+		// Dispatch
+		switch (ptx_version) {
+		case 100:
+			return Dispatch::template Enact<100, Detail>(detail);
+		case 110:
+			return Dispatch::template Enact<110, Detail>(detail);
+		case 120:
+			return Dispatch::template Enact<120, Detail>(detail);
+		case 130:
+			return Dispatch::template Enact<130, Detail>(detail);
+		case 200:
+			return Dispatch::template Enact<200, Detail>(detail);
+		case 210:
+			return Dispatch::template Enact<210, Detail>(detail);
+		default:
+			// We were compiled for something new: treat it as we would SM2.0
+			return Dispatch::template Enact<200, Detail>(detail);
+		};
+	}
+};
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/basic_utils.cuh
+++ b/include/b40c/util/basic_utils.cuh
@@ -1,0 +1,240 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Common B40C Routines 
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace util {
+
+
+/******************************************************************************
+ * Macro utilities
+ ******************************************************************************/
+
+/**
+ * Select maximum
+ */
+#define B40C_MAX(a, b) ((a > b) ? a : b)
+
+
+/**
+ * Select maximum
+ */
+#define B40C_MIN(a, b) ((a < b) ? a : b)
+
+/**
+ * Return the size in quad-words of a number of bytes
+ */
+#define B40C_QUADS(bytes) (((bytes + sizeof(uint4) - 1) / sizeof(uint4)))
+
+/******************************************************************************
+ * Simple templated utilities
+ ******************************************************************************/
+
+/**
+ * Supress warnings for unused constants
+ */
+template <typename T>
+__host__ __device__ __forceinline__ void SuppressUnusedConstantWarning(const T) {}
+
+
+/**
+ * Perform a swap
+ */
+template <typename T> 
+void __host__ __device__ __forceinline__ Swap(T &a, T &b) {
+	T temp = a;
+	a = b;
+	b = temp;
+}
+
+
+template <typename K, int magnitude, bool shift_left> struct MagnitudeShiftOp;
+
+/**
+ * MagnitudeShift().  Allows you to shift left for positive magnitude values, 
+ * right for negative.   
+ * 
+ * N.B. This code is a little strange; we are using this meta-programming 
+ * pattern of partial template specialization for structures in order to 
+ * decide whether to shift left or right.  Normally we would just use a 
+ * conditional to decide if something was negative or not and then shift 
+ * accordingly, knowing that the compiler will elide the untaken branch, 
+ * i.e., the out-of-bounds shift during dead code elimination. However, 
+ * the pass for bounds-checking shifts seems to happen before the DCE 
+ * phase, which results in a an unsightly number of compiler warnings, so 
+ * we force the issue earlier using structural template specialization.
+ */
+template <typename K, int magnitude> 
+__device__ __forceinline__ K MagnitudeShift(K key)
+{
+	return MagnitudeShiftOp<K, (magnitude > 0) ? magnitude : magnitude * -1, (magnitude > 0)>::Shift(key);
+}
+
+template <typename K, int magnitude>
+struct MagnitudeShiftOp<K, magnitude, true>
+{
+	__device__ __forceinline__ static K Shift(K key)
+	{
+		return key << magnitude;
+	}
+};
+
+template <typename K, int magnitude>
+struct MagnitudeShiftOp<K, magnitude, false>
+{
+	__device__ __forceinline__ static K Shift(K key)
+	{
+		return key >> magnitude;
+	}
+};
+
+
+/******************************************************************************
+ * Metaprogramming Utilities
+ ******************************************************************************/
+
+/**
+ * Null type
+ */
+struct NullType {};
+
+
+/**
+ * Int2Type
+ */
+template <int N>
+struct Int2Type
+{
+	enum {VALUE = N};
+};
+
+
+/**
+ * Statically determine log2(N), rounded up, e.g.,
+ * 		Log2<8>::VALUE == 3
+ * 		Log2<3>::VALUE == 2
+ */
+template <int N, int CURRENT_VAL = N, int COUNT = 0>
+struct Log2
+{
+	// Inductive case
+	static const int VALUE = Log2<N, (CURRENT_VAL >> 1), COUNT + 1>::VALUE;
+};
+
+template <int N, int COUNT>
+struct Log2<N, 0, COUNT>
+{
+	// Base case
+	static const int VALUE = (1 << (COUNT - 1) < N) ?
+		COUNT :
+		COUNT - 1;
+};
+
+
+/**
+ * If/Then/Else
+ */
+template <bool IF, typename ThenType, typename ElseType>
+struct If
+{
+	// true
+	typedef ThenType Type;
+};
+
+template <typename ThenType, typename ElseType>
+struct If<false, ThenType, ElseType>
+{
+	// false
+	typedef ElseType Type;
+};
+
+
+/**
+ * Equals 
+ */
+template <typename A, typename B>
+struct Equals
+{
+	enum {
+		VALUE = 0,
+		NEGATE = 1
+	};
+};
+
+template <typename A>
+struct Equals <A, A>
+{
+	enum {
+		VALUE = 1,
+		NEGATE = 0
+	};
+};
+
+
+
+/**
+ * Is volatile
+ */
+template <typename Tp>
+struct IsVolatile
+{
+	enum { VALUE = 0 };
+};
+template <typename Tp>
+struct IsVolatile<Tp volatile>
+{
+	enum { VALUE = 1 };
+};
+
+
+/**
+ * Removes pointers
+ */
+template <typename Tp, typename Up>
+struct RemovePointersHelper
+{
+	typedef Tp Type;
+};
+template <typename Tp, typename Up>
+struct RemovePointersHelper<Tp, Up*>
+{
+	typedef typename RemovePointersHelper<Up, Up>::Type Type;
+};
+template <typename Tp>
+struct RemovePointers : RemovePointersHelper<Tp, Tp> {};
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/cta_work_distribution.cuh
+++ b/include/b40c/util/cta_work_distribution.cuh
@@ -1,0 +1,195 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ * Work Management Datastructures
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Structure for describing the limits of work-processing for a given CTA
+ */
+template <typename SizeT>
+struct CtaWorkLimits
+{
+	SizeT 	offset;				// Offset at which this CTA begins processing
+	SizeT 	elements;			// Total number of elements for this CTA to process
+	SizeT 	guarded_offset; 	// Offset of final, partially-full tile (requires guarded loads)
+	SizeT 	guarded_elements;	// Number of elements in partially-full tile
+	SizeT 	out_of_bounds;		// Offset at which this CTA is out-of-bounds
+	bool	last_block;			// If this block is the last block in the grid with any work
+
+	/**
+	 * Constructor
+	 */
+	__host__ __device__ __forceinline__ CtaWorkLimits() {}
+
+	/**
+	 * Constructor
+	 */
+	__host__ __device__ __forceinline__ CtaWorkLimits(
+		SizeT 	offset,
+		SizeT 	elements,
+		SizeT 	guarded_offset,
+		SizeT 	guarded_elements,
+		SizeT 	out_of_bounds,
+		bool	last_block) :
+			offset(offset),
+			elements(elements),
+			guarded_offset(guarded_offset),
+			guarded_elements(guarded_elements),
+			out_of_bounds(out_of_bounds),
+			last_block(last_block)
+		{}
+};
+
+
+/**
+ * Description of work distribution amongst CTAs
+ *
+ * A given threadblock may receive one of three different amounts of 
+ * work: "big", "normal", and "last".  The big workloads are one
+ * grain greater than the normal, and the last workload 
+ * does the extra work.
+ */
+template <typename SizeT> 		// Integer type for indexing into problem arrays (e.g., int, long long, etc.)
+struct CtaWorkDistribution
+{
+	SizeT 	num_elements;		// Number of elements in the problem
+	SizeT 	total_grains;		// Number of "grain" blocks to break the problem into (round up)
+	SizeT 	grains_per_cta;		// Number of "grain" blocks per CTA
+	SizeT 	extra_grains;		// Number of CTAs having one extra "grain block"
+	int 	grid_size;			// Number of CTAs
+
+
+	/**
+	 * Initializer
+	 */
+	template <int LOG_SCHEDULE_GRANULARITY>
+	__host__ __device__ __forceinline__ void Init(
+		SizeT num_elements,
+		int grid_size)
+	{
+		const int SCHEDULE_GRANULARITY = 1 << LOG_SCHEDULE_GRANULARITY;
+
+		this->num_elements 		= num_elements;
+		this->total_grains 		= ((num_elements + SCHEDULE_GRANULARITY - 1) >> LOG_SCHEDULE_GRANULARITY);	// round up
+		this->grains_per_cta 	= total_grains / grid_size;													// round down for the ks
+		this->extra_grains 		= total_grains - (grains_per_cta * grid_size);								// the CTAs with +1 grains
+		this->grid_size 		= grid_size;
+	}
+
+	/**
+	 * Initializer
+	 */
+	__host__ __device__ __forceinline__ void Init(
+		SizeT num_elements,
+		int grid_size,
+		int log_schedule_granularity)
+	{
+		const int SCHEDULE_GRANULARITY = 1 << log_schedule_granularity;
+
+		this->num_elements 		= num_elements;
+		this->total_grains 		= ((num_elements + SCHEDULE_GRANULARITY - 1) >> log_schedule_granularity);	// round up
+		this->grains_per_cta 	= total_grains / grid_size;													// round down for the ks
+		this->extra_grains 		= total_grains - (grains_per_cta * grid_size);								// the CTAs with +1 grains
+		this->grid_size 		= grid_size;
+	}
+
+
+	/**
+	 * Computes work limits for the current CTA
+	 */	
+	template <
+		int LOG_TILE_ELEMENTS,			// CTA tile size, i.e., granularity by which the CTA processes work
+		int LOG_SCHEDULE_GRANULARITY>	// Problem granularity by which work is distributed amongst CTA threadblocks
+	__host__ __device__ __forceinline__ void GetCtaWorkLimits(
+		CtaWorkLimits<SizeT> &work_limits)	// Out param
+	{
+		const int TILE_ELEMENTS 				= 1 << LOG_TILE_ELEMENTS;
+		
+		// Compute number of elements and offset at which to start tile processing
+		if (blockIdx.x < extra_grains) {
+
+			// This CTA gets grains_per_cta+1 grains
+			work_limits.elements = (grains_per_cta + 1) << LOG_SCHEDULE_GRANULARITY;
+			work_limits.offset = work_limits.elements * blockIdx.x;
+
+		} else if (blockIdx.x < total_grains) {
+
+			// This CTA gets grains_per_cta grains
+			work_limits.elements = grains_per_cta << LOG_SCHEDULE_GRANULARITY;
+			work_limits.offset = (work_limits.elements * blockIdx.x) + (extra_grains << LOG_SCHEDULE_GRANULARITY);
+
+		} else {
+
+			// This CTA gets no work (problem small enough that some CTAs don't even a single grain)
+			work_limits.elements = 0;
+			work_limits.offset = 0;
+		}
+
+		// The offset at which this CTA is out-of-bounds
+		work_limits.out_of_bounds = work_limits.offset + work_limits.elements;
+
+		// Correct for the case where the last CTA having work has rounded its last grain up past the end
+		if (work_limits.last_block = work_limits.out_of_bounds >= num_elements) {
+			work_limits.out_of_bounds = num_elements;
+			work_limits.elements = num_elements - work_limits.offset;
+		}
+
+		// The number of extra guarded-load elements to process afterward (always
+		// less than a full tile)
+		work_limits.guarded_elements = work_limits.elements & (TILE_ELEMENTS - 1);
+
+		// The tile-aligned limit for full-tile processing
+		work_limits.guarded_offset = work_limits.out_of_bounds - work_limits.guarded_elements;
+	}
+
+
+	/**
+	 * Print to stdout
+	 */
+	void Print()
+	{
+		printf("num_elements: %lu, total_grains: %lu, grains_per_cta: %lu, extra_grains: %lu, grid_size: %lu\n",
+			(unsigned long) num_elements,
+			(unsigned long) total_grains,
+			(unsigned long) grains_per_cta,
+			(unsigned long) extra_grains,
+			(unsigned long) grid_size);
+	}
+};
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/cta_work_progress.cuh
+++ b/include/b40c/util/cta_work_progress.cuh
@@ -1,0 +1,410 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Management of temporary device storage needed for implementing work-stealing
+ * progress between CTAs in a single grid
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/error_utils.cuh>
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/device_intrinsics.cuh>
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+namespace b40c {
+namespace util {
+
+/**
+ * Manages device storage needed for implementing work-stealing
+ * and queuing progress between CTAs in a single grid.
+ *
+ * Can be used for:
+ *
+ * (1) Work-stealing. Consists of a pair of counters in
+ *     global device memory, optionally, a host-managed selector for
+ *     indexing into the pair.
+ *
+ * (2) Device-managed queue.  Consists of a quadruplet of counters
+ *     in global device memory and selection into the counters is made
+ *     based upon the supplied iteration count.
+ *     		Current iteration: incoming queue length
+ *     		Next iteration: outgoing queue length
+ *     		Next next iteration: needs to be reset before next iteration
+ *     Can be used with work-stealing counters to for work-stealing
+ *     queue operation
+ *
+ * For work-stealing passes, the current counter provides an atomic
+ * reference of progress, and the current pass will typically reset
+ * the counter for the next.
+ *
+ */
+class CtaWorkProgress
+{
+protected :
+
+	enum {
+		QUEUE_COUNTERS 		= 4,
+		STEAL_COUNTERS 		= 2,
+		OVERFLOW_COUNTERS 	= 1,
+	};
+
+	// Seven pointer-sized counters in global device memory (we may not use
+	// all of them, or may only use 32-bit versions of them)
+	size_t *d_counters;
+
+	// Host-controlled selector for indexing into d_counters.
+	int progress_selector;
+
+public:
+
+	enum {
+		COUNTERS = QUEUE_COUNTERS + STEAL_COUNTERS + OVERFLOW_COUNTERS
+	};
+
+	/**
+	 * Constructor
+	 */
+	CtaWorkProgress() :
+		d_counters(NULL),
+		progress_selector(0) {}
+
+	/**
+	 * Resets all counters.  Must be called by thread-0 through
+	 * thread-(COUNTERS - 1)
+	 */
+	template <typename SizeT>
+	__device__ __forceinline__ void Reset()
+	{
+		SizeT reset_val = 0;
+		util::io::ModifiedStore<util::io::st::cg>::St(
+			reset_val, ((SizeT *) d_counters) + threadIdx.x);
+	}
+
+	//---------------------------------------------------------------------
+	// Work-stealing
+	//---------------------------------------------------------------------
+
+	/**
+	 * Steals work from the host-indexed progress counter, returning
+	 * the offset of that work (from zero) and incrementing it by count.
+	 * Typically called by thread-0
+	 */
+	template <typename SizeT>
+	__device__ __forceinline__ SizeT Steal(int count)
+	{
+		SizeT* d_steal_counters = ((SizeT*) d_counters) + QUEUE_COUNTERS;
+		return util::AtomicInt<SizeT>::Add(d_steal_counters + progress_selector, count);
+	}
+
+	/**
+	 * Steals work from the specified iteration's progress counter, returning the
+	 * offset of that work (from zero) and incrementing it by count.
+	 * Typically called by thread-0
+	 */
+	template <typename SizeT, typename IterationT>
+	__device__ __forceinline__ SizeT Steal(int count, IterationT iteration)
+	{
+		SizeT* d_steal_counters = ((SizeT*) d_counters) + QUEUE_COUNTERS;
+		return util::AtomicInt<SizeT>::Add(d_steal_counters + (iteration & 1), count);
+	}
+
+	/**
+	 * Resets the work progress for the next host-indexed work-stealing
+	 * pass.  Typically called by thread-0 in block-0.
+	 */
+	template <typename SizeT>
+	__device__ __forceinline__ void PrepResetSteal()
+	{
+		SizeT 	reset_val = 0;
+		SizeT* 	d_steal_counters = ((SizeT*) d_counters) + QUEUE_COUNTERS;
+		util::io::ModifiedStore<util::io::st::cg>::St(
+				reset_val, d_steal_counters + (progress_selector ^ 1));
+	}
+
+	/**
+	 * Resets the work progress for the specified work-stealing iteration.
+	 * Typically called by thread-0 in block-0.
+	 */
+	template <typename SizeT, typename IterationT>
+	__device__ __forceinline__ void PrepResetSteal(IterationT iteration)
+	{
+		SizeT 	reset_val = 0;
+		SizeT* 	d_steal_counters = ((SizeT*) d_counters) + QUEUE_COUNTERS;
+		util::io::ModifiedStore<util::io::st::cg>::St(
+			reset_val, d_steal_counters + (iteration & 1));
+	}
+
+
+	//---------------------------------------------------------------------
+	// Queuing
+	//---------------------------------------------------------------------
+
+	/**
+	 * Get counter for specified iteration
+	 */
+	template <typename SizeT, typename IterationT>
+	__device__ __forceinline__ SizeT* GetQueueCounter(IterationT iteration)
+	{
+		return ((SizeT*) d_counters) + (iteration & 3);
+	}
+
+	/**
+	 * Load work queue length for specified iteration
+	 */
+	template <typename SizeT, typename IterationT>
+	__device__ __forceinline__ SizeT LoadQueueLength(IterationT iteration)
+	{
+		SizeT queue_length;
+		util::io::ModifiedLoad<util::io::ld::cg>::Ld(
+			queue_length, GetQueueCounter<SizeT>(iteration));
+		return queue_length;
+	}
+
+	/**
+	 * Store work queue length for specified iteration
+	 */
+	template <typename SizeT, typename IterationT>
+	__device__ __forceinline__ void StoreQueueLength(SizeT queue_length, IterationT iteration)
+	{
+		util::io::ModifiedStore<util::io::st::cg>::St(
+			queue_length, GetQueueCounter<SizeT>(iteration));
+	}
+
+	/**
+	 * Enqueues work from the specified iteration's queue counter, returning the
+	 * offset of that work (from zero) and incrementing it by count.
+	 * Typically called by thread-0
+	 */
+	template <typename SizeT, typename IterationT>
+	__device__ __forceinline__ SizeT Enqueue(SizeT count, IterationT iteration)
+	{
+		return util::AtomicInt<SizeT>::Add(
+			GetQueueCounter<SizeT>(iteration),
+			count);
+	}
+
+	/**
+	 * Sets the overflow counter to non-zero
+	 */
+	template <typename SizeT>
+	__device__ __forceinline__ void SetOverflow ()
+	{
+		((SizeT*) d_counters)[QUEUE_COUNTERS + STEAL_COUNTERS] = 1;
+	}
+
+};
+
+
+/**
+ * Version of work progress with storage lifetime management.
+ *
+ * We can use this in host enactors, and pass the base CtaWorkProgress
+ * as parameters to kernels.
+ */
+class CtaWorkProgressLifetime : public CtaWorkProgress
+{
+protected:
+
+	// GPU d_counters was allocated on
+	int gpu;
+
+public:
+
+	/**
+	 * Constructor
+	 */
+	CtaWorkProgressLifetime() :
+		CtaWorkProgress(),
+		gpu(B40C_INVALID_DEVICE) {}
+
+
+	/**
+	 * Deallocates and resets the progress counters
+	 */
+	cudaError_t HostReset()
+	{
+		cudaError_t retval = cudaSuccess;
+
+		do {
+			if (gpu != B40C_INVALID_DEVICE) {
+
+				// Save current gpu
+				int current_gpu;
+				if (retval = util::B40CPerror(cudaGetDevice(&current_gpu),
+					"CtaWorkProgress cudaGetDevice failed: ", __FILE__, __LINE__)) break;
+
+				// Deallocate
+				if (retval = util::B40CPerror(cudaSetDevice(gpu),
+					"CtaWorkProgress cudaSetDevice failed: ", __FILE__, __LINE__)) break;
+				if (retval = util::B40CPerror(cudaFree(d_counters),
+					"CtaWorkProgress cudaFree d_counters failed: ", __FILE__, __LINE__)) break;
+
+				d_counters = NULL;
+				gpu = B40C_INVALID_DEVICE;
+
+				// Restore current gpu
+				if (retval = util::B40CPerror(cudaSetDevice(current_gpu),
+					"CtaWorkProgress cudaSetDevice failed: ", __FILE__, __LINE__)) break;
+			}
+
+			progress_selector = 0;
+
+		} while (0);
+
+		return retval;
+	}
+
+
+	/**
+	 * Destructor
+	 */
+	virtual ~CtaWorkProgressLifetime()
+	{
+		HostReset();
+	}
+
+
+	/**
+	 * Sets up the progress counters for the next kernel launch (lazily
+	 * allocating and initializing them if necessary)
+	 */
+	cudaError_t Setup()
+	{
+		cudaError_t retval = cudaSuccess;
+		do {
+
+			// Make sure that our progress counters are allocated
+			if (!d_counters) {
+
+				size_t h_counters[COUNTERS];
+				for (int i = 0; i < COUNTERS; i++) {
+					h_counters[i] = 0;
+				}
+
+				// Allocate and initialize
+				if (retval = util::B40CPerror(cudaGetDevice(&gpu),
+					"CtaWorkProgress cudaGetDevice failed: ", __FILE__, __LINE__)) break;
+				if (retval = util::B40CPerror(cudaMalloc((void**) &d_counters, sizeof(h_counters)),
+					"CtaWorkProgress cudaMalloc d_counters failed", __FILE__, __LINE__)) break;
+				if (retval = util::B40CPerror(cudaMemcpy(d_counters, h_counters, sizeof(h_counters), cudaMemcpyHostToDevice),
+					"CtaWorkProgress cudaMemcpy d_counters failed", __FILE__, __LINE__)) break;
+			}
+
+			// Update our progress counter selector to index the next progress counter
+			progress_selector ^= 1;
+
+		} while (0);
+
+		return retval;
+	}
+
+
+	/**
+	 * Checks if overflow counter is set
+	 */
+	template <typename SizeT>
+	cudaError_t CheckOverflow(bool &overflow)	// out param
+	{
+		cudaError_t retval = cudaSuccess;
+
+		do {
+			SizeT counter;
+
+			if (retval = util::B40CPerror(cudaMemcpy(
+					&counter,
+					((SizeT*) d_counters) + QUEUE_COUNTERS + STEAL_COUNTERS,
+					1 * sizeof(SizeT),
+					cudaMemcpyDeviceToHost),
+				"CtaWorkProgress cudaMemcpy d_counters failed", __FILE__, __LINE__)) break;
+
+			overflow = counter;
+
+		} while (0);
+
+		return retval;
+	}
+
+
+	/**
+	 * Acquire work queue length
+	 */
+	template <typename IterationT, typename SizeT>
+	cudaError_t GetQueueLength(
+		IterationT iteration,
+		SizeT &queue_length)		// out param
+	{
+		cudaError_t retval = cudaSuccess;
+
+		do {
+			int queue_length_idx = iteration & 0x3;
+
+			if (retval = util::B40CPerror(cudaMemcpy(
+					&queue_length,
+					((SizeT*) d_counters) + queue_length_idx,
+					1 * sizeof(SizeT),
+					cudaMemcpyDeviceToHost),
+				"CtaWorkProgress cudaMemcpy d_counters failed", __FILE__, __LINE__)) break;
+
+		} while (0);
+
+		return retval;
+	}
+
+
+	/**
+	 * Set work queue length
+	 */
+	template <typename IterationT, typename SizeT>
+	cudaError_t SetQueueLength(
+		IterationT iteration,
+		SizeT queue_length)
+	{
+		cudaError_t retval = cudaSuccess;
+
+		do {
+			int queue_length_idx = iteration & 0x3;
+
+			if (retval = util::B40CPerror(cudaMemcpy(
+					((SizeT*) d_counters) + queue_length_idx,
+					&queue_length,
+					1 * sizeof(SizeT),
+					cudaMemcpyHostToDevice),
+				"CtaWorkProgress cudaMemcpy d_counters failed", __FILE__, __LINE__)) break;
+
+		} while (0);
+
+		return retval;
+	}
+};
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/cuda_properties.cuh
+++ b/include/b40c/util/cuda_properties.cuh
@@ -1,0 +1,192 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * CUDA Properties
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace util {
+
+/******************************************************************************
+ * Macros for guiding compilation paths
+ ******************************************************************************/
+
+/**
+ * CUDA architecture of the current compilation path
+ */
+#ifndef __CUDA_ARCH__
+	#define __B40C_CUDA_ARCH__ 0						// Host path
+#else
+	#define __B40C_CUDA_ARCH__ __CUDA_ARCH__			// Device path
+#endif
+
+
+
+/******************************************************************************
+ * Device properties by SM architectural version
+ ******************************************************************************/
+
+// Invalid CUDA device ordinal
+#define B40C_INVALID_DEVICE				(-1)
+
+// Threads per warp. 
+#define B40C_LOG_WARP_THREADS(arch)		(5)			// 32 threads in a warp 
+#define B40C_WARP_THREADS(arch)			(1 << B40C_LOG_WARP_THREADS(arch))
+
+// SM memory bank stride (in bytes)
+#define B40C_LOG_BANK_STRIDE_BYTES(arch)	(2)		// 4 byte words
+#define B40C_BANK_STRIDE_BYTES(arch)		(1 << B40C_LOG_BANK_STRIDE_BYTES)
+
+// Memory banks per SM
+#define B40C_SM20_LOG_MEM_BANKS()		(5)			// 32 banks on SM2.0+
+#define B40C_SM10_LOG_MEM_BANKS()		(4)			// 16 banks on SM1.0-SM1.3
+#define B40C_LOG_MEM_BANKS(arch)		((arch >= 200) ? B40C_SM20_LOG_MEM_BANKS() : 	\
+														 B40C_SM10_LOG_MEM_BANKS())		
+
+// Physical shared memory per SM (bytes)
+#define B40C_SM20_SMEM_BYTES()			(49152)		// 48KB on SM2.0+
+#define B40C_SM10_SMEM_BYTES()			(16384)		// 32KB on SM1.0-SM1.3
+#define B40C_SMEM_BYTES(arch)			((arch >= 200) ? B40C_SM20_SMEM_BYTES() : 	\
+														 B40C_SM10_SMEM_BYTES())		
+
+// Physical threads per SM
+#define B40C_SM20_SM_THREADS()			(1536)		// 1536 threads on SM2.0+
+#define B40C_SM12_SM_THREADS()			(1024)		// 1024 threads on SM1.2-SM1.3
+#define B40C_SM10_SM_THREADS()			(768)		// 768 threads on SM1.0-SM1.1
+#define B40C_SM_THREADS(arch)			((arch >= 200) ? B40C_SM20_SM_THREADS() : 	\
+										 (arch >= 130) ? B40C_SM12_SM_THREADS() : 	\
+												 	 	 B40C_SM10_SM_THREADS())
+
+// Physical threads per CTA
+#define B40C_SM20_LOG_CTA_THREADS()		(10)		// 1024 threads on SM2.0+
+#define B40C_SM10_LOG_CTA_THREADS()		(9)			// 512 threads on SM1.0-SM1.3
+#define B40C_LOG_CTA_THREADS(arch)		((arch >= 200) ? B40C_SM20_LOG_CTA_THREADS() : 	\
+												 	 	 B40C_SM10_LOG_CTA_THREADS())
+
+// Max CTAs per SM
+#define B40C_SM20_SM_CTAS()				(8)		// 8 CTAs on SM2.0+
+#define B40C_SM12_SM_CTAS()				(8)		// 8 CTAs on SM1.2-SM1.3
+#define B40C_SM10_SM_CTAS()				(8)		// 8 CTAs on SM1.0-SM1.1
+#define B40C_SM_CTAS(arch)				((arch >= 200) ? B40C_SM20_SM_CTAS() : 	\
+										 (arch >= 130) ? B40C_SM12_SM_CTAS() : 	\
+												 	 	 B40C_SM10_SM_CTAS())
+
+// Max registers per SM
+#define B40C_SM20_SM_REGISTERS()		(32768)		// 32768 registers on SM2.0+
+#define B40C_SM12_SM_REGISTERS()		(16384)		// 16384 registers on SM1.2-SM1.3
+#define B40C_SM10_SM_REGISTERS()		(8192)		// 8192 registers on SM1.0-SM1.1
+#define B40C_SM_REGISTERS(arch)			((arch >= 200) ? B40C_SM20_SM_REGISTERS() : 	\
+										 (arch >= 130) ? B40C_SM12_SM_REGISTERS() : 	\
+												 	 	 B40C_SM10_SM_REGISTERS())
+
+/******************************************************************************
+ * Inlined PTX helper macros
+ ******************************************************************************/
+
+
+// Register modifier for pointer-types (for inlining PTX assembly)
+#if defined(_WIN64) || defined(__LP64__)
+	#define __B40C_LP64__ 1
+	// 64-bit register modifier for inlined asm
+	#define _B40C_ASM_PTR_ "l"
+#else
+	#define __B40C_LP64__ 0
+	// 32-bit register modifier for inlined asm
+	#define _B40C_ASM_PTR_ "r"
+#endif
+
+
+
+/******************************************************************************
+ * CUDA/GPU inspection utilities
+ ******************************************************************************/
+
+/**
+ * Empty Kernel
+ */
+template <typename T>
+__global__ void FlushKernel(void) { }
+
+
+/**
+ * Class encapsulating device properties for dynamic host-side inspection
+ */
+class CudaProperties 
+{
+public:
+	
+	// Information about our target device
+	cudaDeviceProp 		device_props;
+	int 				device_sm_version;
+	
+	// Information about our kernel assembly
+	int 				kernel_ptx_version;
+	
+public:
+	
+	/**
+	 * Constructor
+	 */
+	CudaProperties() 
+	{
+		// Get current device properties 
+		int current_device;
+		cudaGetDevice(&current_device);
+		cudaGetDeviceProperties(&device_props, current_device);
+		device_sm_version = device_props.major * 100 + device_props.minor * 10;
+	
+		// Get SM version of compiled kernel assemblies
+		cudaFuncAttributes flush_kernel_attrs;
+		cudaFuncGetAttributes(&flush_kernel_attrs, FlushKernel<void>);
+		kernel_ptx_version = flush_kernel_attrs.ptxVersion * 10;
+	}
+
+	/**
+	 * Constructor
+	 */
+	CudaProperties(int gpu)
+	{
+		// Get current device properties
+		cudaGetDeviceProperties(&device_props, gpu);
+		device_sm_version = device_props.major * 100 + device_props.minor * 10;
+
+		// Get SM version of compiled kernel assemblies
+		cudaFuncAttributes flush_kernel_attrs;
+		cudaFuncGetAttributes(&flush_kernel_attrs, FlushKernel<void>);
+		kernel_ptx_version = flush_kernel_attrs.ptxVersion * 10;
+	}
+};
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/device_intrinsics.cuh
+++ b/include/b40c/util/device_intrinsics.cuh
@@ -1,0 +1,216 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Common device intrinsics (potentially specialized by architecture)
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/reduction/warp_reduce.cuh>
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Terminates the calling thread
+ */
+__device__ __forceinline__ void ThreadExit() {
+	asm("exit;");
+}	
+
+
+/**
+ * Returns the warp lane ID of the calling thread
+ */
+__device__ __forceinline__ unsigned int LaneId()
+{
+	unsigned int ret;
+	asm("mov.u32 %0, %laneid;" : "=r"(ret) );
+	return ret;
+}
+
+
+/**
+ * The best way to multiply integers (24 effective bits or less)
+ */
+__device__ __forceinline__ unsigned int FastMul(unsigned int a, unsigned int b)
+{
+#if __CUDA_ARCH__ >= 200
+	return a * b;
+#else
+	return __umul24(a, b);
+#endif
+}
+
+
+/**
+ * The best way to multiply integers (24 effective bits or less)
+ */
+__device__ __forceinline__ int FastMul(int a, int b)
+{
+#if __CUDA_ARCH__ >= 200
+	return a * b;
+#else
+	return __mul24(a, b);
+#endif	
+}
+
+
+/**
+ * The best way to tally a warp-vote
+ */
+template <int LOG_ACTIVE_WARPS, int LOG_ACTIVE_THREADS>
+__device__ __forceinline__ int TallyWarpVote(int predicate)
+{
+#if __CUDA_ARCH__ >= 200
+	return __popc(__ballot(predicate));
+#else
+	const int ACTIVE_WARPS = 1 << LOG_ACTIVE_WARPS;
+	const int ACTIVE_THREADS = 1 << LOG_ACTIVE_THREADS;
+
+	__shared__ volatile int storage[ACTIVE_WARPS + 1][ACTIVE_THREADS];
+
+	int tid = threadIdx.x & (B40C_WARP_THREADS(__B40C_CUDA_ARCH__) - 1);
+	int wid = threadIdx.x >> B40C_LOG_WARP_THREADS(__B40C_CUDA_ARCH__);
+
+	return reduction::WarpReduce<LOG_ACTIVE_THREADS>::Invoke(predicate, storage[wid], tid);
+#endif
+}
+
+
+/**
+ * The best way to tally a warp-vote in the first warp
+ */
+template <int LOG_ACTIVE_THREADS>
+__device__ __forceinline__ int TallyWarpVote(
+	int predicate,
+	volatile int storage[2][1 << LOG_ACTIVE_THREADS])
+{
+#if __CUDA_ARCH__ >= 200
+	return __popc(__ballot(predicate));
+#else
+	return reduction::WarpReduce<LOG_ACTIVE_THREADS>::Invoke(
+		predicate, 
+		storage);
+#endif
+}
+
+
+/**
+ * The best way to warp-vote-all
+ */
+template <int LOG_ACTIVE_WARPS, int LOG_ACTIVE_THREADS>
+__device__ __forceinline__ int WarpVoteAll(int predicate)
+{
+#if __CUDA_ARCH__ >= 120
+	return __all(predicate);
+#else 
+	const int ACTIVE_THREADS = 1 << LOG_ACTIVE_THREADS;
+	return (TallyWarpVote<LOG_ACTIVE_WARPS, LOG_ACTIVE_THREADS>(predicate) == ACTIVE_THREADS);
+#endif
+}
+
+
+/**
+ * The best way to warp-vote-all in the first warp
+ */
+template <int LOG_ACTIVE_THREADS>
+__device__ __forceinline__ int WarpVoteAll(int predicate)
+{
+#if __CUDA_ARCH__ >= 120
+	return __all(predicate);
+#else
+	const int ACTIVE_THREADS = 1 << LOG_ACTIVE_THREADS;
+	__shared__ volatile int storage[2][ACTIVE_THREADS];
+
+	return (TallyWarpVote<LOG_ACTIVE_THREADS>(predicate, storage) == ACTIVE_THREADS);
+#endif
+}
+
+/**
+ * The best way to warp-vote-any
+ */
+template <int LOG_ACTIVE_WARPS, int LOG_ACTIVE_THREADS>
+__device__ __forceinline__ int WarpVoteAny(int predicate)
+{
+#if __CUDA_ARCH__ >= 120
+	return __any(predicate);
+#else
+	return TallyWarpVote<LOG_ACTIVE_WARPS, LOG_ACTIVE_THREADS>(predicate);
+#endif
+}
+
+
+/**
+ * The best way to warp-vote-any in the first warp
+ */
+template <int LOG_ACTIVE_THREADS>
+__device__ __forceinline__ int WarpVoteAny(int predicate)
+{
+#if __CUDA_ARCH__ >= 120
+	return __any(predicate);
+#else
+	const int ACTIVE_THREADS = 1 << LOG_ACTIVE_THREADS;
+	__shared__ volatile int storage[2][ACTIVE_THREADS];
+
+	return TallyWarpVote<LOG_ACTIVE_THREADS>(predicate, storage);
+#endif
+}
+
+
+/**
+ * Wrapper for performing atomic operations on integers of type size_t 
+ */
+template <typename T, int SizeT = sizeof(T)>
+struct AtomicInt;
+
+template <typename T>
+struct AtomicInt<T, 4>
+{
+	static __device__ __forceinline__ T Add(T* ptr, T val)
+	{
+		return atomicAdd((unsigned int *) ptr, (unsigned int) val);
+	}
+};
+
+template <typename T>
+struct AtomicInt<T, 8>
+{
+	static __device__ __forceinline__ T Add(T* ptr, T val)
+	{
+		return atomicAdd((unsigned long long int *) ptr, (unsigned long long int) val);
+	}
+};
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/enactor_base.cuh
+++ b/include/b40c/util/enactor_base.cuh
@@ -1,0 +1,583 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Enactor base class
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/cta_work_distribution.cuh>
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/util/error_utils.cuh>
+
+namespace b40c {
+namespace util {
+
+
+
+/**
+ * Enactor base class
+ */
+class EnactorBase
+{
+public:
+
+	//---------------------------------------------------------------------
+	// Utility Fields
+	//---------------------------------------------------------------------
+
+	// Debug level.  If set, the enactor blocks after kernel calls to check
+	// for successful launch/execution
+	bool ENACTOR_DEBUG;
+
+
+	// The arch version of the code for the current device that actually have
+	// compiled kernels for
+	int PtxVersion()
+	{
+		return this->cuda_props.kernel_ptx_version;
+	}
+
+	// The number of SMs on the current device
+	int SmCount()
+	{
+		return this->cuda_props.device_props.multiProcessorCount;
+	}
+
+protected:
+
+	template <typename MyType, typename DerivedType = void>
+	struct DispatchType
+	{
+		typedef DerivedType Type;
+	};
+
+	template <typename MyType>
+	struct DispatchType<MyType, void>
+	{
+		typedef MyType Type;
+	};
+
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Device properties
+	const util::CudaProperties cuda_props;
+
+
+	//---------------------------------------------------------------------
+	// Tuning Utility Routines
+	//---------------------------------------------------------------------
+
+	/**
+	 * Computes dynamic smem allocations to ensure all three kernels end up
+	 * allocating the same amount of smem per CTA
+	 */
+	template <
+		typename UpsweepKernelPtr,
+		typename SpineKernelPtr,
+		typename DownsweepKernelPtr>
+	cudaError_t PadUniformSmem(
+		int dynamic_smem[3],
+		UpsweepKernelPtr UpsweepKernel,
+		SpineKernelPtr SpineKernel,
+		DownsweepKernelPtr DownsweepKernel)
+	{
+		cudaError_t retval = cudaSuccess;
+		do {
+
+			// Get kernel attributes
+			cudaFuncAttributes upsweep_kernel_attrs, spine_kernel_attrs, downsweep_kernel_attrs;
+			if (retval = util::B40CPerror(cudaFuncGetAttributes(&upsweep_kernel_attrs, UpsweepKernel),
+				"EnactorBase cudaFuncGetAttributes upsweep_kernel_attrs failed", __FILE__, __LINE__)) break;
+			if (retval = util::B40CPerror(cudaFuncGetAttributes(&spine_kernel_attrs, SpineKernel),
+				"EnactorBase cudaFuncGetAttributes spine_kernel_attrs failed", __FILE__, __LINE__)) break;
+			if (retval = util::B40CPerror(cudaFuncGetAttributes(&downsweep_kernel_attrs, DownsweepKernel),
+				"EnactorBase cudaFuncGetAttributes spine_kernel_attrs failed", __FILE__, __LINE__)) break;
+
+			int max_static_smem = B40C_MAX(
+				upsweep_kernel_attrs.sharedSizeBytes,
+				B40C_MAX(spine_kernel_attrs.sharedSizeBytes, downsweep_kernel_attrs.sharedSizeBytes));
+
+			dynamic_smem[0] = max_static_smem - upsweep_kernel_attrs.sharedSizeBytes;
+			dynamic_smem[1] = max_static_smem - spine_kernel_attrs.sharedSizeBytes;
+			dynamic_smem[2] = max_static_smem - downsweep_kernel_attrs.sharedSizeBytes;
+
+		} while (0);
+
+		return retval;
+	}
+
+
+	/**
+	 * Computes dynamic smem allocations to ensure both kernels end up
+	 * allocating the same amount of smem per CTA
+	 */
+	template <
+		typename UpsweepKernelPtr,
+		typename SpineKernelPtr>
+	cudaError_t PadUniformSmem(
+		int dynamic_smem[2],				// out param
+		UpsweepKernelPtr UpsweepKernel,
+		SpineKernelPtr SpineKernel)
+	{
+		cudaError_t retval = cudaSuccess;
+		do {
+
+			// Get kernel attributes
+			cudaFuncAttributes upsweep_kernel_attrs, spine_kernel_attrs;
+			if (retval = util::B40CPerror(cudaFuncGetAttributes(&upsweep_kernel_attrs, UpsweepKernel),
+				"EnactorBase cudaFuncGetAttributes upsweep_kernel_attrs failed", __FILE__, __LINE__)) break;
+			if (retval = util::B40CPerror(cudaFuncGetAttributes(&spine_kernel_attrs, SpineKernel),
+				"EnactorBase cudaFuncGetAttributes spine_kernel_attrs failed", __FILE__, __LINE__)) break;
+
+			int max_static_smem = B40C_MAX(
+				upsweep_kernel_attrs.sharedSizeBytes,
+				spine_kernel_attrs.sharedSizeBytes);
+
+			dynamic_smem[0] = max_static_smem - upsweep_kernel_attrs.sharedSizeBytes;
+			dynamic_smem[1] = max_static_smem - spine_kernel_attrs.sharedSizeBytes;
+
+		} while (0);
+
+		return retval;
+	}
+
+
+	template <typename KernelPtr>
+	cudaError_t MaxCtaOccupancy(
+		int &max_cta_occupancy,					// out param
+		KernelPtr Kernel,
+		int threads)
+	{
+		cudaError_t retval = cudaSuccess;
+		do {
+			// Get kernel attributes
+			cudaFuncAttributes kernel_attrs;
+			if (retval = util::B40CPerror(cudaFuncGetAttributes(&kernel_attrs, Kernel),
+				"EnactorBase cudaFuncGetAttributes kernel_attrs failed", __FILE__, __LINE__)) break;
+
+			max_cta_occupancy = B40C_MIN(
+				B40C_SM_CTAS(cuda_props.device_sm_version),
+				B40C_MIN(
+					B40C_SM_THREADS(cuda_props.device_sm_version) / threads,
+					B40C_MIN(
+						(kernel_attrs.sharedSizeBytes > 0) ?
+							B40C_SMEM_BYTES(cuda_props.device_sm_version) / (kernel_attrs.sharedSizeBytes) :
+							B40C_SMEM_BYTES(cuda_props.device_sm_version),
+						B40C_SM_REGISTERS(cuda_props.device_sm_version) / (kernel_attrs.numRegs * threads))));
+
+			if (ENACTOR_DEBUG) printf("Occupancy:\t[sweep occupancy: %d]\n", max_cta_occupancy);
+
+		} while (0);
+
+		return retval;
+
+	}
+
+	template <
+		typename UpsweepKernelPtr,
+		typename DownsweepKernelPtr>
+	cudaError_t MaxCtaOccupancy(
+		int &max_cta_occupancy,					// out param
+		UpsweepKernelPtr UpsweepKernel,
+		int upsweep_threads,
+		DownsweepKernelPtr DownsweepKernel,
+		int downsweep_threads)
+	{
+		cudaError_t retval = cudaSuccess;
+		do {
+			int upsweep_cta_occupancy, downsweep_cta_occupancy;
+
+			bool old_debug = ENACTOR_DEBUG;
+			ENACTOR_DEBUG = false;
+
+			if (retval = MaxCtaOccupancy(upsweep_cta_occupancy, UpsweepKernel, upsweep_threads)) break;
+			if (retval = MaxCtaOccupancy(downsweep_cta_occupancy, DownsweepKernel, downsweep_threads)) break;
+
+			ENACTOR_DEBUG = old_debug;
+
+			if (ENACTOR_DEBUG) printf("Occupancy:\t[upsweep occupancy: %d, downsweep occupancy %d]\n",
+				upsweep_cta_occupancy, downsweep_cta_occupancy);
+
+			max_cta_occupancy = B40C_MIN(upsweep_cta_occupancy, downsweep_cta_occupancy);
+
+		} while (0);
+
+		return retval;
+
+	}
+
+
+
+	/**
+	 * Returns the number of threadblocks to launch for the given problem size.
+	 * Does not exceed the full-occupancy on the current device or the
+	 * optional max_grid_size limit.
+	 *
+	 * Useful for kernels that work-steal or use global barriers (where
+	 * over-subscription is not ideal or allowed)
+	 */
+	int OccupiedGridSize(
+		int schedule_granularity,
+		int max_cta_occupancy,
+		int num_elements,
+		int max_grid_size = 0)
+	{
+		int grid_size;
+
+		if (max_grid_size > 0) {
+			grid_size = max_grid_size;
+		} else {
+			grid_size = cuda_props.device_props.multiProcessorCount * max_cta_occupancy;
+		}
+
+		// Reduce if we have less work than we can divide up among this
+		// many CTAs
+		int grains = (num_elements + schedule_granularity - 1) / schedule_granularity;
+		if (grid_size > grains) {
+			grid_size = grains;
+		}
+
+
+		return grid_size;
+	}
+
+
+	/**
+	 * Returns the number of threadblocks to launch for the given problem size.
+	 * May over/under subscribe the current device based upon heuristics.  Does not
+	 * the optional max_grid_size limit.
+	 *
+	 * Useful for kernels that evenly divide up the work amongst threadblocks.
+	 */
+	int OversubscribedGridSize(
+		int schedule_granularity,
+		int max_cta_occupancy,
+		int num_elements,
+		int max_grid_size)
+	{
+		int grid_size;
+
+		if (max_grid_size > 0) {
+
+			grid_size = max_grid_size;
+
+		} else {
+
+			if (cuda_props.device_sm_version < 120) {
+
+				// G80/G90: double CTA occupancy times SM count
+				grid_size = cuda_props.device_props.multiProcessorCount * max_cta_occupancy * 2;
+
+			} else if (cuda_props.device_sm_version < 200) {
+
+				// GT200: Special sauce
+
+				// Start with with full downsweep occupancy of all SMs
+				grid_size =
+					cuda_props.device_props.multiProcessorCount * max_cta_occupancy;
+
+				// Increase by default every 64 million key-values
+				int step = 1024 * 1024 * 64;
+				grid_size *= (num_elements + step - 1) / step;
+
+				double multiplier1 = 4.0;
+				double multiplier2 = 16.0;
+
+				double delta1 = 0.068;
+				double delta2 = 0.1285;
+
+				int dividend = (num_elements + 512 - 1) / 512;
+
+				int bumps = 0;
+				while(true) {
+
+					if (grid_size <= cuda_props.device_props.multiProcessorCount) {
+						break;
+					}
+
+					double quotient = ((double) dividend) / (multiplier1 * grid_size);
+					quotient -= (int) quotient;
+
+					if ((quotient > delta1) && (quotient < 1 - delta1)) {
+
+						quotient = ((double) dividend) / (multiplier2 * grid_size / 3.0);
+						quotient -= (int) quotient;
+
+						if ((quotient > delta2) && (quotient < 1 - delta2)) {
+							break;
+						}
+					}
+
+					if (bumps == 3) {
+						// Bump it down by 27
+						grid_size -= 27;
+						bumps = 0;
+					} else {
+						// Bump it down by 1
+						grid_size--;
+						bumps++;
+					}
+				}
+
+			} else {
+
+				// GF10x
+				if (cuda_props.device_sm_version == 210) {
+					// GF110
+					grid_size = 4 * (cuda_props.device_props.multiProcessorCount * max_cta_occupancy);
+				} else {
+					// Anything but GF110
+					grid_size = 4 * (cuda_props.device_props.multiProcessorCount * max_cta_occupancy) - 2;
+				}
+			}
+		}
+
+
+		// Reduce if we have less work than we can divide up among this
+		// many CTAs
+		int grains = (num_elements + schedule_granularity - 1) / schedule_granularity;
+		if (grid_size > grains) {
+			grid_size = grains;
+		}
+
+		return grid_size;
+	}
+
+
+	/**
+	 * Returns the number of threadblocks to launch for the given problem size.
+	 */
+	int GridSize(
+		bool oversubscribed,
+		int schedule_granularity,
+		int max_cta_occupancy,
+		int num_elements,
+		int max_grid_size)
+	{
+		return (oversubscribed) ?
+			OversubscribedGridSize(
+				schedule_granularity,
+				max_cta_occupancy,
+				num_elements,
+				max_grid_size) :
+			OccupiedGridSize(
+				schedule_granularity,
+				max_cta_occupancy,
+				num_elements,
+				max_grid_size);
+	}
+
+	//-----------------------------------------------------------------------------
+	// Debug Utility Routines
+	//-----------------------------------------------------------------------------
+
+	/**
+	 * Utility method to display the contents of a device array
+	 */
+	template <typename T>
+	void DisplayDeviceResults(
+		T *d_data,
+		size_t num_elements)
+	{
+		// Allocate array on host and copy back
+		T *h_data = (T*) malloc(num_elements * sizeof(T));
+		cudaMemcpy(h_data, d_data, sizeof(T) * num_elements, cudaMemcpyDeviceToHost);
+
+		// Display data
+		for (int i = 0; i < num_elements; i++) {
+			PrintValue(h_data[i]);
+			printf(", ");
+		}
+		printf("\n\n");
+
+		// Cleanup
+		if (h_data) free(h_data);
+	}
+
+
+	/**
+	 * Prints key size information
+	 */
+	template <typename KernelPolicy>
+	bool PrintKeySizeInfo(typename KernelPolicy::KeyType *ptr) {
+		printf("%lu byte keys, ", (unsigned long) sizeof(typename KernelPolicy::KeyType));
+		return true;
+	}
+	template <typename KernelPolicy>
+	bool PrintKeySizeInfo(...) {return false;}
+
+	/**
+	 * Prints value size information
+	 */
+	template <typename KernelPolicy>
+	bool PrintValueSizeInfo(typename KernelPolicy::ValueType *ptr) {
+		if (!util::Equals<typename KernelPolicy::ValueType, util::NullType>::VALUE) {
+			printf("%lu byte values, ", (unsigned long) sizeof(typename KernelPolicy::ValueType));
+		}
+		return true;
+	}
+	template <typename KernelPolicy>
+	bool PrintValueSizeInfo(...) {return false;}
+
+	/**
+	 * Prints T size information
+	 */
+	template <typename KernelPolicy>
+	bool PrintTSizeInfo(typename KernelPolicy::T *ptr) {
+		printf("%lu byte data, ", (unsigned long) sizeof(typename KernelPolicy::T));
+		return true;
+	}
+	template <typename KernelPolicy>
+	bool PrintTSizeInfo(...) {return false;}
+
+	/**
+	 * Prints workstealing information
+	 */
+	template <typename KernelPolicy>
+	bool PrintWorkstealingInfo(int (*data)[KernelPolicy::WORK_STEALING + 1]) {
+		printf("%sworkstealing, ", (KernelPolicy::WORK_STEALING) ? "" : "non-");
+		return true;
+	}
+	template <typename KernelPolicy>
+	bool PrintWorkstealingInfo(...) {return false;}
+
+	/**
+	 * Prints work distribution information
+	 */
+	template <typename KernelPolicy, typename SizeT>
+	void PrintWorkInfo(util::CtaWorkDistribution<SizeT> &work)
+	{
+		printf("Work: \t\t[");
+		if (PrintKeySizeInfo<KernelPolicy>(NULL)) {
+			PrintValueSizeInfo<KernelPolicy>(NULL);
+		} else {
+			PrintTSizeInfo<KernelPolicy>(NULL);
+		}
+		PrintWorkstealingInfo<KernelPolicy>(NULL);
+
+		unsigned long last_grain_elements =
+			(work.num_elements & (KernelPolicy::SCHEDULE_GRANULARITY - 1));
+		if (last_grain_elements == 0) last_grain_elements = KernelPolicy::SCHEDULE_GRANULARITY;
+
+		printf("%lu byte SizeT, "
+				"%lu elements, "
+				"%lu-element granularity, "
+				"%lu total grains, "
+				"%lu grains per cta, "
+				"%lu extra grains, "
+				"%lu last-grain elements]\n",
+			(unsigned long) sizeof(SizeT),
+			(unsigned long) work.num_elements,
+			(unsigned long) KernelPolicy::SCHEDULE_GRANULARITY,
+			(unsigned long) work.total_grains,
+			(unsigned long) work.grains_per_cta,
+			(unsigned long) work.extra_grains,
+			(unsigned long) last_grain_elements);
+		fflush(stdout);
+	}
+
+
+	/**
+	 * Prints pass information
+	 */
+	template <typename UpsweepPolicy, typename SizeT>
+	void PrintPassInfo(
+		util::CtaWorkDistribution<SizeT> &work,
+		int spine_elements = 0)
+	{
+		printf("CodeGen: \t[device_sm_version: %d, kernel_ptx_version: %d, SM count: %d]\n",
+			cuda_props.device_sm_version,
+			cuda_props.kernel_ptx_version,
+			cuda_props.device_props.multiProcessorCount);
+		PrintWorkInfo<UpsweepPolicy, SizeT>(work);
+		printf("Upsweep: \t[sweep_grid_size: %d, threads %d, tile_elements: %d]\n",
+			work.grid_size,
+			UpsweepPolicy::THREADS,
+			UpsweepPolicy::TILE_ELEMENTS);
+		fflush(stdout);
+	}
+
+	/**
+	 * Prints pass information
+	 */
+	template <typename UpsweepPolicy, typename SpinePolicy, typename SizeT>
+	void PrintPassInfo(
+		util::CtaWorkDistribution<SizeT> &work,
+		int spine_elements = 0)
+	{
+		PrintPassInfo<UpsweepPolicy>(work);
+		printf("Spine: \t\t[threads: %d, spine_elements: %d, tile_elements: %d]\n",
+			SpinePolicy::THREADS,
+			spine_elements,
+			SpinePolicy::TILE_ELEMENTS);
+		fflush(stdout);
+	}
+
+	/**
+	 * Prints pass information
+	 */
+	template <typename UpsweepPolicy, typename SpinePolicy, typename DownsweepPolicy, typename SizeT>
+	void PrintPassInfo(
+		util::CtaWorkDistribution<SizeT> &work,
+		int spine_elements = 0)
+	{
+		PrintPassInfo<UpsweepPolicy, SpinePolicy>(work, spine_elements);
+		printf("Downsweep: \t[sweep_grid_size: %d, threads %d, tile_elements: %d]\n",
+			work.grid_size,
+			DownsweepPolicy::THREADS,
+			DownsweepPolicy::TILE_ELEMENTS);
+		fflush(stdout);
+	}
+
+
+
+
+	//---------------------------------------------------------------------
+	// Constructors
+	//---------------------------------------------------------------------
+
+	EnactorBase() :
+#if	defined(__THRUST_SYNCHRONOUS) || defined(DEBUG) || defined(_DEBUG)
+			ENACTOR_DEBUG(true)
+#else
+			ENACTOR_DEBUG(false)
+#endif
+		{}
+
+};
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/error_utils.cuh
+++ b/include/b40c/util/error_utils.cuh
@@ -1,0 +1,108 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Error handling utility routines
+ ******************************************************************************/
+
+#pragma once
+
+#include <stdio.h>
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Displays error message in accordance with debug mode
+ */
+cudaError_t B40CPerror(
+	cudaError_t error,
+	const char *message,
+	const char *filename,
+	int line,
+	bool print = true)
+{
+	if (error && print) {
+		fprintf(stderr, "[%s, %d] %s (CUDA error %d: %s)\n", filename, line, message, error, cudaGetErrorString(error));
+		fflush(stderr);
+	}
+	return error;
+}
+
+/**
+ * Checks and resets last CUDA error.  If set, displays last error message in accordance with debug mode.
+ */
+cudaError_t B40CPerror(
+	const char *message,
+	const char *filename,
+	int line,
+	bool print = true)
+{
+	cudaError_t error = cudaGetLastError();
+	if (error && print) {
+
+		fprintf(stderr, "[%s, %d] %s (CUDA error %d: %s)\n", filename, line, message, error, cudaGetErrorString(error));
+		fflush(stderr);
+	}
+	return error;
+}
+
+/**
+ * Displays error message in accordance with debug mode
+ */
+cudaError_t B40CPerror(
+	cudaError_t error,
+	bool print = true)
+{
+	if (error && print) {
+		fprintf(stderr, "(CUDA error %d: %s)\n", error, cudaGetErrorString(error));
+		fflush(stderr);
+	}
+	return error;
+}
+
+
+/**
+ * Checks and resets last CUDA error.  If set, displays last error message in accordance with debug mode.
+ */
+cudaError_t B40CPerror(
+	bool print = true)
+{
+	cudaError_t error = cudaGetLastError();
+	if (error && print) {
+		fprintf(stderr, "(CUDA error %d: %s)\n", error, cudaGetErrorString(error));
+		fflush(stderr);
+	}
+	return error;
+}
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/global_barrier.cuh
+++ b/include/b40c/util/global_barrier.cuh
@@ -1,0 +1,213 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Software Global Barrier
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/memset_kernel.cuh>
+#include <b40c/util/error_utils.cuh>
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Manages device storage needed for implementing a global software barrier
+ * between CTAs in a single grid
+ */
+class GlobalBarrier
+{
+public:
+
+	typedef unsigned int SyncFlag;
+
+protected :
+
+
+	// Counters in global device memory
+	SyncFlag* d_sync;
+
+	/**
+	 * Simple wrapper for returning a CG-loaded SyncFlag at the specified pointer
+	 */
+	__device__ __forceinline__ SyncFlag LoadCG(SyncFlag* d_ptr) const
+	{
+		SyncFlag retval;
+		util::io::ModifiedLoad<util::io::ld::cg>::Ld(retval, d_ptr);
+		return retval;
+	}
+
+public:
+
+	/**
+	 * Constructor
+	 */
+	GlobalBarrier() : d_sync(NULL) {}
+
+
+	/**
+	 * Synchronize
+	 */
+	__device__ __forceinline__ void Sync() const
+	{
+        volatile SyncFlag *d_vol_sync = d_sync;
+
+        // Threadfence and syncthreads to make sure global writes are visible before
+		// thread-0 reports in with its sync counter
+		__threadfence();
+		__syncthreads();
+
+		if (blockIdx.x == 0) {
+
+			// Report in ourselves
+			if (threadIdx.x == 0) {
+			    d_vol_sync[blockIdx.x] = 1;
+			}
+
+			__syncthreads();
+
+			// Wait for everyone else to report in
+			for (int peer_block = threadIdx.x; peer_block < gridDim.x; peer_block += blockDim.x) {
+				while (LoadCG(d_sync + peer_block) == 0) {
+					__threadfence_block();
+				}
+			}
+
+			__syncthreads();
+
+			// Let everyone know it's safe to read their prefix sums
+			for (int peer_block = threadIdx.x; peer_block < gridDim.x; peer_block += blockDim.x) {
+			    d_vol_sync[peer_block] = 0;
+			}
+
+		} else {
+
+			if (threadIdx.x == 0) {
+				// Report in
+			    d_vol_sync[blockIdx.x] = 1;
+
+				// Wait for acknowledgement
+				while (LoadCG(d_sync + blockIdx.x) == 1) {
+					__threadfence_block();
+				}
+			}
+
+			__syncthreads();
+		}
+	}
+};
+
+
+/**
+ * Version of global barrier with storage lifetime management.
+ *
+ * We can use this in host enactors, and pass the base GlobalBarrier
+ * as parameters to kernels.
+ */
+class GlobalBarrierLifetime : public GlobalBarrier
+{
+protected:
+
+	// Number of bytes backed by d_sync
+	size_t sync_bytes;
+
+public:
+
+	/**
+	 * Constructor
+	 */
+	GlobalBarrierLifetime() : GlobalBarrier(), sync_bytes(0) {}
+
+
+	/**
+	 * Deallocates and resets the progress counters
+	 */
+	cudaError_t HostReset()
+	{
+		cudaError_t retval = cudaSuccess;
+		if (d_sync) {
+			retval = util::B40CPerror(cudaFree(d_sync), "GlobalBarrier cudaFree d_sync failed: ", __FILE__, __LINE__);
+			d_sync = NULL;
+		}
+		sync_bytes = 0;
+		return retval;
+	}
+
+
+	/**
+	 * Destructor
+	 */
+	virtual ~GlobalBarrierLifetime()
+	{
+		HostReset();
+	}
+
+
+	/**
+	 * Sets up the progress counters for the next kernel launch (lazily
+	 * allocating and initializing them if necessary)
+	 */
+	cudaError_t Setup(int sweep_grid_size)
+	{
+		cudaError_t retval = cudaSuccess;
+		do {
+			size_t new_sync_bytes = sweep_grid_size * sizeof(SyncFlag);
+			if (new_sync_bytes > sync_bytes) {
+
+				if (d_sync) {
+					if (retval = util::B40CPerror(cudaFree(d_sync),
+						"GlobalBarrierLifetime cudaFree d_sync failed", __FILE__, __LINE__)) break;
+				}
+
+				sync_bytes = new_sync_bytes;
+
+				if (retval = util::B40CPerror(cudaMalloc((void**) &d_sync, sync_bytes),
+					"GlobalBarrierLifetime cudaMalloc d_sync failed", __FILE__, __LINE__)) break;
+
+				// Initialize to zero
+				util::MemsetKernel<SyncFlag><<<(sweep_grid_size + 128 - 1) / 128, 128>>>(
+					d_sync, 0, sweep_grid_size);
+				if (retval = util::B40CPerror(cudaThreadSynchronize(),
+					"GlobalBarrierLifetime MemsetKernel d_sync failed", __FILE__, __LINE__)) break;
+			}
+		} while (0);
+
+		return retval;
+	}
+};
+
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/io/gather_tile.cuh
+++ b/include/b40c/util/io/gather_tile.cuh
@@ -1,0 +1,158 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Kernel utilities for gathering data
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/modified_load.cuh>
+#include <b40c/util/operators.cuh>
+
+namespace b40c {
+namespace util {
+namespace io {
+
+
+
+
+/**
+ * Gather a tile of data items using the corresponding tile of gather_offsets
+ *
+ * Uses vec-1 loads.
+ */
+template <
+	int LOG_LOADS_PER_TILE,
+	int LOG_LOAD_VEC_SIZE,
+	int ACTIVE_THREADS,								// Active threads that will be loading
+	ld::CacheModifier CACHE_MODIFIER>				// Cache modifier (e.g., CA/CG/CS/NONE/etc.)
+struct GatherTile
+{
+	static const int LOADS_PER_TILE = 1 << LOG_LOADS_PER_TILE;
+	static const int LOAD_VEC_SIZE = 1 << LOG_LOAD_VEC_SIZE;
+
+
+	//---------------------------------------------------------------------
+	// Helper Structures
+	//---------------------------------------------------------------------
+
+	// Iterate next vec
+	template <int LOAD, int VEC, int dummy = 0>
+	struct Iterate
+	{
+		// predicated on valid
+		template <typename T, void Transform(T&, bool), typename Flag>
+		static __device__ __forceinline__ void Invoke(
+			T *src,
+			T dest[][LOAD_VEC_SIZE],
+			Flag valid_flags[][LOAD_VEC_SIZE])
+		{
+			T *d_src = src + (LOAD * LOAD_VEC_SIZE * ACTIVE_THREADS) + (threadIdx.x << LOG_LOAD_VEC_SIZE) + VEC;
+
+			if (valid_flags[LOAD][VEC]) {
+				ModifiedLoad<CACHE_MODIFIER>::Ld(dest[LOAD][VEC], d_src);
+				Transform(dest[LOAD][VEC], true);
+			} else {
+				Transform(dest[LOAD][VEC], false);
+			}
+
+			Iterate<LOAD, VEC + 1>::template Invoke<T, Transform, Flag>(
+				src, dest, valid_flags);
+		}
+	};
+
+	// Iterate next load
+	template <int LOAD, int dummy>
+	struct Iterate<LOAD, LOAD_VEC_SIZE, dummy>
+	{
+		// predicated on valid
+		template <typename T, void Transform(T&, bool), typename Flag>
+		static __device__ __forceinline__ void Invoke(
+			T *src,
+			T dest[][LOAD_VEC_SIZE],
+			Flag valid_flags[][LOAD_VEC_SIZE])
+		{
+			Iterate<LOAD + 1, 0>::template Invoke<T, Transform, Flag>(
+				src, dest, valid_flags);
+		}
+	};
+
+	// Terminate
+	template <int dummy>
+	struct Iterate<LOADS_PER_TILE, 0, dummy>
+	{
+		// predicated on valid
+		template <typename T, void Transform(T&, bool), typename Flag>
+		static __device__ __forceinline__ void Invoke(
+			T *src,
+			T dest[][LOAD_VEC_SIZE],
+			Flag valid_flags[][LOAD_VEC_SIZE]) {}
+	};
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Gather to destination with transform, predicated on the valid flag
+	 */
+	template <
+		typename T,
+		void Transform(T&, bool), 							// Assignment function to transform the loaded value
+		typename Flag>
+	static __device__ __forceinline__ void Gather(
+		T *src,
+		T dest[][LOAD_VEC_SIZE],
+		Flag valid_flags[][LOAD_VEC_SIZE])
+	{
+		Iterate<0, 0>::template Invoke<T, Transform>(
+			src, dest, valid_flags);
+	}
+
+	/**
+	 * Gather to destination predicated on the valid flag
+	 */
+	template <typename T, typename Flag>
+	static __device__ __forceinline__ void Gather(
+		T *src,
+		T dest[][LOAD_VEC_SIZE],
+		Flag valid_flags[][LOAD_VEC_SIZE])
+	{
+		Gather<T, NopLdTransform<T>, Flag>(
+			src, dest, valid_flags);
+	}
+
+};
+
+
+
+} // namespace io
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/io/initialize_tile.cuh
+++ b/include/b40c/util/io/initialize_tile.cuh
@@ -1,0 +1,300 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Kernel utilities for initializing 2D arrays (tiles)
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace util {
+namespace io {
+
+
+/**
+ * Initialize a tile of items
+ */
+template <
+	int LOG_LOADS_PER_TILE,
+	int LOG_LOAD_VEC_SIZE,
+	int ACTIVE_THREADS>
+struct InitializeTile
+{
+	enum {
+		LOADS_PER_TILE 				= 1 << LOG_LOADS_PER_TILE,
+		LOAD_VEC_SIZE 				= 1 << LOG_LOAD_VEC_SIZE,
+		LOG_ELEMENTS_PER_THREAD		= LOG_LOADS_PER_TILE + LOG_LOAD_VEC_SIZE,
+		ELEMENTS_PER_THREAD			= 1 << LOG_ELEMENTS_PER_THREAD,
+		TILE_SIZE 					= ACTIVE_THREADS * ELEMENTS_PER_THREAD,
+	};
+
+	//---------------------------------------------------------------------
+	// Helper Structures
+	//---------------------------------------------------------------------
+
+	// Iterate over vec-elements
+	template <int LOAD, int VEC>
+	struct Iterate
+	{
+		template <typename T, typename S>
+		static __device__ __forceinline__ void Copy(
+			T target[][LOAD_VEC_SIZE],
+			S source[][LOAD_VEC_SIZE])
+		{
+			target[LOAD][VEC] = source[LOAD][VEC];
+			Iterate<LOAD, VEC + 1>::Copy(target, source);
+		}
+
+		template <typename T, typename S>
+		static __device__ __forceinline__ void Init(
+			T target[][LOAD_VEC_SIZE],
+			S datum)
+		{
+			target[LOAD][VEC] = datum;
+			Iterate<LOAD, VEC + 1>::Init(target, datum);
+		}
+
+		template <typename T, typename S, typename TransformOp>
+		static __device__ __forceinline__ void Transform(
+			T target[][LOAD_VEC_SIZE],
+			S source[][LOAD_VEC_SIZE],
+			TransformOp transform_op)
+		{
+			target[LOAD][VEC] = transform_op(source[LOAD][VEC]);
+			Iterate<LOAD, VEC + 1>::Transform(target, source, transform_op);
+		}
+
+		template <typename T, typename S, typename TransformOp, typename SizeT>
+		static __device__ __forceinline__ void Transform(
+			T target[][LOAD_VEC_SIZE],
+			S source[][LOAD_VEC_SIZE],
+			TransformOp transform_op,
+			const SizeT &guarded_elements,
+			T oob_default)
+		{
+			SizeT thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + VEC;
+
+			target[LOAD][VEC] = (thread_offset < guarded_elements) ?
+				transform_op(source[LOAD][VEC]) :
+				oob_default;
+
+			Iterate<LOAD, VEC + 1>::Transform(
+				target,
+				source,
+				transform_op,
+				guarded_elements,
+				oob_default);
+		}
+
+		template <typename SoaT, typename SoaS, typename TransformOp>
+		static __device__ __forceinline__ void Transform(
+			SoaT target_soa,
+			SoaS source_soa,
+			TransformOp transform_op)
+		{
+			SoaS source;
+			source_soa.Get(source, LOAD, VEC);
+			SoaT target = transform_op(source);
+			target_soa.Set(target, LOAD, VEC);
+			Iterate<LOAD, VEC + 1>::Transform(target, source, transform_op);
+		}
+	};
+
+	// Iterate over loads
+	template <int LOAD>
+	struct Iterate<LOAD, LOAD_VEC_SIZE>
+	{
+		template <typename T, typename S>
+		static __device__ __forceinline__ void Copy(
+			T target[][LOAD_VEC_SIZE],
+			S source[][LOAD_VEC_SIZE])
+		{
+			Iterate<LOAD + 1, 0>::Copy(target, source);
+		}
+
+		template <typename T, typename S>
+		static __device__ __forceinline__ void Init(
+			T target[][LOAD_VEC_SIZE],
+			S datum)
+		{
+			Iterate<LOAD + 1, 0>::Init(target, datum);
+		}
+
+		template <typename T, typename S, typename TransformOp>
+		static __device__ __forceinline__ void Transform(
+			T target[][LOAD_VEC_SIZE],
+			S source[][LOAD_VEC_SIZE],
+			TransformOp transform_op)
+		{
+			Iterate<LOAD + 1, 0>::Transform(target, source, transform_op);
+		}
+
+		template <typename T, typename S, typename TransformOp, typename SizeT>
+		static __device__ __forceinline__ void Transform(
+			T target[][LOAD_VEC_SIZE],
+			S source[][LOAD_VEC_SIZE],
+			TransformOp transform_op,
+			const SizeT &guarded_elements,
+			T oob_default)
+		{
+			Iterate<LOAD + 1, 0>::Transform(target, source, transform_op, guarded_elements, oob_default);
+		}
+
+		template <typename SoaT, typename SoaS, typename TransformOp>
+		static __device__ __forceinline__ void Transform(
+			SoaT target_soa,
+			SoaS source_soa,
+			TransformOp transform_op)
+		{
+			Iterate<LOAD + 1, 0>::Transform(target_soa, source_soa, transform_op);
+		}
+	};
+
+	// Terminate
+	template <int VEC>
+	struct Iterate<LOADS_PER_TILE, VEC>
+	{
+		template <typename T, typename S>
+		static __device__ __forceinline__ void Copy(
+			T target[][LOAD_VEC_SIZE],
+			S source[][LOAD_VEC_SIZE]) {}
+
+		template <typename T, typename S>
+		static __device__ __forceinline__ void Init(
+			T target[][LOAD_VEC_SIZE],
+			S datum) {}
+
+		template <typename T, typename S, typename TransformOp>
+		static __device__ __forceinline__ void Transform(
+			T target[][LOAD_VEC_SIZE],
+			S source[][LOAD_VEC_SIZE],
+			TransformOp transform_op) {}
+
+		template <typename T, typename S, typename TransformOp, typename SizeT>
+		static __device__ __forceinline__ void Transform(
+			T target[][LOAD_VEC_SIZE],
+			S source[][LOAD_VEC_SIZE],
+			TransformOp transform_op,
+			const SizeT &guarded_elements,
+			T oob_default) {}
+
+		template <typename SoaT, typename SoaS, typename TransformOp>
+		static __device__ __forceinline__ void Transform(
+			SoaT target_soa,
+			SoaS source_soa,
+			TransformOp transform_op) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Copy source to target
+	 */
+	template <typename T, typename S>
+	static __device__ __forceinline__ void Copy(
+		T target[][LOAD_VEC_SIZE],
+		S source[][LOAD_VEC_SIZE])
+	{
+		Iterate<0, 0>::Copy(target, source);
+	}
+
+
+	/**
+	 * Initialize target with datum
+	 */
+	template <typename T, typename S>
+	static __device__ __forceinline__ void Init(
+		T target[][LOAD_VEC_SIZE],
+		S datum)
+	{
+		Iterate<0, 0>::Init(target, datum);
+	}
+
+
+	/**
+	 * Apply unary transform_op operator to source
+	 */
+	template <typename T, typename S, typename TransformOp>
+	static __device__ __forceinline__ void Transform(
+		T target[][LOAD_VEC_SIZE],
+		S source[][LOAD_VEC_SIZE],
+		TransformOp transform_op)
+	{
+		Iterate<0, 0>::Transform(target, source, transform_op);
+	}
+
+	/**
+	 * Apply unary transform_op operator to source (guarded)
+	 */
+	template <typename T, typename S, typename TransformOp, typename SizeT>
+	static __device__ __forceinline__ void Transform(
+		T target[][LOAD_VEC_SIZE],
+		S source[][LOAD_VEC_SIZE],
+		TransformOp transform_op,
+		const SizeT &guarded_elements,
+		T oob_default)
+	{
+		if (guarded_elements >= TILE_SIZE) {
+
+			// unguarded
+			Transform(target, source, transform_op);
+
+		} else {
+
+			// guarded
+			Iterate<0, 0>::Transform(
+				target,
+				source,
+				transform_op,
+				guarded_elements,
+				oob_default);
+		}
+	}
+
+	/**
+	 * Apply structure-of-array transform_op operator to source
+	 */
+	template <typename SoaT, typename SoaS, typename TransformOp>
+	static __device__ __forceinline__ void Transform(
+		SoaT target_soa,
+		SoaS source_soa,
+		TransformOp transform_op)
+	{
+		Iterate<0, 0>::Transform(target_soa, source_soa, transform_op);
+	}
+};
+
+
+} // namespace io
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/io/load_tile.cuh
+++ b/include/b40c/util/io/load_tile.cuh
@@ -1,0 +1,444 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Kernel utilities for loading tiles of data through global memory
+ * with cache modifiers
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/operators.cuh>
+#include <b40c/util/vector_types.cuh>
+#include <b40c/util/io/modified_load.cuh>
+
+namespace b40c {
+namespace util {
+namespace io {
+
+
+/**
+ * Load a tile of items
+ */
+template <
+	int LOG_LOADS_PER_TILE, 									// Number of vector loads (log)
+	int LOG_LOAD_VEC_SIZE,										// Number of items per vector load (log)
+	int ACTIVE_THREADS,											// Active threads that will be loading
+	ld::CacheModifier CACHE_MODIFIER,							// Cache modifier (e.g., CA/CG/CS/NONE/etc.)
+	bool CHECK_ALIGNMENT>										// Whether or not to check alignment to see if vector loads can be used
+struct LoadTile
+{
+	enum {
+		LOADS_PER_TILE 				= 1 << LOG_LOADS_PER_TILE,
+		LOAD_VEC_SIZE 				= 1 << LOG_LOAD_VEC_SIZE,
+		LOG_ELEMENTS_PER_THREAD		= LOG_LOADS_PER_TILE + LOG_LOAD_VEC_SIZE,
+		ELEMENTS_PER_THREAD			= 1 << LOG_ELEMENTS_PER_THREAD,
+		TILE_SIZE 					= ACTIVE_THREADS * ELEMENTS_PER_THREAD,
+	};
+	
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	template <int LOAD, int VEC, int dummy = 0> struct Iterate;
+
+	/**
+	 * First vec element of a vector-load
+	 */
+	template <int LOAD, int dummy>
+	struct Iterate<LOAD, 0, dummy>
+	{
+		// Vector (unguarded)
+		template <typename T, void Transform(T&), typename VectorType>
+		static __device__ __forceinline__ void LoadVector(
+			T data[][LOAD_VEC_SIZE],
+			VectorType vectors[],
+			VectorType *d_in_vectors)
+		{
+			ModifiedLoad<CACHE_MODIFIER>::Ld(vectors[LOAD], d_in_vectors);
+			Transform(data[LOAD][0]);		// Apply transform function with in_bounds = true
+
+			Iterate<LOAD, 1>::template LoadVector<T, Transform>(
+				data, vectors, d_in_vectors);
+		}
+
+		// Regular (unguarded)
+		template <typename T, void Transform(T&)>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T *d_in)
+		{
+			int thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + 0;
+
+			ModifiedLoad<CACHE_MODIFIER>::Ld(data[LOAD][0], d_in + thread_offset);
+			Transform(data[LOAD][0]);
+
+			Iterate<LOAD, 1>::template LoadValid<T, Transform>(
+				data, d_in);
+		}
+
+		// Regular (guarded)
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T *d_in,
+			const SizeT &guarded_elements)
+		{
+			SizeT thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + 0;
+
+			if (thread_offset < guarded_elements) {
+				ModifiedLoad<CACHE_MODIFIER>::Ld(data[LOAD][0], d_in + thread_offset);
+				Transform(data[LOAD][0]);
+			}
+
+			Iterate<LOAD, 1>::template LoadValid<T, Transform>(
+				data, d_in, guarded_elements);
+		}
+
+		// Regular (guarded with out-of-bounds default)
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T oob_default,
+			T *d_in,
+			const SizeT &guarded_elements)
+		{
+			SizeT thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + 0;
+
+			if (thread_offset < guarded_elements) {
+				ModifiedLoad<CACHE_MODIFIER>::Ld(data[LOAD][0], d_in + thread_offset);
+				Transform(data[LOAD][0]);
+			} else {
+				data[LOAD][0] = oob_default;
+			}
+
+			Iterate<LOAD, 1>::template LoadValid<T, Transform>(
+				data, oob_default, d_in, guarded_elements);
+		}
+	};
+
+
+	/**
+	 * Next vec element of a vector-load
+	 */
+	template <int LOAD, int VEC, int dummy>
+	struct Iterate
+	{
+		// Vector (unguarded)
+		template <typename T, void Transform(T&), typename VectorType>
+		static __device__ __forceinline__ void LoadVector(
+			T data[][LOAD_VEC_SIZE],
+			VectorType vectors[],
+			VectorType *d_in_vectors)
+		{
+			Transform(data[LOAD][VEC]);
+
+			Iterate<LOAD, VEC + 1>::template LoadVector<T, Transform>(
+				data, vectors, d_in_vectors);
+		}
+
+		// Regular (unguarded)
+		template <typename T, void Transform(T&)>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T *d_in)
+		{
+			int thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + VEC;
+
+			ModifiedLoad<CACHE_MODIFIER>::Ld(data[LOAD][VEC], d_in + thread_offset);
+			Transform(data[LOAD][VEC]);
+
+			Iterate<LOAD, VEC + 1>::template LoadValid<T, Transform>(
+				data, d_in);
+		}
+
+		// Regular (guarded)
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T *d_in,
+			const SizeT &guarded_elements)
+		{
+			SizeT thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + VEC;
+
+			if (thread_offset < guarded_elements) {
+				ModifiedLoad<CACHE_MODIFIER>::Ld(data[LOAD][VEC], d_in + thread_offset);
+				Transform(data[LOAD][VEC]);
+			}
+
+			Iterate<LOAD, VEC + 1>::template LoadValid<T, Transform>(
+				data, d_in, guarded_elements);
+		}
+
+		// Regular (guarded with out-of-bounds default)
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T oob_default,
+			T *d_in,
+			const SizeT &guarded_elements)
+		{
+			SizeT thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + VEC;
+
+			if (thread_offset < guarded_elements) {
+				ModifiedLoad<CACHE_MODIFIER>::Ld(data[LOAD][VEC], d_in + thread_offset);
+				Transform(data[LOAD][VEC]);
+			} else {
+				data[LOAD][VEC] = oob_default;
+			}
+
+			Iterate<LOAD, VEC + 1>::template LoadValid<T, Transform>(
+				data, oob_default, d_in, guarded_elements);
+		}
+	};
+
+
+	/**
+	 * Next load
+	 */
+	template <int LOAD, int dummy>
+	struct Iterate<LOAD, LOAD_VEC_SIZE, dummy>
+	{
+		// Vector (unguarded)
+		template <typename T, void Transform(T&), typename VectorType>
+		static __device__ __forceinline__ void LoadVector(
+			T data[][LOAD_VEC_SIZE],
+			VectorType vectors[],
+			VectorType *d_in_vectors)
+		{
+			Iterate<LOAD + 1, 0>::template LoadVector<T, Transform>(
+				data, vectors, d_in_vectors + ACTIVE_THREADS);
+		}
+
+		// Regular (unguarded)
+		template <typename T, void Transform(T&)>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T *d_in)
+		{
+			Iterate<LOAD + 1, 0>::template LoadValid<T, Transform>(
+				data, d_in);
+		}
+
+		// Regular (guarded)
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T *d_in,
+			const SizeT &guarded_elements)
+		{
+			Iterate<LOAD + 1, 0>::template LoadValid<T, Transform>(
+				data, d_in, guarded_elements);
+		}
+
+		// Regular (guarded with out-of-bounds default)
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T oob_default,
+			T *d_in,
+			const SizeT &guarded_elements)
+		{
+			Iterate<LOAD + 1, 0>::template LoadValid<T, Transform>(
+				data, oob_default, d_in, guarded_elements);
+		}
+	};
+	
+	/**
+	 * Terminate
+	 */
+	template <int dummy>
+	struct Iterate<LOADS_PER_TILE, 0, dummy>
+	{
+		// Vector (unguarded)
+		template <typename T, void Transform(T&), typename VectorType>
+		static __device__ __forceinline__ void LoadVector(
+			T data[][LOAD_VEC_SIZE],
+			VectorType vectors[],
+			VectorType *d_in_vectors) {}
+
+		// Regular (unguarded)
+		template <typename T, void Transform(T&)>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T *d_in) {}
+
+		// Regular (guarded)
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T *d_in,
+			const SizeT &guarded_elements) {}
+
+		// Regular (guarded with out-of-bounds default)
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			T oob_default,
+			T *d_in,
+			const SizeT &guarded_elements) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Load a full tile with transform
+	 */
+	template <
+		typename T,
+		void Transform(T&),
+		typename SizeT>
+	static __device__ __forceinline__ void LoadValid(
+		T data[][LOAD_VEC_SIZE],
+		T *d_in,
+		SizeT cta_offset)
+	{
+		const size_t MASK = ((sizeof(T) * 8 * LOAD_VEC_SIZE) - 1);
+
+		if ((CHECK_ALIGNMENT) && (LOAD_VEC_SIZE > 1) && (((size_t) d_in) & MASK)) {
+
+			Iterate<0, 0>::template LoadValid<T, Transform>(
+				data, d_in + cta_offset);
+
+		} else {
+
+			// Use an aliased pointer to keys array to perform built-in vector loads
+			typedef typename VecType<T, LOAD_VEC_SIZE>::Type VectorType;
+
+			VectorType *vectors = (VectorType *) data;
+			VectorType *d_in_vectors = (VectorType *) (d_in + cta_offset + (threadIdx.x << LOG_LOAD_VEC_SIZE));
+
+			Iterate<0, 0>::template LoadVector<T, Transform>(
+				data, vectors, d_in_vectors);
+		}
+	}
+
+
+	/**
+	 * Load a full tile
+	 */
+	template <
+		typename T,
+		typename SizeT>
+	static __device__ __forceinline__ void LoadValid(
+		T data[][LOAD_VEC_SIZE],
+		T *d_in,
+		SizeT cta_offset)
+	{
+		LoadValid<T, Operators<T>::NopTransform>(data, d_in, cta_offset);
+	}
+
+
+	/**
+	 * Load guarded_elements of a tile with transform and out-of-bounds default
+	 */
+	template <
+		typename T,
+		void Transform(T&),
+		typename SizeT>
+	static __device__ __forceinline__ void LoadValid(
+		T data[][LOAD_VEC_SIZE],
+		T *d_in,
+		SizeT cta_offset,
+		const SizeT &guarded_elements,
+		T oob_default)
+	{
+		if (guarded_elements >= TILE_SIZE) {
+			LoadValid<T, Transform>(data, d_in, cta_offset);
+		} else {
+			Iterate<0, 0>::template LoadValid<T, Transform>(
+				data, oob_default, d_in + cta_offset, guarded_elements);
+		}
+	}
+
+
+	/**
+	 * Load guarded_elements of a tile with transform
+	 */
+	template <
+		typename T,
+		void Transform(T&),
+		typename SizeT>
+	static __device__ __forceinline__ void LoadValid(
+		T data[][LOAD_VEC_SIZE],
+		T *d_in,
+		SizeT cta_offset,
+		const SizeT &guarded_elements)
+	{
+		if (guarded_elements >= TILE_SIZE) {
+			LoadValid<T, Transform>(data, d_in, cta_offset);
+		} else {
+			Iterate<0, 0>::template LoadValid<T, Transform>(
+				data, d_in + cta_offset, guarded_elements);
+		}
+	}
+
+
+	/**
+	 * Load guarded_elements of a tile and out_of_bounds default
+	 */
+	template <
+		typename T,
+		typename SizeT>
+	static __device__ __forceinline__ void LoadValid(
+		T data[][LOAD_VEC_SIZE],
+		T *d_in,
+		SizeT cta_offset,
+		const SizeT &guarded_elements,
+		T oob_default)
+	{
+		LoadValid<T, Operators<T>::NopTransform>(
+			data, d_in, cta_offset, guarded_elements, oob_default);
+	}
+
+
+	/**
+	 * Load guarded_elements of a tile
+	 */
+	template <
+		typename T,
+		typename SizeT>
+	static __device__ __forceinline__ void LoadValid(
+		T data[][LOAD_VEC_SIZE],
+		T *d_in,
+		SizeT cta_offset,
+		const SizeT &guarded_elements)
+	{
+		LoadValid<T, Operators<T>::NopTransform, int>(
+			data, d_in, cta_offset, guarded_elements);
+	}
+};
+
+
+} // namespace io
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/io/load_tile_discontinuity.cuh
+++ b/include/b40c/util/io/load_tile_discontinuity.cuh
@@ -1,0 +1,488 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ * Kernel utilities for loading tiles of data through global memory
+ * with cache modifiers, marking discontinuities between consecutive elements
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/operators.cuh>
+#include <b40c/util/vector_types.cuh>
+#include <b40c/util/io/modified_load.cuh>
+
+namespace b40c {
+namespace util {
+namespace io {
+
+
+/**
+ * Load a tile of items and initialize discontinuity flags
+ */
+template <
+	int LOG_LOADS_PER_TILE, 									// Number of vector loads (log)
+	int LOG_LOAD_VEC_SIZE,										// Number of items per vector load (log)
+	int ACTIVE_THREADS,											// Active threads that will be loading
+	ld::CacheModifier CACHE_MODIFIER,							// Cache modifier (e.g., CA/CG/CS/NONE/etc.)
+	bool CHECK_ALIGNMENT,										// Whether or not to check alignment to see if vector loads can be used
+	bool CONSECUTIVE_SMEM_ASSIST,								// Whether nor not to use supplied smem to assist in discontinuity detection
+	bool FIRST_TILE,											// Whether or not this is the first tile loaded by the CTA
+	bool FLAG_FIRST_OOB>										// Whether or not the first element that is out-of-bounds should also be flagged
+struct LoadTileDiscontinuity
+{
+	enum {
+		LOADS_PER_TILE 				= 1 << LOG_LOADS_PER_TILE,
+		LOAD_VEC_SIZE 				= 1 << LOG_LOAD_VEC_SIZE,
+		LOG_ELEMENTS_PER_THREAD		= LOG_LOADS_PER_TILE + LOG_LOAD_VEC_SIZE,
+		ELEMENTS_PER_THREAD			= 1 << LOG_ELEMENTS_PER_THREAD,
+		TILE_SIZE 					= ACTIVE_THREADS * ELEMENTS_PER_THREAD,
+	};
+	
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	template <int LOAD, int VEC, int dummy = 0> struct Iterate;
+
+	/**
+	 * First vec element of a vector-load
+	 */
+	template <int LOAD, int dummy>
+	struct Iterate<LOAD, 0, dummy>
+	{
+		// Vector with discontinuity flags (unguarded)
+		template <
+			typename T,
+			typename Flag,
+			typename VectorType,
+			typename EqualityOp>
+		static __device__ __forceinline__ void VectorLoadValid(
+			T smem[ACTIVE_THREADS + 1],
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			VectorType vectors[], 
+			VectorType *d_in_vectors,
+			EqualityOp equality_op)
+		{
+			// Load the vector
+			ModifiedLoad<CACHE_MODIFIER>::Ld(vectors[LOAD], d_in_vectors);
+
+
+			if (CONSECUTIVE_SMEM_ASSIST) {
+
+				// Place last vec element into shared buffer
+				smem[threadIdx.x + 1] = data[LOAD][LOAD_VEC_SIZE - 1];
+
+				__syncthreads();
+
+				// Process first vec element
+				if (FIRST_TILE && (LOAD == 0) && (threadIdx.x == 0)) {
+
+					// First thread's first load of first tile
+					if (blockIdx.x == 0) {
+
+						// First CTA: start a new discontinuity
+						flags[LOAD][0] = 1;
+
+					} else {
+						// Get the previous vector element from global
+						T *d_ptr = (T*) d_in_vectors;
+						T previous;
+						ModifiedLoad<CACHE_MODIFIER>::Ld(previous, d_ptr - 1);
+						flags[LOAD][0] = !equality_op(previous, data[LOAD][0]);
+					}
+				} else {
+
+					T previous = smem[threadIdx.x];
+					flags[LOAD][0] = !equality_op(previous, data[LOAD][0]);
+				}
+
+				__syncthreads();
+
+				// Save last vector item for first of next load
+				if (threadIdx.x == ACTIVE_THREADS - 1) {
+					smem[0] = data[LOAD][LOAD_VEC_SIZE - 1];
+				}
+
+			} else {
+
+				// Process first vec element
+				if (FIRST_TILE && (LOAD == 0) && (blockIdx.x == 0) && (threadIdx.x == 0)) {
+
+					// First thread's first load of first tile of first CTA: start a new discontinuity
+					flags[LOAD][0] = 1;
+
+				} else {
+					// Get the previous vector element from global
+					T *d_ptr = (T*) d_in_vectors;
+					T previous;
+					ModifiedLoad<CACHE_MODIFIER>::Ld(previous, d_ptr - 1);
+					flags[LOAD][0] = !equality_op(previous, data[LOAD][0]);
+				}
+			}
+
+			Iterate<LOAD, 1>::VectorLoadValid(
+				smem, data, flags, vectors, d_in_vectors, equality_op);
+		}
+
+		// With discontinuity flags (unguarded)
+		template <
+			typename T,
+			typename Flag,
+			typename EqualityOp>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			T *d_in,
+			EqualityOp equality_op)
+		{
+			int thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + 0;
+
+			ModifiedLoad<CACHE_MODIFIER>::Ld(data[LOAD][0], d_in + thread_offset);
+
+			if (FIRST_TILE && (LOAD == 0) && (blockIdx.x == 0) && (threadIdx.x == 0)) {
+
+				// First load of first tile of first CTA: discontinuity
+				flags[LOAD][0] = 1;
+
+			} else {
+
+				// Get the previous vector element (which is in range b/c this one is in range)
+				T previous;
+				ModifiedLoad<CACHE_MODIFIER>::Ld(previous, d_in + thread_offset - 1);
+				flags[LOAD][0] = !equality_op(previous, data[LOAD][0]);
+			}
+
+			Iterate<LOAD, 1>::LoadValid(
+				data, flags, d_in, equality_op);
+		}
+
+		// With discontinuity flags (guarded)
+		template <
+			typename T,
+			typename Flag,
+			typename SizeT,
+			typename EqualityOp>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			T *d_in,
+			const SizeT &guarded_elements,
+			EqualityOp equality_op)
+		{
+			SizeT thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + 0;
+
+			if (thread_offset < guarded_elements) {
+				ModifiedLoad<CACHE_MODIFIER>::Ld(data[LOAD][0], d_in + thread_offset);
+
+				if (FIRST_TILE && (LOAD == 0) && (blockIdx.x == 0) && (threadIdx.x == 0)) {
+
+					// First load of first tile of first CTA: discontinuity
+					flags[LOAD][0] = 1;
+
+				} else {
+
+					// Get the previous vector element (which is in range b/c this one is in range)
+					T previous;
+					ModifiedLoad<CACHE_MODIFIER>::Ld(previous, d_in + thread_offset - 1);
+					flags[LOAD][0] = !equality_op(previous, data[LOAD][0]);
+				}
+
+			} else {
+				flags[LOAD][0] = ((FLAG_FIRST_OOB) && (thread_offset == guarded_elements));
+			}
+
+			Iterate<LOAD, 1>::LoadValid(
+				data, flags, d_in, guarded_elements, equality_op);
+		}
+	};
+
+
+	/**
+	 * Next vec element of a vector-load
+	 */
+	template <int LOAD, int VEC, int dummy>
+	struct Iterate
+	{
+		// Vector with discontinuity flags
+		template <
+			typename T,
+			typename Flag,
+			typename VectorType,
+			typename EqualityOp>
+		static __device__ __forceinline__ void VectorLoadValid(
+			T smem[ACTIVE_THREADS + 1],
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			VectorType vectors[], 
+			VectorType *d_in_vectors,
+			EqualityOp equality_op)
+		{
+			T current = data[LOAD][VEC];
+			T previous = data[LOAD][VEC - 1];
+			flags[LOAD][VEC] = !equality_op(previous, current);
+
+			Iterate<LOAD, VEC + 1>::VectorLoadValid(
+				smem, data, flags, vectors, d_in_vectors, equality_op);
+		}
+
+		// With discontinuity flags (unguarded)
+		template <
+			typename T,
+			typename Flag,
+			typename EqualityOp>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			T *d_in,
+			EqualityOp equality_op)
+		{
+			int thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + VEC;
+
+			ModifiedLoad<CACHE_MODIFIER>::Ld(data[LOAD][VEC], d_in + thread_offset);
+
+			T previous = data[LOAD][VEC - 1];
+			T current = data[LOAD][VEC];
+			flags[LOAD][VEC] = !equality_op(previous, current);
+
+			Iterate<LOAD, VEC + 1>::LoadValid(
+				data, flags, d_in, equality_op);
+		}
+
+		// With discontinuity flags (guarded)
+		template <
+			typename T,
+			typename Flag,
+			typename SizeT,
+			typename EqualityOp>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			T *d_in,
+			const SizeT &guarded_elements,
+			EqualityOp equality_op)
+		{
+			SizeT thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + VEC;
+
+			if (thread_offset < guarded_elements) {
+				ModifiedLoad<CACHE_MODIFIER>::Ld(data[LOAD][VEC], d_in + thread_offset);
+
+				T previous = data[LOAD][VEC - 1];
+				T current = data[LOAD][VEC];
+				flags[LOAD][VEC] = !equality_op(previous, current);
+
+			} else {
+				flags[LOAD][VEC] = ((FLAG_FIRST_OOB) && (thread_offset == guarded_elements));
+			}
+
+			Iterate<LOAD, VEC + 1>::LoadValid(
+				data, flags, d_in, guarded_elements, equality_op);
+		}
+	};
+
+
+	/**
+	 * Next load
+	 */
+	template <int LOAD, int dummy>
+	struct Iterate<LOAD, LOAD_VEC_SIZE, dummy>
+	{
+		// Vector with discontinuity flags (unguarded)
+		template <
+			typename T,
+			typename Flag,
+			typename VectorType,
+			typename EqualityOp>
+		static __device__ __forceinline__ void VectorLoadValid(
+			T smem[ACTIVE_THREADS + 1],
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			VectorType vectors[], 
+			VectorType *d_in_vectors,
+			EqualityOp equality_op)
+		{
+			Iterate<LOAD + 1, 0>::VectorLoadValid(
+				smem, data, flags, vectors, d_in_vectors + ACTIVE_THREADS, equality_op);
+		}
+
+		// With discontinuity flags (unguarded)
+		template <
+			typename T,
+			typename Flag,
+			typename EqualityOp>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			T *d_in,
+			EqualityOp equality_op)
+		{
+			Iterate<LOAD + 1, 0>::LoadValid(
+				data, flags, d_in, equality_op);
+		}
+
+		// With discontinuity flags (guarded)
+		template <
+			typename T,
+			typename Flag,
+			typename SizeT,
+			typename EqualityOp>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			T *d_in,
+			const SizeT &guarded_elements,
+			EqualityOp equality_op)
+		{
+			Iterate<LOAD + 1, 0>::LoadValid(
+				data, flags, d_in, guarded_elements, equality_op);
+		}
+	};
+	
+	/**
+	 * Terminate
+	 */
+	template <int dummy>
+	struct Iterate<LOADS_PER_TILE, 0, dummy>
+	{
+		// Vector with discontinuity flags (unguarded)
+		template <
+			typename T,
+			typename Flag,
+			typename VectorType,
+			typename EqualityOp>
+		static __device__ __forceinline__ void VectorLoadValid(
+			T smem[ACTIVE_THREADS + 1],
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			VectorType vectors[], 
+			VectorType *d_in_vectors,
+			EqualityOp equality_op) {}
+
+		// With discontinuity flags (unguarded)
+		template <
+			typename T,
+			typename Flag,
+			typename EqualityOp>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			T *d_in,
+			EqualityOp equality_op) {}
+
+		// With discontinuity flags (guarded)
+		template <
+			typename T,
+			typename Flag,
+			typename SizeT,
+			typename EqualityOp>
+		static __device__ __forceinline__ void LoadValid(
+			T data[][LOAD_VEC_SIZE],
+			Flag flags[][LOAD_VEC_SIZE],
+			T *d_in,
+			const SizeT &guarded_elements,
+			EqualityOp equality_op) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Load a full tile and initialize discontinuity flags when values change
+	 * between consecutive elements
+	 */
+	template <
+		typename T,										// Tile type
+		typename Flag,									// Discontinuity flag type
+		typename SizeT,
+		typename EqualityOp>
+	static __device__ __forceinline__ void LoadValid(
+		T smem[ACTIVE_THREADS + 1],
+		T data[][LOAD_VEC_SIZE],
+		Flag flags[][LOAD_VEC_SIZE],
+		T *d_in,
+		SizeT cta_offset,
+		EqualityOp equality_op)
+	{
+		const size_t MASK = ((sizeof(T) * 8 * LOAD_VEC_SIZE) - 1);
+
+
+		if ((CHECK_ALIGNMENT) && (LOAD_VEC_SIZE > 1) && (((size_t) d_in) & MASK)) {
+
+			Iterate<0, 0>::LoadValid(
+				data, flags, d_in + cta_offset, equality_op);
+
+		} else {
+
+			// Use an aliased pointer to keys array to perform built-in vector loads
+			typedef typename VecType<T, LOAD_VEC_SIZE>::Type VectorType;
+
+			VectorType *vectors = (VectorType *) data;
+			VectorType *d_in_vectors = (VectorType *) (d_in + cta_offset + (threadIdx.x << LOG_LOAD_VEC_SIZE));
+
+			Iterate<0, 0>::VectorLoadValid(
+				smem, data, flags, vectors, d_in_vectors, equality_op);
+		}
+	}
+
+	/**
+	 * Load guarded_elements of a tile and initialize discontinuity flags when
+	 * values change between consecutive elements
+	 */
+	template <
+		typename T,										// Tile type
+		typename Flag,									// Discontinuity flag type
+		typename SizeT,									// Integer type for indexing into global arrays
+		typename EqualityOp>
+	static __device__ __forceinline__ void LoadValid(
+		T smem[ACTIVE_THREADS + 1],
+		T data[][LOAD_VEC_SIZE],
+		Flag flags[][LOAD_VEC_SIZE],
+		T *d_in,
+		SizeT cta_offset,
+		const SizeT &guarded_elements,
+		EqualityOp equality_op)
+	{
+		if (guarded_elements >= TILE_SIZE) {
+
+			LoadValid(smem, data, flags, d_in, cta_offset, equality_op);
+
+		} else {
+
+			Iterate<0, 0>::LoadValid(
+				data, flags, d_in + cta_offset, guarded_elements, equality_op);
+		}
+	} 
+};
+
+
+} // namespace io
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/io/modified_load.cuh
+++ b/include/b40c/util/io/modified_load.cuh
@@ -1,0 +1,262 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Kernel utilities for loading types through global memory with cache modifiers
+ ******************************************************************************/
+
+#pragma once
+
+#include <cuda.h>
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/vector_types.cuh>
+
+namespace b40c {
+namespace util {
+namespace io {
+
+
+/**
+ * Enumeration of data movement cache modifiers.
+ */
+namespace ld {
+
+	enum CacheModifier {
+		NONE,				// default (currently ca)
+		cg,					// cache global
+		ca,					// cache all
+		cs, 				// cache streaming
+
+		LIMIT
+	};
+
+} // namespace ld
+
+
+
+/**
+ * TODO: replace this with something better
+ */
+#define CacheModifierToString(modifier)	(	((int) modifier == b40c::util::io::ld::NONE) ? 		"util::io::ld::NONE" :	\
+											((int) modifier == b40c::util::io::ld::cg) ? 		"util::io::ld::cg" :		\
+											((int) modifier == b40c::util::io::ld::ca) ? 		"util::io::ld::ca" :		\
+											((int) modifier == b40c::util::io::ld::cs) ? 		"util::io::ld::cs" :		\
+											((int) modifier == b40c::util::io::st::NONE) ? 		"util::io::st::NONE" :	\
+											((int) modifier == b40c::util::io::st::cg) ? 		"util::io::st::cg" :		\
+											((int) modifier == b40c::util::io::st::wb) ? 		"util::io::st::wb" :		\
+											((int) modifier == b40c::util::io::st::cs) ? 		"util::io::st::cs" :		\
+																								"<ERROR>")
+
+/**
+ * Basic utility for performing modified loads through cache.
+ */
+template <ld::CacheModifier CACHE_MODIFIER>
+struct ModifiedLoad
+{
+	/**
+	 * Load operation we will provide specializations for
+	 */
+	template <typename T>
+	__device__ __forceinline__ static void Ld(T &val, T *ptr);
+
+	/**
+	 * Vec-4 loads for 64-bit types are implemented as two vec-2 loads
+	 */
+	__device__ __forceinline__ static void Ld(double4 &val, double4* ptr)
+	{
+		ModifiedLoad<CACHE_MODIFIER>::Ld(*reinterpret_cast<double2*>(&val.x), reinterpret_cast<double2*>(ptr));
+		ModifiedLoad<CACHE_MODIFIER>::Ld(*reinterpret_cast<double2*>(&val.z), reinterpret_cast<double2*>(ptr) + 1);
+	}
+
+	__device__ __forceinline__ static void Ld(ulonglong4 &val, ulonglong4* ptr)
+	{
+		ModifiedLoad<CACHE_MODIFIER>::Ld(*reinterpret_cast<ulonglong2*>(&val.x), reinterpret_cast<ulonglong2*>(ptr));
+		ModifiedLoad<CACHE_MODIFIER>::Ld(*reinterpret_cast<ulonglong2*>(&val.z), reinterpret_cast<ulonglong2*>(ptr) + 1);
+	}
+
+	__device__ __forceinline__ static void Ld(longlong4 &val, longlong4* ptr)
+	{
+		ModifiedLoad<CACHE_MODIFIER>::Ld(*reinterpret_cast<longlong2*>(&val.x), reinterpret_cast<longlong2*>(ptr));
+		ModifiedLoad<CACHE_MODIFIER>::Ld(*reinterpret_cast<longlong2*>(&val.z), reinterpret_cast<longlong2*>(ptr) + 1);
+	}
+};
+
+
+#if __CUDA_ARCH__ >= 200
+
+	/**
+	 * Specialization for NONE modifier
+	 */
+	template <>
+	template <typename T>
+	__device__ __forceinline__ void ModifiedLoad<ld::NONE>::Ld(T &val, T *ptr)
+	{
+		val = *ptr;
+	}
+
+	/**
+	 * Singleton store op
+	 */
+	#define B40C_LOAD(base_type, ptx_type, reg_mod, cast_type, modifier)																	\
+		template<> template<> void ModifiedLoad<ld::modifier>::Ld(base_type &val, base_type* ptr) {												\
+			asm volatile ("ld.global."#modifier"."#ptx_type" %0, [%1];" : "="#reg_mod(reinterpret_cast<cast_type&>(val)) : _B40C_ASM_PTR_(ptr));			\
+		}																																		\
+
+	/**
+	 * Vector load ops
+	 */
+	#define B40C_LOAD_VEC1(base_type, ptx_type, reg_mod, cast_type, modifier)																	\
+		template<> template<> void ModifiedLoad<ld::modifier>::Ld(base_type &val, base_type* ptr) {												\
+			asm volatile ("ld.global."#modifier"."#ptx_type" %0, [%1];" : "="#reg_mod(reinterpret_cast<cast_type&>(val.x)) : _B40C_ASM_PTR_(ptr));			\
+		}																																		\
+
+	#define B40C_LOAD_VEC2(base_type, ptx_type, reg_mod, cast_type, modifier)																	\
+		template<> template<> void ModifiedLoad<ld::modifier>::Ld(base_type &val, base_type* ptr) {												\
+			asm volatile ("ld.global."#modifier".v2."#ptx_type" {%0, %1}, [%2];" : "="#reg_mod(reinterpret_cast<cast_type&>(val.x)), "="#reg_mod(reinterpret_cast<cast_type&>(val.y)) : _B40C_ASM_PTR_(ptr));		\
+		}
+
+	#define B40C_LOAD_VEC4(base_type, ptx_type, reg_mod, cast_type, modifier)																	\
+		template<> template<> void ModifiedLoad<ld::modifier>::Ld(base_type &val, base_type* ptr) {												\
+			asm volatile ("ld.global."#modifier".v4."#ptx_type" {%0, %1, %2, %3}, [%4];" : "="#reg_mod(reinterpret_cast<cast_type&>(val.x)), "="#reg_mod(reinterpret_cast<cast_type&>(val.y)), "="#reg_mod(reinterpret_cast<cast_type&>(val.z)), "="#reg_mod(reinterpret_cast<cast_type&>(val.w)) : _B40C_ASM_PTR_(ptr));		\
+		}
+
+
+	/**
+	 * Defines specialized load ops for only the base type
+	 */
+	#define B40C_LOAD_BASE(base_type, ptx_type, reg_mod, cast_type)		\
+		B40C_LOAD(base_type, ptx_type, reg_mod, cast_type, cg)			\
+		B40C_LOAD(base_type, ptx_type, reg_mod, cast_type, ca)			\
+		B40C_LOAD(base_type, ptx_type, reg_mod, cast_type, cs)
+
+
+	/**
+	 * Defines specialized load ops for the base type and for its derivative vec1 and vec2 types
+	 */
+	#define B40C_LOAD_BASE_ONE_TWO(base_type, dest_type, short_type, ptx_type, reg_mod, cast_type)	\
+		B40C_LOAD_BASE(base_type, ptx_type, reg_mod, cast_type)										\
+																									\
+		B40C_LOAD_VEC1(short_type##1, ptx_type, reg_mod, cast_type, cg)								\
+		B40C_LOAD_VEC1(short_type##1, ptx_type, reg_mod, cast_type, ca)								\
+		B40C_LOAD_VEC1(short_type##1, ptx_type, reg_mod, cast_type, cs)								\
+																									\
+		B40C_LOAD_VEC2(short_type##2, ptx_type, reg_mod, cast_type, cg)								\
+		B40C_LOAD_VEC2(short_type##2, ptx_type, reg_mod, cast_type, ca)								\
+		B40C_LOAD_VEC2(short_type##2, ptx_type, reg_mod, cast_type, cs)
+
+
+	/**
+	 * Defines specialized load ops for the base type and for its derivative vec1, vec2, and vec4 types
+	 */
+	#define B40C_LOAD_BASE_ONE_TWO_FOUR(base_type, dest_type, short_type, ptx_type, reg_mod, cast_type)	\
+		B40C_LOAD_BASE_ONE_TWO(base_type, dest_type, short_type, ptx_type, reg_mod, cast_type)			\
+		B40C_LOAD_VEC4(short_type##4, ptx_type, reg_mod, cast_type, cg)									\
+		B40C_LOAD_VEC4(short_type##4, ptx_type, reg_mod, cast_type, ca)									\
+		B40C_LOAD_VEC4(short_type##4, ptx_type, reg_mod, cast_type, cs)
+
+
+#if CUDA_VERSION >= 4000
+	#define B40C_REG8		h
+	#define B40C_REG16 		h
+	#define B40C_CAST8 		short
+#else
+	#define B40C_REG8		r
+	#define B40C_REG16 		r
+	#define B40C_CAST8 		char
+#endif
+
+
+	/**
+	 * Define cache-modified loads for all 4-byte (and smaller) structures
+	 */
+	B40C_LOAD_BASE_ONE_TWO_FOUR(char, 			char, 			char, 	s8, 	B40C_REG8, 		B40C_CAST8)
+	B40C_LOAD_BASE_ONE_TWO_FOUR(short, 			short, 			short, 	s16, 	B40C_REG16, 	short)
+	B40C_LOAD_BASE_ONE_TWO_FOUR(int, 			int, 			int, 	s32, 	r, 				int)
+	B40C_LOAD_BASE_ONE_TWO_FOUR(unsigned char, 	unsigned char, 	uchar,	u8, 	B40C_REG8, 		unsigned B40C_CAST8)
+	B40C_LOAD_BASE_ONE_TWO_FOUR(unsigned short,	unsigned short,	ushort,	u16, 	B40C_REG16, 	unsigned short)
+	B40C_LOAD_BASE_ONE_TWO_FOUR(unsigned int, 	unsigned int, 	uint,	u32, 	r, 				unsigned int)
+	B40C_LOAD_BASE_ONE_TWO_FOUR(float, 			float, 			float, 	f32, 	f, 				float)
+
+	#if !defined(__LP64__) || (__LP64__ == 0)
+	// longs are 64-bit on non-Windows 64-bit compilers
+	B40C_LOAD_BASE_ONE_TWO_FOUR(long, 			long, 			long, 	s32, 	r, long)
+	B40C_LOAD_BASE_ONE_TWO_FOUR(unsigned long, 	unsigned long, 	ulong, 	u32, 	r, unsigned long)
+	#endif
+
+	B40C_LOAD_BASE(signed char, s8, r, unsigned int)		// Only need to define base: char2,char4, etc already defined from char
+
+
+	/**
+	 * Define cache-modified loads for all 8-byte structures
+	 */
+	B40C_LOAD_BASE_ONE_TWO(unsigned long long, 	unsigned long long, 	ulonglong, 	u64, l, unsigned long long)
+	B40C_LOAD_BASE_ONE_TWO(long long, 			long long, 				longlong, 	s64, l, long long)
+	B40C_LOAD_BASE_ONE_TWO(double, 				double, 				double, 	s64, l, long long)				// Cast to 64-bit long long a workaround for the fact that the 3.x assembler has no register constraint for doubles
+
+	#if defined(__LP64__)
+	// longs are 64-bit on non-Windows 64-bit compilers
+	B40C_LOAD_BASE_ONE_TWO(long, 				long, 					long, 		s64, l, long)
+	B40C_LOAD_BASE_ONE_TWO(unsigned long, 		unsigned long, 			ulong, 		u64, l, unsigned long)
+	#endif
+
+
+	/**
+	 * Undefine macros
+	 */
+	#undef B40C_LOAD_VEC1
+	#undef B40C_LOAD_VEC2
+	#undef B40C_LOAD_VEC4
+	#undef B40C_LOAD_BASE
+	#undef B40C_LOAD_BASE_ONE_TWO
+	#undef B40C_LOAD_BASE_ONE_TWO_FOUR
+	#undef B40C_CAST8
+	#undef B40C_REG8
+	#undef B40C_REG16
+
+
+
+#else  //__CUDA_ARCH__
+
+
+	template <ld::CacheModifier READ_MODIFIER>
+	template <typename T>
+	__device__ __forceinline__ void ModifiedLoad<READ_MODIFIER>::Ld(T &val, T *ptr)
+	{
+		val = *ptr;
+	}
+
+
+#endif //__CUDA_ARCH__
+
+
+
+
+} // namespace io
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/io/modified_store.cuh
+++ b/include/b40c/util/io/modified_store.cuh
@@ -1,0 +1,253 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Kernel utilities for storing types through global memory with cache modifiers
+ ******************************************************************************/
+
+#pragma once
+
+#include <cuda.h>
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/vector_types.cuh>
+
+namespace b40c {
+namespace util {
+namespace io {
+
+
+/**
+ * Enumeration of data movement cache modifiers.
+ */
+namespace st {
+
+	enum CacheModifier {
+		NONE,			// default (currently wb)
+		cg,				// cache global
+		wb,				// write back all levels
+		cs, 			// cache streaming
+
+		LIMIT
+	};
+
+} // namespace st
+
+
+
+/**
+ * Basic utility for performing modified stores through cache.
+ */
+template <st::CacheModifier CACHE_MODIFIER>
+struct ModifiedStore
+{
+	/**
+	 * Store operation we will provide specializations for
+	 */
+	template <typename T>
+	__device__ __forceinline__ static void St(T val, T *ptr);
+
+	/**
+	 * Vec-4 stores for 64-bit types are implemented as two vec-2 stores
+	 */
+	__device__ __forceinline__ static void St(double4 val, double4* ptr)
+	{
+		ModifiedStore<CACHE_MODIFIER>::St(*reinterpret_cast<double2*>(&val.x), reinterpret_cast<double2*>(ptr));
+		ModifiedStore<CACHE_MODIFIER>::St(*reinterpret_cast<double2*>(&val.z), reinterpret_cast<double2*>(ptr) + 1);
+	}
+
+	__device__ __forceinline__ static void St(ulonglong4 val, ulonglong4* ptr)
+	{
+		ModifiedStore<CACHE_MODIFIER>::St(*reinterpret_cast<ulonglong2*>(&val.x), reinterpret_cast<ulonglong2*>(ptr));
+		ModifiedStore<CACHE_MODIFIER>::St(*reinterpret_cast<ulonglong2*>(&val.z), reinterpret_cast<ulonglong2*>(ptr) + 1);
+	}
+
+	__device__ __forceinline__ static void St(longlong4 val, longlong4* ptr)
+	{
+		ModifiedStore<CACHE_MODIFIER>::St(*reinterpret_cast<longlong2*>(&val.x), reinterpret_cast<longlong2*>(ptr));
+		ModifiedStore<CACHE_MODIFIER>::St(*reinterpret_cast<longlong2*>(&val.z), reinterpret_cast<longlong2*>(ptr) + 1);
+	}
+};
+
+
+
+#if __CUDA_ARCH__ >= 200
+
+	/**
+	 * Specialization for NONE modifier
+	 */
+	template <>
+	template <typename T>
+	__device__ __forceinline__ void ModifiedStore<st::NONE>::St(T val, T *ptr)
+	{
+		*ptr = val;
+	}
+
+	/**
+	 * Singleton store op
+	 */
+	#define B40C_STORE(base_type, ptx_type, reg_mod, cast_type, modifier)																	\
+		template<> template<> void ModifiedStore<st::modifier>::St(base_type val, base_type* ptr) {											\
+			asm volatile ("st.global."#modifier"."#ptx_type" [%0], %1;" : : _B40C_ASM_PTR_(ptr), #reg_mod(reinterpret_cast<cast_type&>(val)));			\
+		}
+
+	/**
+	 * Vector store ops
+	 */
+	#define B40C_STORE_VEC1(component_type, base_type, ptx_type, reg_mod, cast_type, modifier)																	\
+		template<> template<> void ModifiedStore<st::modifier>::St(base_type val, base_type* ptr) {											\
+			component_type c = val.x;																											\
+			asm volatile ("st.global."#modifier"."#ptx_type" [%0], %1;" : : _B40C_ASM_PTR_(ptr), #reg_mod(reinterpret_cast<cast_type&>(c)));			\
+		}
+
+	#define B40C_STORE_VEC2(component_type, base_type, ptx_type, reg_mod, cast_type, modifier)																	\
+		template<> template<> void ModifiedStore<st::modifier>::St(base_type val, base_type* ptr) {											\
+			component_type cx = val.x;																											\
+			component_type cy = val.y;																											\
+			asm volatile ("st.global."#modifier".v2."#ptx_type" [%0], {%1, %2};" : : _B40C_ASM_PTR_(ptr), #reg_mod(reinterpret_cast<cast_type&>(cx)), #reg_mod(reinterpret_cast<cast_type&>(cy)));		\
+		}
+
+	#define B40C_STORE_VEC4(component_type, base_type, ptx_type, reg_mod, cast_type, modifier)																	\
+		template<> template<> void ModifiedStore<st::modifier>::St(base_type val, base_type* ptr) {											\
+			component_type cx = val.x;																											\
+			component_type cy = val.y;																											\
+			component_type cz = val.z;																											\
+			component_type cw = val.w;																											\
+			asm volatile ("st.global."#modifier".v4."#ptx_type" [%0], {%1, %2, %3, %4};" : : _B40C_ASM_PTR_(ptr), #reg_mod(reinterpret_cast<cast_type&>(cx)), #reg_mod(reinterpret_cast<cast_type&>(cy)), #reg_mod(reinterpret_cast<cast_type&>(cz)), #reg_mod(reinterpret_cast<cast_type&>(cw)));		\
+		}
+
+
+	/**
+	 * Defines specialized store ops for only the base type
+	 */
+	#define B40C_STORE_BASE(base_type, ptx_type, reg_mod, cast_type)		\
+		B40C_STORE(base_type, ptx_type, reg_mod, cast_type, cg)		\
+		B40C_STORE(base_type, ptx_type, reg_mod, cast_type, wb)		\
+		B40C_STORE(base_type, ptx_type, reg_mod, cast_type, cs)
+
+
+	/**
+	 * Defines specialized store ops for the base type and for its derivative vec1 and vec2 types
+	 */
+	#define B40C_STORE_BASE_ONE_TWO(base_type, dest_type, short_type, ptx_type, reg_mod, cast_type)		\
+		B40C_STORE_BASE(base_type, ptx_type, reg_mod, cast_type)										\
+																										\
+		B40C_STORE_VEC1(base_type, short_type##1, ptx_type, reg_mod, cast_type, cg)						\
+		B40C_STORE_VEC1(base_type, short_type##1, ptx_type, reg_mod, cast_type, wb)						\
+		B40C_STORE_VEC1(base_type, short_type##1, ptx_type, reg_mod, cast_type, cs)						\
+																										\
+		B40C_STORE_VEC2(base_type, short_type##2, ptx_type, reg_mod, cast_type, cg)								\
+		B40C_STORE_VEC2(base_type, short_type##2, ptx_type, reg_mod, cast_type, wb)								\
+		B40C_STORE_VEC2(base_type, short_type##2, ptx_type, reg_mod, cast_type, cs)
+
+
+	/**
+	 * Defines specialized store ops for the base type and for its derivative vec1, vec2, and vec4 types
+	 */
+	#define B40C_STORE_BASE_ONE_TWO_FOUR(base_type, dest_type, short_type, ptx_type, reg_mod, cast_type)	\
+		B40C_STORE_BASE_ONE_TWO(base_type, dest_type, short_type, ptx_type, reg_mod, cast_type)				\
+																											\
+		B40C_STORE_VEC4(base_type, short_type##4, ptx_type, reg_mod, cast_type, cg)									\
+		B40C_STORE_VEC4(base_type, short_type##4, ptx_type, reg_mod, cast_type, wb)									\
+		B40C_STORE_VEC4(base_type, short_type##4, ptx_type, reg_mod, cast_type, cs)
+
+
+#if CUDA_VERSION >= 4000
+	#define B40C_REG8		h
+	#define B40C_REG16 		h
+	#define B40C_CAST8 		short
+#else
+	#define B40C_REG8		r
+	#define B40C_REG16 		r
+	#define B40C_CAST8 		char
+#endif
+
+
+	/**
+	 * Define cache-modified stores for all 4-byte (and smaller) structures
+	 */
+	B40C_STORE_BASE_ONE_TWO_FOUR(char, 				char, 			char, 	s8, 	B40C_REG8, 		B40C_CAST8)
+	B40C_STORE_BASE_ONE_TWO_FOUR(short, 			short, 			short, 	s16, 	B40C_REG16, 	short)
+	B40C_STORE_BASE_ONE_TWO_FOUR(int, 				int, 			int, 	s32, 	r, 				int)
+	B40C_STORE_BASE_ONE_TWO_FOUR(unsigned char, 	unsigned char, 	uchar,	u8, 	B40C_REG8, 		unsigned B40C_CAST8)
+	B40C_STORE_BASE_ONE_TWO_FOUR(unsigned short,	unsigned short,	ushort,	u16, 	B40C_REG16, 	unsigned short)
+	B40C_STORE_BASE_ONE_TWO_FOUR(unsigned int, 		unsigned int, 	uint,	u32, 	r, 				unsigned int)
+	B40C_STORE_BASE_ONE_TWO_FOUR(float, 			float, 			float, 	f32, 	f, 				float)
+
+	#if !defined(__LP64__) || (__LP64__ == 0)
+	// longs are 64-bit on non-Windows 64-bit compilers
+	B40C_STORE_BASE_ONE_TWO_FOUR(long, 				long, 			long, 	s32, 	r, long)
+	B40C_STORE_BASE_ONE_TWO_FOUR(unsigned long, 	unsigned long, 	ulong, 	u32, 	r, unsigned long)
+	#endif
+
+	B40C_STORE_BASE(signed char, s8, r, unsigned int)		// Only need to define base: char2,char4, etc already defined from char
+
+
+	/**
+	 * Define cache-modified stores for all 8-byte structures
+	 */
+	B40C_STORE_BASE_ONE_TWO(unsigned long long, 	unsigned long long, 	ulonglong, 	u64, l, unsigned long long)
+	B40C_STORE_BASE_ONE_TWO(long long, 				long long, 				longlong, 	s64, l, long long)
+	B40C_STORE_BASE_ONE_TWO(double, 				double, 				double, 	s64, l, long long)				// Cast to 64-bit long long a workaround for the fact that the 3.x assembler has no register constraint for doubles
+
+	#if defined(__LP64__)
+	// longs are 64-bit on non-Windows 64-bit compilers
+	B40C_STORE_BASE_ONE_TWO(long, 					long, 					long, 		s64, l, long)
+	B40C_STORE_BASE_ONE_TWO(unsigned long, 			unsigned long, 			ulong, 		u64, l, unsigned long)
+	#endif
+
+	/**
+	 * Undefine macros
+	 */
+	#undef B40C_STORE_VEC1
+	#undef B40C_STORE_VEC2
+	#undef B40C_STORE_VEC4
+	#undef B40C_STORE_BASE
+	#undef B40C_STORE_BASE_ONE_TWO
+	#undef B40C_STORE_BASE_ONE_TWO_FOUR
+	#undef B40C_CAST8
+	#undef B40C_REG8
+	#undef B40C_REG16
+
+#else  //__CUDA_ARCH__
+
+	template <st::CacheModifier WRITE_MODIFIER>
+	template <typename T>
+	__device__ __forceinline__ void ModifiedStore<WRITE_MODIFIER>::St(T val, T *ptr)
+	{
+		*ptr = val;
+	}
+
+#endif //__CUDA_ARCH__
+
+
+
+
+} // namespace io
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/io/scatter_tile.cuh
+++ b/include/b40c/util/io/scatter_tile.cuh
@@ -1,0 +1,340 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Kernel utilities for scattering data
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/modified_store.cuh>
+#include <b40c/util/operators.cuh>
+
+namespace b40c {
+namespace util {
+namespace io {
+
+
+
+
+/**
+ * Scatter a tile of data items using the corresponding tile of scatter_offsets
+ */
+template <
+	int LOG_LOADS_PER_TILE, 									// Number of vector loads (log)
+	int LOG_LOAD_VEC_SIZE,										// Number of items per vector load (log)
+	int ACTIVE_THREADS,											// Active threads that will be loading
+	st::CacheModifier CACHE_MODIFIER>							// Cache modifier (e.g., CA/CG/CS/NONE/etc.)
+struct ScatterTile
+{
+	enum {
+		LOADS_PER_TILE 				= 1 << LOG_LOADS_PER_TILE,
+		LOAD_VEC_SIZE 				= 1 << LOG_LOAD_VEC_SIZE,
+		LOG_ELEMENTS_PER_THREAD		= LOG_LOADS_PER_TILE + LOG_LOAD_VEC_SIZE,
+		ELEMENTS_PER_THREAD			= 1 << LOG_ELEMENTS_PER_THREAD,
+		TILE_SIZE 					= ACTIVE_THREADS * ELEMENTS_PER_THREAD,
+	};
+
+	//---------------------------------------------------------------------
+	// Helper Structures
+	//---------------------------------------------------------------------
+
+	// Iterate next vector item
+	template <int LOAD, int VEC, int dummy = 0>
+	struct Iterate
+	{
+		// Unguarded
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE])
+		{
+			Transform(data[LOAD][VEC]);
+			ModifiedStore<CACHE_MODIFIER>::St(data[LOAD][VEC], dest + scatter_offsets[LOAD][VEC]);
+
+			Iterate<LOAD, VEC + 1>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets);
+		}
+
+		// Guarded by flags
+		template <typename T, void Transform(T&), typename Flag, typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE],
+			Flag valid_flags[][LOAD_VEC_SIZE])
+		{
+			if (valid_flags[LOAD][VEC]) {
+
+				Transform(data[LOAD][VEC]);
+				ModifiedStore<CACHE_MODIFIER>::St(data[LOAD][VEC], dest + scatter_offsets[LOAD][VEC]);
+			}
+
+			Iterate<LOAD, VEC + 1>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets, valid_flags);
+		}
+
+		// Guarded by partial tile size
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE],
+			const SizeT &partial_tile_size)
+		{
+			int tile_rank = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + VEC;
+
+			if (tile_rank < partial_tile_size) {
+
+				Transform(data[LOAD][VEC]);
+				ModifiedStore<CACHE_MODIFIER>::St(data[LOAD][VEC], dest + scatter_offsets[LOAD][VEC]);
+			}
+
+			Iterate<LOAD, VEC + 1>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets, partial_tile_size);
+		}
+
+		// Guarded by flags and partial tile size
+		template <typename T, void Transform(T&), typename Flag, typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE],
+			Flag valid_flags[][LOAD_VEC_SIZE],
+			const SizeT &partial_tile_size)
+		{
+			int tile_rank = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + VEC;
+
+			if (valid_flags[LOAD][VEC] && (tile_rank < partial_tile_size)) {
+
+				Transform(data[LOAD][VEC]);
+				ModifiedStore<CACHE_MODIFIER>::St(data[LOAD][VEC], dest + scatter_offsets[LOAD][VEC]);
+			}
+
+			Iterate<LOAD, VEC + 1>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets, valid_flags, partial_tile_size);
+		}
+	};
+
+
+	// Next Load
+	template <int LOAD, int dummy>
+	struct Iterate<LOAD, LOAD_VEC_SIZE, dummy>
+	{
+		// Unguarded
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE])
+		{
+			Iterate<LOAD + 1, 0>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets);
+		}
+
+		// Guarded by flags
+		template <typename T, void Transform(T&), typename Flag, typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE],
+			Flag valid_flags[][LOAD_VEC_SIZE])
+		{
+			Iterate<LOAD + 1, 0>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets, valid_flags);
+		}
+
+		// Guarded by partial tile size
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE],
+			const SizeT &partial_tile_size)
+		{
+			Iterate<LOAD + 1, 0>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets, partial_tile_size);
+		}
+
+		// Guarded by flags and partial tile size
+		template <typename T, void Transform(T&), typename Flag, typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE],
+			Flag valid_flags[][LOAD_VEC_SIZE],
+			const SizeT &partial_tile_size)
+		{
+			Iterate<LOAD + 1, 0>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets, valid_flags, partial_tile_size);
+		}
+	};
+
+
+	// Terminate
+	template <int dummy>
+	struct Iterate<LOADS_PER_TILE, 0, dummy>
+	{
+		// Unguarded
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE]) {}
+
+		// Guarded by flags
+		template <typename T, void Transform(T&), typename Flag, typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE],
+			Flag valid_flags[][LOAD_VEC_SIZE]) {}
+
+		// Guarded by partial tile size
+		template <typename T, void Transform(T&), typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE],
+			const SizeT &partial_tile_size) {}
+
+		// Guarded by flags and partial tile size
+		template <typename T, void Transform(T&), typename Flag, typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T *dest,
+			T data[][LOAD_VEC_SIZE],
+			SizeT scatter_offsets[][LOAD_VEC_SIZE],
+			Flag valid_flags[][LOAD_VEC_SIZE],
+			const SizeT &partial_tile_size) {}
+	};
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Scatter to destination with transform.  The write is
+	 * predicated on the element's index in
+	 * the tile is not exceeding the partial tile size
+	 */
+	template <
+		typename T,
+		void Transform(T&), 							// Assignment function to transform the stored value
+		typename SizeT>
+	static __device__ __forceinline__ void Scatter(
+		T *dest,
+		T data[][LOAD_VEC_SIZE],
+		SizeT scatter_offsets[][LOAD_VEC_SIZE],
+		const SizeT &partial_tile_size = TILE_SIZE)
+	{
+		if (partial_tile_size < TILE_SIZE) {
+
+			// guarded IO
+			Iterate<0, 0>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets, partial_tile_size);
+
+		} else {
+
+			// unguarded IO
+			Iterate<0, 0>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets);
+		}
+	}
+
+	/**
+	 * Scatter to destination.  The write is predicated on the element's index in
+	 * the tile is not exceeding the partial tile size
+	 */
+	template <typename T, typename SizeT>
+	static __device__ __forceinline__ void Scatter(
+		T *dest,
+		T data[][LOAD_VEC_SIZE],
+		SizeT scatter_offsets[][LOAD_VEC_SIZE],
+		const SizeT &partial_tile_size = TILE_SIZE)
+	{
+		Scatter<T, Operators<T>::NopTransform>(
+			dest, data, scatter_offsets, partial_tile_size);
+	}
+
+	/**
+	 * Scatter to destination with transform.  The write is
+	 * predicated on valid flags and that the element's index in
+	 * the tile is not exceeding the partial tile size
+	 */
+	template <
+		typename T,
+		void Transform(T&), 							// Assignment function to transform the stored value
+		typename Flag,
+		typename SizeT>
+	static __device__ __forceinline__ void Scatter(
+		T *dest,
+		T data[][LOAD_VEC_SIZE],
+		Flag flags[][LOAD_VEC_SIZE],
+		SizeT scatter_offsets[][LOAD_VEC_SIZE],
+		const SizeT &partial_tile_size = TILE_SIZE)
+	{
+		if (partial_tile_size < TILE_SIZE) {
+
+			// guarded by flags and partial tile size
+			Iterate<0, 0>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets, flags, partial_tile_size);
+
+		} else {
+
+			// guarded by flags
+			Iterate<0, 0>::template Invoke<T, Transform>(
+				dest, data, scatter_offsets, flags);
+		}
+	}
+
+	/**
+	 * Scatter to destination.  The write is
+	 * predicated on valid flags and that the element's index in
+	 * the tile is not exceeding the partial tile size
+	 */
+	template <typename T, typename Flag, typename SizeT>
+	static __device__ __forceinline__ void Scatter(
+		T *dest,
+		T data[][LOAD_VEC_SIZE],
+		Flag flags[][LOAD_VEC_SIZE],
+		SizeT scatter_offsets[][LOAD_VEC_SIZE],
+		const SizeT &partial_tile_size = TILE_SIZE)
+	{
+		Scatter<T, Operators<T>::NopTransform>(
+			dest, data, flags, scatter_offsets, partial_tile_size);
+	}
+
+};
+
+
+
+} // namespace io
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/io/store_tile.cuh
+++ b/include/b40c/util/io/store_tile.cuh
@@ -1,0 +1,229 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Kernel utilities for storing tiles of data through global memory
+ * with cache modifiers
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/vector_types.cuh>
+#include <b40c/util/io/modified_store.cuh>
+
+namespace b40c {
+namespace util {
+namespace io {
+
+/**
+ * Store of a tile of items using guarded stores 
+ */
+template <
+	int LOG_LOADS_PER_TILE, 									// Number of vector stores (log)
+	int LOG_LOAD_VEC_SIZE,										// Number of items per vector store (log)
+	int ACTIVE_THREADS,											// Active threads that will be storing
+	st::CacheModifier CACHE_MODIFIER,							// Cache modifier (e.g., WB/CG/CS/NONE/etc.)
+	bool CHECK_ALIGNMENT>										// Whether or not to check alignment to see if vector stores can be used
+struct StoreTile
+{
+	enum {
+		LOADS_PER_TILE 			= 1 << LOG_LOADS_PER_TILE,
+		LOAD_VEC_SIZE 				= 1 << LOG_LOAD_VEC_SIZE,
+		LOG_ELEMENTS_PER_THREAD		= LOG_LOADS_PER_TILE + LOG_LOAD_VEC_SIZE,
+		ELEMENTS_PER_THREAD			= 1 << LOG_ELEMENTS_PER_THREAD,
+		TILE_SIZE 					= ACTIVE_THREADS * LOADS_PER_TILE * LOAD_VEC_SIZE,
+	};
+
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	// Iterate over vec-elements
+	template <int LOAD, int VEC>
+	struct Iterate
+	{
+		// Vector
+		template <typename VectorType>
+		static __device__ __forceinline__ void Invoke(
+			VectorType vectors[],
+			VectorType *d_in_vectors)
+		{
+			Iterate<LOAD, VEC + 1>::Invoke(vectors, d_in_vectors);
+		}
+
+		// Unguarded
+		template <typename T>
+		static __device__ __forceinline__ void Invoke(
+			T data[][LOAD_VEC_SIZE],
+			T *d_out)
+		{
+			int thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + VEC;
+
+			ModifiedStore<CACHE_MODIFIER>::St(data[LOAD][VEC], d_out + thread_offset);
+
+			Iterate<LOAD, VEC + 1>::Invoke(data, d_out);
+		}
+
+		// Guarded
+		template <typename T, typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T data[][LOAD_VEC_SIZE],
+			T *d_out,
+			const SizeT &guarded_elements)
+		{
+			SizeT thread_offset = (threadIdx.x << LOG_LOAD_VEC_SIZE) + (LOAD * ACTIVE_THREADS * LOAD_VEC_SIZE) + VEC;
+
+			if (thread_offset < guarded_elements) {
+				ModifiedStore<CACHE_MODIFIER>::St(data[LOAD][VEC], d_out + thread_offset);
+			}
+			Iterate<LOAD, VEC + 1>::Invoke(data, d_out, guarded_elements);
+		}
+	};
+
+	// Iterate over stores
+	template <int LOAD>
+	struct Iterate<LOAD, LOAD_VEC_SIZE>
+	{
+		// Vector
+		template <typename VectorType>
+		static __device__ __forceinline__ void Invoke(
+			VectorType vectors[],
+			VectorType *d_in_vectors)
+		{
+			ModifiedStore<CACHE_MODIFIER>::St(
+				vectors[LOAD], d_in_vectors);
+
+			Iterate<LOAD + 1, 0>::Invoke(vectors, d_in_vectors + ACTIVE_THREADS);
+		}
+
+		// Unguarded
+		template <typename T>
+		static __device__ __forceinline__ void Invoke(
+			T data[][LOAD_VEC_SIZE],
+			T *d_out)
+		{
+			Iterate<LOAD + 1, 0>::Invoke(data, d_out);
+		}
+
+		// Guarded
+		template <typename T, typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T data[][LOAD_VEC_SIZE],
+			T *d_out,
+			const SizeT &guarded_elements)
+		{
+			Iterate<LOAD + 1, 0>::Invoke(data, d_out, guarded_elements);
+		}
+	};
+	
+	// Terminate
+	template <int VEC>
+	struct Iterate<LOADS_PER_TILE, VEC>
+	{
+		// Vector
+		template <typename VectorType>
+		static __device__ __forceinline__ void Invoke(
+			VectorType vectors[], VectorType *d_in_vectors) {}
+
+		// Unguarded
+		template <typename T>
+		static __device__ __forceinline__ void Invoke(
+			T data[][LOAD_VEC_SIZE],
+			T *d_out) {}
+
+		// Guarded
+		template <typename T, typename SizeT>
+		static __device__ __forceinline__ void Invoke(
+			T data[][LOAD_VEC_SIZE],
+			T *d_out,
+			const SizeT &guarded_elements) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Store a full tile
+	 */
+	template <typename T, typename SizeT>
+	static __device__ __forceinline__ void Store(
+		T data[][LOAD_VEC_SIZE],
+		T *d_out,
+		SizeT cta_offset)
+	{
+		const size_t MASK = ((sizeof(T) * 8 * LOAD_VEC_SIZE) - 1);
+
+		if ((CHECK_ALIGNMENT) && (LOAD_VEC_SIZE > 1) && (((size_t) d_out) & MASK)) {
+
+			Iterate<0, 0>::Invoke(
+				data, d_out + cta_offset);
+
+		} else {
+
+			// Aliased vector type
+			typedef typename VecType<T, LOAD_VEC_SIZE>::Type VectorType;
+
+			// Use an aliased pointer to keys array to perform built-in vector stores
+			VectorType *vectors = (VectorType *) data;
+			VectorType *d_in_vectors = (VectorType *) (d_out + cta_offset + (threadIdx.x << LOG_LOAD_VEC_SIZE));
+
+			Iterate<0, 0>::Invoke(vectors, d_in_vectors);
+		}
+	}
+
+	/**
+	 * Store guarded_elements of a tile
+	 */
+	template <typename T, typename SizeT>
+	static __device__ __forceinline__ void Store(
+		T data[][LOAD_VEC_SIZE],
+		T *d_out,
+		SizeT cta_offset,
+		const SizeT &guarded_elements)
+	{
+		if (guarded_elements >= TILE_SIZE) {
+
+			Store(data, d_out, cta_offset);
+
+		} else {
+
+			Iterate<0, 0>::Invoke(
+				data, d_out + cta_offset, guarded_elements);
+		}
+	} 
+};
+
+
+
+} // namespace io
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/io/two_phase_scatter_tile.cuh
+++ b/include/b40c/util/io/two_phase_scatter_tile.cuh
@@ -1,0 +1,129 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Kernel utilities for two-phase tile scattering
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/io/scatter_tile.cuh>
+#include <b40c/util/io/load_tile.cuh>
+#include <b40c/util/io/store_tile.cuh>
+
+namespace b40c {
+namespace util {
+namespace io {
+
+
+/**
+ * Performs a two-phase tile scattering in order to improve global-store write
+ * coalescing: first to smem, then to global.
+ *
+ * Does not barrier after usage: a subsequent sync is needed to make shared memory
+ * coherent for re-use
+ */
+template <
+	int LOG_LOADS_PER_TILE, 									// Number of vector loads (log)
+	int LOG_LOAD_VEC_SIZE,										// Number of items per vector load (log)
+	int ACTIVE_THREADS,
+	st::CacheModifier CACHE_MODIFIER,
+	bool CHECK_ALIGNMENT>
+struct TwoPhaseScatterTile
+{
+	enum {
+		LOG_ELEMENTS_PER_THREAD		= LOG_LOADS_PER_TILE + LOG_LOAD_VEC_SIZE,
+		ELEMENTS_PER_THREAD			= 1 << LOG_ELEMENTS_PER_THREAD,
+		LOADS_PER_TILE 				= 1 << LOG_LOADS_PER_TILE,
+		LOAD_VEC_SIZE 				= 1 << LOG_LOAD_VEC_SIZE,
+		TILE_SIZE					= ELEMENTS_PER_THREAD * ACTIVE_THREADS,
+	};
+
+	template <
+		typename T,
+		typename Flag,
+		typename Rank,
+		typename SizeT>
+	__device__ __forceinline__ void Scatter(
+		T data[LOADS_PER_TILE][LOAD_VEC_SIZE],								// Elements of data to scatter
+		Flag flags[LOADS_PER_TILE][LOAD_VEC_SIZE],							// Valid predicates for data elements
+		Rank ranks[LOADS_PER_TILE][LOAD_VEC_SIZE],							// Local ranks of data to scatter
+		Rank valid_elements,												// Number of valid elements
+		T smem_exchange[TILE_SIZE],											// Smem swap exchange storage
+		T *d_out,															// Global output to scatter to
+		SizeT cta_offset)													// CTA offset into d_out at which to scatter to
+	{
+		// Scatter valid data into smem exchange, predicated on head_flags
+		ScatterTile<
+			LOG_LOADS_PER_TILE,
+			LOG_LOAD_VEC_SIZE,
+			ACTIVE_THREADS,
+			st::NONE>::Scatter(
+				smem_exchange,
+				data,
+				flags,
+				ranks);
+
+		// Barrier sync to protect smem exchange storage
+		__syncthreads();
+
+		// Tile of compacted elements
+		T compacted_data[ELEMENTS_PER_THREAD][1];
+
+		// Gather compacted data from smem exchange (in 1-element stride loads)
+		LoadTile<
+			LOG_ELEMENTS_PER_THREAD,
+			0, 											// Vec-1
+			ACTIVE_THREADS,
+			ld::NONE,
+			false>::LoadValid(							// No need to check alignment
+				compacted_data,
+				smem_exchange,
+				0,
+				valid_elements);
+
+		// Scatter compacted data to global output
+		util::io::StoreTile<
+			LOG_ELEMENTS_PER_THREAD,
+			0, 											// Vec-1
+			ACTIVE_THREADS,
+			CACHE_MODIFIER,
+			CHECK_ALIGNMENT>::Store(
+				compacted_data,
+				d_out,
+				cta_offset,
+				valid_elements);
+	}
+};
+
+
+
+} // namespace io
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/kernel_runtime_stats.cuh
+++ b/include/b40c/util/kernel_runtime_stats.cuh
@@ -1,0 +1,316 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Kernel runtime statistics
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/error_utils.cuh>
+#include <b40c/util/cuda_properties.cuh>
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Manages device storage needed for conveying kernel runtime stats
+ */
+class KernelRuntimeStats
+{
+protected :
+
+	enum {
+		CLOCKS		= 0,
+		AGGREGATE,
+
+		TOTAL_COUNTERS,
+	};
+
+	// Counters in global device memory
+	unsigned long long 		*d_stat;
+
+
+	clock_t 				start;				// Start time
+	clock_t 				clocks;				// Accumulated time
+	unsigned long long 		aggregate;			// General-purpose aggregate counter
+
+public:
+
+	/**
+	 * Constructor
+	 */
+	KernelRuntimeStats() :
+		d_stat(NULL),
+		clocks(0),
+		aggregate(0) {}
+
+	/**
+	 * Marks start time.  Typically called by thread-0.
+	 */
+	__device__ __forceinline__ void MarkStart()
+	{
+		start = clock();
+	}
+
+	/**
+	 * Marks stop time.  Typically called by thread-0.
+	 */
+	__device__ __forceinline__ void MarkStop()
+	{
+		clock_t stop = clock();
+		clock_t runtime = (stop >= start) ?
+			stop - start :
+			stop + (((clock_t) -1) - start);
+		clocks += runtime;
+	}
+
+	/**
+	 * Increments the aggregate counter by the specified amount.
+	 * Typically called by thread-0.
+	 */
+	template <typename T>
+	__device__ __forceinline__ void Aggregate(T increment)
+	{
+		aggregate += increment;
+	}
+
+	/**
+	 * Flushes statistics to global mem
+	 */
+	__device__ __forceinline__ void Flush()
+	{
+		if (d_stat != NULL) {
+			d_stat[blockIdx.x + (CLOCKS * gridDim.x)] = clocks;
+			d_stat[blockIdx.x + (AGGREGATE * gridDim.x)] = aggregate;
+		}
+	}
+
+	/**
+	 * Resets statistics. Typically called by thread-0.
+	 */
+	__device__ __forceinline__ void Reset() const
+	{
+		if (d_stat != NULL) {
+			d_stat[blockIdx.x + (CLOCKS * gridDim.x)] = 0;
+			d_stat[blockIdx.x + (AGGREGATE * gridDim.x)] = 0;
+		}
+	}
+
+};
+
+
+/**
+ * Version of global barrier with storage lifetime management.
+ *
+ * We can use this in host enactors, and pass the base GlobalBarrier
+ * as parameters to kernels.
+ */
+class KernelRuntimeStatsLifetime : public KernelRuntimeStats
+{
+protected:
+
+	// Number of bytes backed by d_stat
+	size_t stat_bytes;
+
+	// GPU d_counters was allocated on
+	int gpu;
+
+public:
+
+	/**
+	 * Constructor
+	 */
+	KernelRuntimeStatsLifetime() :
+		KernelRuntimeStats(),
+		stat_bytes(0),
+		gpu(B40C_INVALID_DEVICE) {}
+
+
+	/**
+	 * Deallocates and resets the progress counters
+	 */
+	cudaError_t HostReset()
+	{
+		cudaError_t retval = cudaSuccess;
+
+		do {
+
+			if (d_stat) {
+
+				// Save current gpu
+				int current_gpu;
+				if (retval = util::B40CPerror(cudaGetDevice(&current_gpu),
+					"KernelRuntimeStatsLifetime cudaGetDevice failed: ", __FILE__, __LINE__)) break;
+
+				// Deallocate
+				if (retval = util::B40CPerror(cudaSetDevice(gpu),
+					"KernelRuntimeStatsLifetime cudaSetDevice failed: ", __FILE__, __LINE__)) break;
+				if (retval = util::B40CPerror(cudaFree(d_stat),
+					"KernelRuntimeStatsLifetime cudaFree d_stat failed: ", __FILE__, __LINE__)) break;
+
+				d_stat = NULL;
+				gpu = B40C_INVALID_DEVICE;
+
+				// Restore current gpu
+				if (retval = util::B40CPerror(cudaSetDevice(current_gpu),
+					"KernelRuntimeStatsLifetime cudaSetDevice failed: ", __FILE__, __LINE__)) break;
+			}
+
+			stat_bytes = 0;
+
+		} while (0);
+
+		return retval;
+	}
+
+
+	/**
+	 * Destructor
+	 */
+	virtual ~KernelRuntimeStatsLifetime()
+	{
+		HostReset();
+	}
+
+
+	/**
+	 * Sets up the progress counters for the next kernel launch (lazily
+	 * allocating and initializing them if necessary)
+	 */
+	cudaError_t Setup(int grid_size)
+	{
+		cudaError_t retval = cudaSuccess;
+		do {
+			size_t new_stat_bytes = grid_size * sizeof(unsigned long long) * TOTAL_COUNTERS;
+			if (new_stat_bytes > stat_bytes) {
+
+				// Deallocate if exists
+				if (retval = HostReset()) break;
+
+				// Remember device
+				if (retval = util::B40CPerror(cudaGetDevice(&gpu),
+					"KernelRuntimeStatsLifetime cudaGetDevice failed: ", __FILE__, __LINE__)) break;
+
+				// Reallocate
+				stat_bytes = new_stat_bytes;
+
+				if (retval = util::B40CPerror(cudaMalloc((void**) &d_stat, stat_bytes),
+					"KernelRuntimeStatsLifetime cudaMalloc d_stat failed", __FILE__, __LINE__)) break;
+
+				// Initialize to zero
+				util::MemsetKernel<unsigned long long><<<(grid_size + 128 - 1) / 128, 128>>>(
+					d_stat, 0, grid_size);
+				if (retval = util::B40CPerror(cudaThreadSynchronize(),
+					"KernelRuntimeStatsLifetime MemsetKernel d_stat failed", __FILE__, __LINE__)) break;
+			}
+		} while (0);
+
+		return retval;
+	}
+
+
+	/**
+	 * Accumulates avg live, max live, and total aggregate
+	 */
+	cudaError_t Accumulate(
+		int grid_size,
+		unsigned long long &total_runtimes,
+		unsigned long long &total_lifetimes,
+		unsigned long long &total_aggregate)
+	{
+		cudaError_t retval = cudaSuccess;
+
+		do {
+
+			unsigned long long *h_stat = (unsigned long long*) malloc(stat_bytes);
+
+			// Save current gpu
+			int current_gpu;
+			if (retval = util::B40CPerror(cudaGetDevice(&current_gpu),
+				"KernelRuntimeStatsLifetime cudaGetDevice failed: ", __FILE__, __LINE__)) break;
+
+			if (retval = util::B40CPerror(cudaSetDevice(gpu),
+				"KernelRuntimeStatsLifetime cudaSetDevice failed: ", __FILE__, __LINE__)) break;
+
+			// Copy out stats
+			if (retval = util::B40CPerror(cudaMemcpy(h_stat, d_stat, stat_bytes, cudaMemcpyDeviceToHost),
+				"KernelRuntimeStatsLifetime d_stat failed", __FILE__, __LINE__)) break;
+
+			// Restore current gpu
+			if (retval = util::B40CPerror(cudaSetDevice(current_gpu),
+				"KernelRuntimeStatsLifetime cudaSetDevice failed: ", __FILE__, __LINE__)) break;
+
+			// Compute runtimes, find max
+			unsigned long long max_runtime = 0;
+			for (int block = 0; block < grid_size; block++) {
+
+				unsigned long long runtime = h_stat[(CLOCKS * grid_size) + block];
+
+				if (runtime > max_runtime) {
+					max_runtime = runtime;
+				}
+
+				total_runtimes += runtime;
+			}
+
+			total_lifetimes += (max_runtime * grid_size);
+
+			// Accumulate aggregates
+			for (int block = 0; block < grid_size; block++) {
+				total_aggregate += h_stat[(AGGREGATE * grid_size) + block];
+			}
+
+			free(h_stat);
+
+		} while (0);
+
+		return retval;
+	}
+
+
+	/**
+	 * Accumulates avg live, max live
+	 */
+	cudaError_t Accumulate(
+		int grid_size,
+		unsigned long long &total_runtimes,
+		unsigned long long &total_lifetimes)
+	{
+		unsigned long long total_aggregate = 0;
+		return Accumulate(grid_size, total_runtimes, total_lifetimes, total_aggregate);
+	}
+};
+
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/memset_kernel.cuh
+++ b/include/b40c/util/memset_kernel.cuh
@@ -1,0 +1,52 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ * Simple Memset Kernel
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace util {
+
+/**
+ * Memset a device vector.
+ */
+template <typename T>
+__global__ void MemsetKernel(T *d_out, T value, int length)
+{
+	const int STRIDE = gridDim.x * blockDim.x;
+	for (int idx = (blockIdx.x * blockDim.x) + threadIdx.x; idx < length; idx += STRIDE) {
+		d_out[idx] = value;
+	}
+}
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/multiple_buffering.cuh
+++ b/include/b40c/util/multiple_buffering.cuh
@@ -1,0 +1,170 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+
+/******************************************************************************
+ *  Storage wrapper for multi-pass stream transformations that require a
+ *  secondary problem storage array to stream results back and forth from.
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/basic_utils.cuh>
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Storage wrapper for multi-pass stream transformations that require a
+ * more than one problem storage array to stream results back and forth from.
+ * 
+ * This wrapper provides maximum flexibility for re-using device allocations
+ * for subsequent transformations.  As such, it is the caller's responsibility
+ * to free any non-NULL storage arrays when no longer needed.
+ * 
+ * Many multi-pass stream computations require at least two problem storage
+ * arrays, e.g., one for reading in from, the other for writing out to.
+ * (And their roles can be reversed for each subsequent pass.) This structure
+ * tracks two sets of device vectors (a keys and a values sets), and a "selector"
+ * member to index which vector in each set is "currently valid".  I.e., the
+ * valid data within "MultipleBuffer<2, int, int> b" is accessible by:
+ * 
+ * 		b.d_keys[b.selector];
+ * 
+ */
+template <
+	int BUFFER_COUNT,
+	typename _KeyType,
+	typename _ValueType = util::NullType>
+struct MultipleBuffer
+{
+	typedef _KeyType	KeyType;
+	typedef _ValueType 	ValueType;
+
+	// Set of device vector pointers for keys
+	KeyType* d_keys[BUFFER_COUNT];
+	
+	// Set of device vector pointers for values
+	ValueType* d_values[BUFFER_COUNT];
+
+	// Selector into the set of device vector pointers (i.e., where the results are)
+	int selector;
+
+	// Constructor
+	MultipleBuffer()
+	{
+		selector = 0;
+		for (int i = 0; i < BUFFER_COUNT; i++) {
+			d_keys[i] = NULL;
+			d_values[i] = NULL;
+		}
+	}
+};
+
+
+
+/**
+ * Double buffer (a.k.a. page-flip, ping-pong, etc.) version of the
+ * multi-buffer storage abstraction above.
+ *
+ * Many of the B40C primitives are templated upon the DoubleBuffer type: they
+ * are compiled differently depending upon whether the declared type contains
+ * keys-only versus key-value pairs (i.e., whether ValueType is util::NullType
+ * or some real type).
+ *
+ * Declaring keys-only storage wrapper:
+ *
+ * 		DoubleBuffer<KeyType> key_storage;
+ *
+ * Declaring key-value storage wrapper:
+ *
+ * 		DoubleBuffer<KeyType, ValueType> key_value_storage;
+ *
+ */
+template <
+	typename KeyType,
+	typename ValueType = util::NullType>
+struct DoubleBuffer : MultipleBuffer<2, KeyType, ValueType>
+{
+	typedef MultipleBuffer<2, KeyType, ValueType> ParentType;
+
+	// Constructor
+	DoubleBuffer() : ParentType() {}
+
+	// Constructor
+	DoubleBuffer(
+		KeyType* keys) : ParentType()
+
+	{
+		this->d_keys[0] = keys;
+	}
+
+	// Constructor
+	DoubleBuffer(
+		KeyType* keys,
+		ValueType* values) : ParentType()
+	{
+		this->d_keys[0] = keys;
+		this->d_values[0] = values;
+	}
+
+	// Constructor
+	DoubleBuffer(
+		KeyType* keys0,
+		KeyType* keys1,
+		ValueType* values0,
+		ValueType* values1) : ParentType()
+	{
+		this->d_keys[0] = keys0;
+		this->d_keys[1] = keys1;
+		this->d_values[0] = values0;
+		this->d_values[1] = values1;
+	}
+};
+
+
+/**
+ * Triple buffer version of the multi-buffer storage abstraction above.
+ */
+template <
+	typename KeyType,
+	typename ValueType = util::NullType>
+struct TripleBuffer : MultipleBuffer<3, KeyType, ValueType>
+{
+	typedef MultipleBuffer<3, KeyType, ValueType> ParentType;
+
+	// Constructor
+	TripleBuffer() : ParentType() {}
+};
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/numeric_traits.cuh
+++ b/include/b40c/util/numeric_traits.cuh
@@ -1,0 +1,79 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+
+/******************************************************************************
+ * Type traits for numeric types
+ ******************************************************************************/
+
+#pragma once
+
+
+namespace b40c {
+namespace util {
+
+
+enum Representation
+{
+	NOT_A_NUMBER,
+	SIGNED_INTEGER,
+	UNSIGNED_INTEGER,
+	FLOATING_POINT
+};
+
+
+template <Representation R>
+struct BaseTraits
+{
+	static const Representation REPRESENTATION = R;
+};
+
+
+// Default, non-numeric types
+template <typename T> struct NumericTraits : 				BaseTraits<NOT_A_NUMBER> {};
+
+template <> struct NumericTraits<char> : 					BaseTraits<SIGNED_INTEGER> {};
+template <> struct NumericTraits<signed char> : 			BaseTraits<SIGNED_INTEGER> {};
+template <> struct NumericTraits<short> : 					BaseTraits<SIGNED_INTEGER> {};
+template <> struct NumericTraits<int> : 					BaseTraits<SIGNED_INTEGER> {};
+template <> struct NumericTraits<long> : 					BaseTraits<SIGNED_INTEGER> {};
+template <> struct NumericTraits<long long> : 				BaseTraits<SIGNED_INTEGER> {};
+
+template <> struct NumericTraits<unsigned char> : 			BaseTraits<UNSIGNED_INTEGER> {};
+template <> struct NumericTraits<unsigned short> : 			BaseTraits<UNSIGNED_INTEGER> {};
+template <> struct NumericTraits<unsigned int> : 			BaseTraits<UNSIGNED_INTEGER> {};
+template <> struct NumericTraits<unsigned long> : 			BaseTraits<UNSIGNED_INTEGER> {};
+template <> struct NumericTraits<unsigned long long> : 		BaseTraits<UNSIGNED_INTEGER> {};
+
+template <> struct NumericTraits<float> : 					BaseTraits<FLOATING_POINT> {};
+template <> struct NumericTraits<double> : 					BaseTraits<FLOATING_POINT> {};
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/operators.cuh
+++ b/include/b40c/util/operators.cuh
@@ -1,0 +1,92 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Simple reduction operators
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace util {
+
+/**
+ * Static operator wrapping structure.
+ *
+ * (N.B. due to an NVCC/cudafe 4.0 regression, we can't specify static templated
+ * functions inside other types...)
+ */
+template <typename T, typename R = T>
+struct Operators
+{
+	/**
+	 * Empty default transform function
+	 */
+	static __device__ __forceinline__ void NopTransform(T &val) {}
+
+};
+
+
+/**
+ * Default equality functor
+ */
+template <typename T>
+struct Equality
+{
+	__host__ __device__ __forceinline__ bool operator()(const T &a, const T &b)
+	{
+		return a == b;
+	}
+};
+
+
+/**
+ * Default sum functor
+ */
+template <typename T>
+struct Sum
+{
+	// Binary reduction
+	__host__ __device__ __forceinline__ T operator()(const T &a, const T &b)
+	{
+		return a + b;
+	}
+
+	// Identity
+	__host__ __device__ __forceinline__ T operator()()
+	{
+		return (T) 0;
+	}
+};
+
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/parameter_generation.cuh
+++ b/include/b40c/util/parameter_generation.cuh
@@ -1,0 +1,196 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Functionality for generating parameter lists based upon ranges, suitable
+ * for auto-tuning
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * A recursive tuple type that wraps a constant integer and another tuple type.
+ *
+ * Can be used to construct types that describe static lists of integer constants.
+ */
+template <typename NextTuple, int V, int P, int PREV_SIZE = NextTuple::SIZE>
+struct ParamTuple
+{
+	typedef typename NextTuple::next next;
+
+	enum {
+		P0 = (PREV_SIZE > 0) ? NextTuple::P0 : P, 	V0 = (PREV_SIZE > 0) ? NextTuple::V0 : V,
+		P1 = (PREV_SIZE > 1) ? NextTuple::P1 : P, 	V1 = (PREV_SIZE > 1) ? NextTuple::V1 : V,
+		P2 = (PREV_SIZE > 2) ? NextTuple::P2 : P, 	V2 = (PREV_SIZE > 2) ? NextTuple::V2 : V,
+		P3 = (PREV_SIZE > 3) ? NextTuple::P3 : P, 	V3 = (PREV_SIZE > 3) ? NextTuple::V3 : V,
+
+		P4 = (PREV_SIZE > 4) ? NextTuple::P4 : P, 	V4 = (PREV_SIZE > 4) ? NextTuple::V4 : V,
+		P5 = (PREV_SIZE > 5) ? NextTuple::P5 : P, 	V5 = (PREV_SIZE > 5) ? NextTuple::V5 : V,
+		P6 = (PREV_SIZE > 6) ? NextTuple::P6 : P, 	V6 = (PREV_SIZE > 6) ? NextTuple::V6 : V,
+		P7 = P, 									V7 = V,
+
+		SIZE = PREV_SIZE + 1
+	};
+};
+
+// Prev was full: start a new tuple
+template <typename NextTuple, int V, int P>
+struct ParamTuple<NextTuple, V, P, 8>
+{
+	typedef NextTuple next;
+
+	enum {
+		P0 = P, 	V0 = V,
+		P1 = P, 	V1 = V,
+		P2 = P, 	V2 = V,
+		P3 = P, 	V3 = V,
+
+		P4 = P, 	V4 = V,
+		P5 = P, 	V5 = V,
+		P6 = P, 	V6 = V,
+		P7 = P, 	V7 = V,
+
+		SIZE = 1
+	};
+};
+
+// Empty tuple (forces new tuple)
+struct EmptyTuple
+{
+	enum {
+		SIZE = 8
+	};
+};
+
+
+template <typename ParamList, int SEARCH_PARAM>
+struct Access
+{
+	enum {
+		VALUE = 	(SEARCH_PARAM == ParamList::P0) ?		(int) ParamList::V0 :
+					(SEARCH_PARAM == ParamList::P1) ?		(int) ParamList::V1 :
+					(SEARCH_PARAM == ParamList::P2) ?		(int) ParamList::V2 :
+					(SEARCH_PARAM == ParamList::P3) ?		(int) ParamList::V3 :
+					(SEARCH_PARAM == ParamList::P4) ?		(int) ParamList::V4 :
+					(SEARCH_PARAM == ParamList::P5) ?		(int) ParamList::V5 :
+					(SEARCH_PARAM == ParamList::P6) ?		(int) ParamList::V6 :
+					(SEARCH_PARAM == ParamList::P7) ?		(int) ParamList::V7 :
+															Access<typename ParamList::next, SEARCH_PARAM>::VALUE
+	};
+};
+
+template <int SEARCH_PARAM>
+struct Access<EmptyTuple, SEARCH_PARAM>
+{
+	enum {
+		VALUE = 0
+	};
+};
+
+
+
+/**
+ * A type generator that sweeps an enumerated sequence of tuning parameters,
+ * each of which has an associated (integer) range.  A static list of integer
+ * constants is generated for every possible permutation of parameter values.
+ * A static callback function on the problem-description type TuneProblemDetail
+ * is invoked for each permutation.
+ *
+ * The range structure for a given parameter may be dependent upon the
+ * values selected for tuning parameters occurring prior in the
+ * enumeration. (E.g., the range structure for a "raking threads" parameter
+ * may incorporate a "cta threads" parameter that is swept earlier in
+ * the enumeration to establish an upper bound on raking threads.)
+ */
+template <
+	int PARAM,
+	int MAX_PARAM,
+	template <typename, int> class Ranges>
+struct ParamListSweep
+{
+	// Next parameter increment
+	template <int COUNT, int MAX>
+	struct Sweep
+	{
+		template <typename ParamList, typename TuneProblemDetail>
+		static void Invoke(TuneProblemDetail &detail)
+		{
+			// Sweep subsequent parameter
+			ParamListSweep<
+				PARAM + 1,
+				MAX_PARAM,
+				Ranges>::template Invoke<ParamTuple<ParamList, COUNT, PARAM> >(detail);
+
+			// Continue sweep with increment of this parameter
+			Sweep<COUNT + 1, MAX>::template Invoke<ParamList>(detail);
+		}
+	};
+
+	// Terminate
+	template <int MAX>
+	struct Sweep<MAX, MAX>
+	{
+		template <typename ParamList, typename TuneProblemDetail>
+		static void Invoke(TuneProblemDetail &detail) {}
+	};
+
+	// Interface
+	template <typename ParamList, typename TuneProblemDetail>
+	static void Invoke(TuneProblemDetail &detail)
+	{
+		// Sweep current parameter
+		Sweep<
+			Ranges<ParamList, PARAM>::MIN,
+			Ranges<ParamList, PARAM>::MAX + 1>::template Invoke<ParamList>(detail);
+
+	}
+};
+
+// End of currently-generated list
+template <
+	int MAX_PARAM,
+	template <typename, int> class Ranges>
+struct ParamListSweep <MAX_PARAM, MAX_PARAM, Ranges>
+{
+	template <typename ParamList, typename TuneProblemDetail>
+	static void Invoke(TuneProblemDetail &detail)
+	{
+		// Invoke callback
+		detail.template Invoke<ParamList>();
+	}
+
+};
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/ping_pong_storage.cuh
+++ b/include/b40c/util/ping_pong_storage.cuh
@@ -1,0 +1,75 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+
+/******************************************************************************
+ *  Storage wrapper for double-buffered vectors (deprecated).
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/multiple_buffering.cuh>
+
+namespace b40c {
+namespace util {
+
+/**
+ * Ping-pong buffer (a.k.a. page-flip, double-buffer, etc.).
+ * Deprecated: see b40c::util::DoubleBuffer instead.
+ */
+template <
+	typename KeyType,
+	typename ValueType = util::NullType>
+struct PingPongStorage : DoubleBuffer<KeyType, ValueType>
+{
+	typedef DoubleBuffer<KeyType, ValueType> ParentType;
+
+	// Constructor
+	PingPongStorage() : ParentType() {}
+
+	// Constructor
+	PingPongStorage(
+		KeyType* keys) : ParentType(keys) {}
+
+	// Constructor
+	PingPongStorage(
+		KeyType* keys,
+		ValueType* values) : ParentType(keys, values) {}
+
+	// Constructor
+	PingPongStorage(
+		KeyType* keys0,
+		KeyType* keys1,
+		ValueType* values0,
+		ValueType* values1) : ParentType(keys0, keys1, values0, values1) {}
+};
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/raking_grid.cuh
+++ b/include/b40c/util/raking_grid.cuh
@@ -1,0 +1,279 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Raking grid abstraction
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/basic_utils.cuh>
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Raking grid abstraction.
+ *
+ * A "raking lane" is a region of shared memory into which a group of N active
+ * threads (e.g., a CTA) can place N data items (e.g., partial reductions) in
+ * thread-rank-order.  The lane logically partitions these shared partials
+ * into S contiguous segments of N/S elements each.   These segments can be
+ * mapped to a corresponding a set of S "raking threads" in thread-rank-order.
+ *
+ * The lane is arranged with regular padding cells so that raking threads will
+ * not incur bank conflicts when accessing identical segment offsets.  E.g.,
+ * raking threads are conflict-free when linearly sweeping through their segments.
+ *
+ * A "raking grid" is a set of L raking lanes and R raking threads (R >= L).
+ * Each lane comprises N data items (one item for each of the N active threads)
+ * and is alloted S = R/L raking threads.
+ */
+template <
+	int _CUDA_ARCH,					// CUDA SM architecture to generate code for
+	typename _T,					// Type of items we will be raking
+	int _LOG_ACTIVE_THREADS, 		// Number of threads placing a lane partial (i.e., the number of partials per lane) (log)
+	int _LOG_RAKING_THREADS, 		// Number of threads used for raking (typically 1 warp) (log)
+	int _LOG_LANES = 0>				// Number of raking lanes, default = 1 lane (log)
+struct RakingGrid
+{
+
+	//---------------------------------------------------------------------
+	// Typedefs and constants
+	//---------------------------------------------------------------------
+
+	// Type of items to be placed in the grid
+	typedef _T T;
+	
+	/**
+	 * Enumerated constants
+	 *
+	 * A "row" is a continuous sequence of raking segments without padding cells
+	 */
+	enum {
+		CUDA_ARCH						= _CUDA_ARCH,
+
+		// Number of scan lanes
+		LOG_LANES						= _LOG_LANES,
+		LANES							= 1 <<LOG_LANES,
+
+		// Number number of partials per lane
+		LOG_PARTIALS_PER_LANE 			= _LOG_ACTIVE_THREADS,
+		PARTIALS_PER_LANE				= 1 << LOG_PARTIALS_PER_LANE,
+
+		// Number of raking threads
+		LOG_RAKING_THREADS				= _LOG_RAKING_THREADS,
+		RAKING_THREADS					= 1 << LOG_RAKING_THREADS,
+
+		// Number of raking threads per lane
+		LOG_RAKING_THREADS_PER_LANE		= LOG_RAKING_THREADS - LOG_LANES,
+		RAKING_THREADS_PER_LANE			= 1 << LOG_RAKING_THREADS_PER_LANE,
+
+		// Partials to be raked per raking thread
+		LOG_PARTIALS_PER_SEG 			= LOG_PARTIALS_PER_LANE - LOG_RAKING_THREADS_PER_LANE,
+		PARTIALS_PER_SEG 				= 1 << LOG_PARTIALS_PER_SEG,
+
+		// Number of partials that we can put in one stripe across the shared memory banks
+		LOG_PARTIALS_PER_BANK_ARRAY		= B40C_LOG_MEM_BANKS(CUDA_ARCH) +
+											B40C_LOG_BANK_STRIDE_BYTES(CUDA_ARCH) -
+											Log2<sizeof(T)>::VALUE,
+		PARTIALS_PER_BANK_ARRAY			= 1 << LOG_PARTIALS_PER_BANK_ARRAY,
+
+		LOG_SEGS_PER_BANK_ARRAY 		= B40C_MAX(0, LOG_PARTIALS_PER_BANK_ARRAY - LOG_PARTIALS_PER_SEG),
+		SEGS_PER_BANK_ARRAY				= 1 << LOG_SEGS_PER_BANK_ARRAY,
+
+		// Whether or not one warp of raking threads can rake entirely in one stripe across the shared memory banks
+		NO_PADDING = (LOG_SEGS_PER_BANK_ARRAY >= B40C_LOG_WARP_THREADS(CUDA_ARCH)),
+
+		// Number of raking segments we can have without padding (i.e., a "row")
+		LOG_SEGS_PER_ROW 				= (NO_PADDING) ?
+											LOG_RAKING_THREADS :												// All raking threads (segments)
+											B40C_MIN(LOG_RAKING_THREADS_PER_LANE, LOG_SEGS_PER_BANK_ARRAY),		// Up to as many segments per lane (all lanes must have same amount of padding to have constant lane stride)
+		SEGS_PER_ROW					= 1 << LOG_SEGS_PER_ROW,
+
+		// Number of partials per row
+		LOG_PARTIALS_PER_ROW			= LOG_SEGS_PER_ROW + LOG_PARTIALS_PER_SEG,
+		PARTIALS_PER_ROW				= 1 << LOG_PARTIALS_PER_ROW,
+
+		// Number of partials that we must use to "pad out" one memory bank
+		LOG_BANK_PADDING_PARTIALS		= B40C_MAX(0, B40C_LOG_BANK_STRIDE_BYTES(CUDA_ARCH) - Log2<sizeof(T)>::VALUE),
+		BANK_PADDING_PARTIALS			= 1 << LOG_BANK_PADDING_PARTIALS,
+
+		// Number of partials that we must use to "pad out" a lane to one memory bank
+		LANE_PADDING_PARTIALS			= B40C_MAX(0, PARTIALS_PER_BANK_ARRAY - PARTIALS_PER_LANE),
+
+		// Number of partials (including padding) per "row"
+		PADDED_PARTIALS_PER_ROW			= (NO_PADDING) ?
+											PARTIALS_PER_ROW :
+											PARTIALS_PER_ROW + LANE_PADDING_PARTIALS + BANK_PADDING_PARTIALS,
+
+		// Number of rows in the grid
+		LOG_ROWS						= LOG_RAKING_THREADS - LOG_SEGS_PER_ROW,
+		ROWS 							= 1 << LOG_ROWS,
+
+		// Number of rows per lane (always at least one)
+		LOG_ROWS_PER_LANE				= B40C_MAX(0, LOG_RAKING_THREADS_PER_LANE - LOG_SEGS_PER_ROW),
+		ROWS_PER_LANE					= 1 << LOG_ROWS_PER_LANE,
+
+		// Padded stride between lanes (in partials)
+		LANE_STRIDE						= (NO_PADDING) ?
+											PARTIALS_PER_LANE :
+											ROWS_PER_LANE * PADDED_PARTIALS_PER_ROW,
+
+		// Number of elements needed to back this level of the raking grid
+		RAKING_ELEMENTS					= ROWS * PADDED_PARTIALS_PER_ROW,
+	};
+
+	// Type of pointer for inserting partials into lanes, e.g., lane_partial[LANE][0] = ...
+	typedef T (*LanePartial)[LANE_STRIDE];
+
+
+	// Type of pointer for raking across lane segments
+	typedef T* RakingSegment;
+
+
+	//---------------------------------------------------------------------
+	// Shared storage types
+	//---------------------------------------------------------------------
+
+	// Buffer type for lane storage
+	typedef T LaneStorage[RAKING_ELEMENTS];
+
+
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	/**
+	 * Shared lane storage
+	 */
+	LaneStorage &lane_storage;
+
+	/**
+	 * The location in the smem grid where the calling thread can insert/extract
+	 * its partial for raking reduction/scan into the first lane.
+	 */
+	typename RakingGrid::LanePartial my_lane_partial;
+
+	/**
+	 * The location in the smem grid where the calling thread can begin serial
+	 * raking/scanning (if it is a raking thread)
+	 */
+	typename RakingGrid::RakingSegment my_raking_segment;
+
+
+	//---------------------------------------------------------------------
+	// Methods
+	//---------------------------------------------------------------------
+
+	/**
+	 * Initialize lane_partial
+	 */
+	__device__ __forceinline__  void InitLanePartial(int tid = threadIdx.x)
+	{
+		lane_partial = (LanePartial) (
+			lane_storage + 													// base
+			tid + 															// logical thread offset
+			((tid >> LOG_PARTIALS_PER_ROW) * BANK_PADDING_PARTIALS));		// padding
+	}
+
+
+	/**
+	 * Initialize raking_segment
+	 */
+	__device__ __forceinline__  void InitRakingSegment(int tid = threadIdx.x)
+	{
+		raking_segment = (RakingSegment) (
+			lane_storage +													// base
+			(tid << LOG_PARTIALS_PER_SEG) +									// logical segment offset
+			((threadIdx.x >> LOG_SEGS_PER_ROW) * BANK_PADDING_PARTIALS));	// padding
+	}
+
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ RakingGrid(LaneStorage &lane_storage) :
+		lane_storage(lane_storage)
+	{
+		InitLanePartial();
+		if (threadIdx.x < RakingGrid::RAKING_THREADS) {
+			InitRakingSegment();
+		}
+	}
+
+
+	/**
+	 * Displays configuration to standard out
+	 */
+	static __host__ __device__ __forceinline__ void Print()
+	{
+		printf("LANES: %d\n"
+				"PARTIALS_PER_LANE: %d\n"
+				"RAKING_THREADS: %d\n"
+				"RAKING_THREADS_PER_LANE: %d\n"
+				"PARTIALS_PER_SEG: %d\n"
+				"PARTIALS_PER_BANK_ARRAY: %d\n"
+				"SEGS_PER_BANK_ARRAY: %d\n"
+				"NO_PADDING: %d\n"
+				"SEGS_PER_ROW: %d\n"
+				"PARTIALS_PER_ROW: %d\n"
+				"BANK_PADDING_PARTIALS: %d\n"
+				"LANE_PADDING_PARTIALS: %d\n"
+				"PADDED_PARTIALS_PER_ROW: %d\n"
+				"ROWS: %d\n"
+				"ROWS_PER_LANE: %d\n"
+				"LANE_STRIDE: %d\n"
+				"RAKING_ELEMENTS: %d\n",
+			LANES,
+			PARTIALS_PER_LANE,
+			RAKING_THREADS,
+			RAKING_THREADS_PER_LANE,
+			PARTIALS_PER_SEG,
+			PARTIALS_PER_BANK_ARRAY,
+			SEGS_PER_BANK_ARRAY,
+			NO_PADDING,
+			SEGS_PER_ROW,
+			PARTIALS_PER_ROW,
+			BANK_PADDING_PARTIALS,
+			LANE_PADDING_PARTIALS,
+			PADDED_PARTIALS_PER_ROW,
+			ROWS,
+			ROWS_PER_LANE,
+			LANE_STRIDE,
+			RAKING_ELEMENTS);
+	}
+};
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/random_bits.cuh
+++ b/include/b40c/util/random_bits.cuh
@@ -1,0 +1,91 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Random bits generator
+ ******************************************************************************/
+
+#pragma once
+
+#include <stdlib.h>
+
+namespace b40c {
+namespace util {
+
+/**
+ * Generates random 32-bit keys.
+ * 
+ * We always take the second-order byte from rand() because the higher-order 
+ * bits returned by rand() are commonly considered more uniformly distributed
+ * than the lower-order bits.
+ * 
+ * We can decrease the entropy level of keys by adopting the technique 
+ * of Thearling and Smith in which keys are computed from the bitwise AND of 
+ * multiple random samples: 
+ * 
+ * entropy_reduction	| Effectively-unique bits per key
+ * -----------------------------------------------------
+ * -1					| 0
+ * 0					| 32
+ * 1					| 25.95
+ * 2					| 17.41
+ * 3					| 10.78
+ * 4					| 6.42
+ * ...					| ...
+ * 
+ */
+template <typename K>
+void RandomBits(K &key, int entropy_reduction = 0, int lower_key_bits = sizeof(K) * 8)
+{
+	const unsigned int NUM_UCHARS = (sizeof(K) + sizeof(unsigned char) - 1) / sizeof(unsigned char);
+	unsigned char key_bits[NUM_UCHARS];
+	
+	do {
+	
+		for (int j = 0; j < NUM_UCHARS; j++) {
+			unsigned char quarterword = 0xff;
+			for (int i = 0; i <= entropy_reduction; i++) {
+				quarterword &= (rand() >> 7);
+			}
+			key_bits[j] = quarterword;
+		}
+		
+		if (lower_key_bits < sizeof(K) * 8) {
+			unsigned long long base = 0;
+			memcpy(&base, key_bits, sizeof(K));
+			base &= (1 << lower_key_bits) - 1;
+			memcpy(key_bits, &base, sizeof(K));
+		}
+		
+		memcpy(&key, key_bits, sizeof(K));
+		
+	} while (key != key);		// avoids NaNs when generating random floating point numbers 
+}
+
+} // namespace util
+} // namespace b40c

--- a/include/b40c/util/reduction/cooperative_reduction.cuh
+++ b/include/b40c/util/reduction/cooperative_reduction.cuh
@@ -1,0 +1,287 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Cooperative tile reduction within CTAs
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/srts_grid.cuh>
+#include <b40c/util/reduction/serial_reduce.cuh>
+#include <b40c/util/reduction/warp_reduce.cuh>
+
+namespace b40c {
+namespace util {
+namespace reduction {
+
+
+/**
+ * Cooperative reduction in raking smem grid hierarchies
+ */
+template <
+	typename RakingDetails,
+	typename SecondaryRakingDetails = typename RakingDetails::SecondaryRakingDetails>
+struct CooperativeGridReduction;
+
+
+/**
+ * Cooperative tile reduction
+ */
+template <int VEC_SIZE>
+struct CooperativeTileReduction
+{
+	//---------------------------------------------------------------------
+	// Iteration structures for reducing tile vectors into their
+	// corresponding raking lanes
+	//---------------------------------------------------------------------
+
+	// Next lane/load
+	template <int LANE, int TOTAL_LANES>
+	struct ReduceLane
+	{
+		template <typename RakingDetails, typename ReductionOp>
+		static __device__ __forceinline__ void Invoke(
+			RakingDetails raking_details,
+			typename RakingDetails::T data[RakingDetails::SCAN_LANES][VEC_SIZE],
+			ReductionOp reduction_op)
+		{
+			// Reduce the partials in this lane/load
+			typename RakingDetails::T partial_reduction = SerialReduce<VEC_SIZE>::Invoke(
+				data[LANE], reduction_op);
+
+			// Store partial reduction into raking grid
+			raking_details.lane_partial[LANE][0] = partial_reduction;
+
+			// Next load
+			ReduceLane<LANE + 1, TOTAL_LANES>::Invoke(
+				raking_details, data, reduction_op);
+		}
+	};
+
+
+	// Terminate
+	template <int TOTAL_LANES>
+	struct ReduceLane<TOTAL_LANES, TOTAL_LANES>
+	{
+		template <typename RakingDetails, typename ReductionOp>
+		static __device__ __forceinline__ void Invoke(
+			RakingDetails raking_details,
+			typename RakingDetails::T data[RakingDetails::SCAN_LANES][VEC_SIZE],
+			ReductionOp reduction_op) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Reduce a single tile.  Carry is computed (or updated if REDUCE_INTO_CARRY is set)
+	 * only in last raking thread
+	 *
+	 * Caution: Post-synchronization is needed before grid reuse.
+	 */
+	template <
+		bool REDUCE_INTO_CARRY, 				// Whether or not to assign carry or reduce into it
+		typename RakingDetails,
+		typename ReductionOp>
+	static __device__ __forceinline__ void ReduceTileWithCarry(
+		RakingDetails raking_details,
+		typename RakingDetails::T data[RakingDetails::SCAN_LANES][VEC_SIZE],
+		typename RakingDetails::T &carry,
+		ReductionOp reduction_op)
+	{
+		// Reduce partials in each vector-load, placing resulting partials in raking smem grid lanes (one lane per load)
+		ReduceLane<0, RakingDetails::SCAN_LANES>::Invoke(raking_details, data, reduction_op);
+
+		__syncthreads();
+
+		CooperativeGridReduction<RakingDetails>::template ReduceTileWithCarry<REDUCE_INTO_CARRY>(
+			raking_details, carry, reduction_op);
+	}
+
+	/**
+	 * Reduce a single tile.  Result is computed and returned in all threads.
+	 *
+	 * No post-synchronization needed before grid reuse.
+	 */
+	template <typename RakingDetails, typename ReductionOp>
+	static __device__ __forceinline__ typename RakingDetails::T ReduceTile(
+		RakingDetails raking_details,
+		typename RakingDetails::T data[RakingDetails::SCAN_LANES][VEC_SIZE],
+		ReductionOp reduction_op)
+	{
+		// Reduce partials in each vector-load, placing resulting partials in raking smem grid lanes (one lane per load)
+		ReduceLane<0, RakingDetails::SCAN_LANES>::Invoke(raking_details, data, reduction_op);
+
+		__syncthreads();
+
+		return CooperativeGridReduction<RakingDetails>::ReduceTile(
+			raking_details, reduction_op);
+	}
+};
+
+
+
+
+/******************************************************************************
+ * CooperativeGridReduction
+ ******************************************************************************/
+
+/**
+ * Cooperative raking grid reduction (specialized for last-level of raking grid)
+ */
+template <typename RakingDetails>
+struct CooperativeGridReduction<RakingDetails, NullType>
+{
+	typedef typename RakingDetails::T T;
+
+	/**
+	 * Reduction in last-level raking grid.  Carry is assigned (or reduced into
+	 * if REDUCE_INTO_CARRY is set), but only in last raking thread
+	 */
+	template <
+		bool REDUCE_INTO_CARRY,
+		typename ReductionOp>
+	static __device__ __forceinline__ void ReduceTileWithCarry(
+		RakingDetails raking_details,
+		T &carry,
+		ReductionOp reduction_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T partial = SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, reduction_op);
+
+			// Warp reduction
+			T warpscan_total = WarpReduce<RakingDetails::LOG_RAKING_THREADS>::InvokeSingle(
+				partial, raking_details.warpscan, reduction_op);
+
+			carry = (REDUCE_INTO_CARRY) ?
+				reduction_op(carry, warpscan_total) : 	// Reduce into carry
+				warpscan_total;							// Assign carry
+		}
+	}
+
+
+	/**
+	 * Reduction in last-level raking grid.  Result is computed in all threads.
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ T ReduceTile(
+		RakingDetails raking_details,
+		ReductionOp reduction_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T partial = SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, reduction_op);
+
+			// Warp reduction
+			WarpReduce<RakingDetails::LOG_RAKING_THREADS>::InvokeSingle(
+				partial, raking_details.warpscan, reduction_op);
+		}
+
+		__syncthreads();
+
+		// Return last thread's inclusive partial
+		return raking_details.CumulativePartial();
+	}
+};
+
+
+/**
+ * Cooperative raking grid reduction for multi-level raking grids
+ */
+template <typename RakingDetails, typename SecondaryRakingDetails>
+struct CooperativeGridReduction
+{
+	typedef typename RakingDetails::T T;
+
+	/**
+	 * Reduction in raking grid.  Carry-in/out is updated only in raking threads (homogeneously)
+	 */
+	template <bool REDUCE_INTO_CARRY, typename ReductionOp>
+	static __device__ __forceinline__ void ReduceTileWithCarry(
+		RakingDetails raking_details,
+		T &carry,
+		ReductionOp reduction_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T partial = SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, reduction_op);
+
+			// Place partial in next grid
+			raking_details.secondary_details.lane_partial[0][0] = partial;
+		}
+
+		__syncthreads();
+
+		// Collectively reduce in next grid
+		CooperativeGridReduction<SecondaryRakingDetails>::template ReduceTileWithCarry<REDUCE_INTO_CARRY>(
+			raking_details.secondary_details, carry, reduction_op);
+	}
+
+
+	/**
+	 * Reduction in raking grid.  Result is computed in all threads.
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ T ReduceTile(
+		RakingDetails raking_details,
+		ReductionOp reduction_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T partial = SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, reduction_op);
+
+			// Place partial in next grid
+			raking_details.secondary_details.lane_partial[0][0] = partial;
+		}
+
+		__syncthreads();
+
+		// Collectively reduce in next grid
+		return CooperativeGridReduction<SecondaryRakingDetails>::ReduceTile(
+			raking_details.secondary_details, reduction_op);
+	}
+};
+
+
+
+} // namespace reduction
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/reduction/serial_reduce.cuh
+++ b/include/b40c/util/reduction/serial_reduce.cuh
@@ -1,0 +1,152 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Serial reduction over array types
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/operators.cuh>
+
+namespace b40c {
+namespace util {
+namespace reduction {
+
+/**
+ * Have each thread perform a serial reduction over its specified segment
+ */
+template <int NUM_ELEMENTS>
+struct SerialReduce
+{
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	// Iterate
+	template <int COUNT, int TOTAL>
+	struct Iterate
+	{
+		template <typename T, typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(T *partials, ReductionOp reduction_op)
+		{
+			T a = Iterate<COUNT - 2, TOTAL>::Invoke(partials, reduction_op);
+			T b = partials[TOTAL - COUNT];
+			T c = partials[TOTAL - (COUNT - 1)];
+
+			// TODO: consider specializing with a video 3-op instructions on SM2.0+,
+			// e.g., asm("vadd.s32.s32.s32.add %0, %1, %2, %3;" : "=r"(a) : "r"(a), "r"(b), "r"(c));
+			return reduction_op(a, reduction_op(b, c));
+		}
+	};
+
+	// Terminate
+	template <int TOTAL>
+	struct Iterate<2, TOTAL>
+	{
+		template <typename T, typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(T *partials, ReductionOp reduction_op)
+		{
+			return reduction_op(partials[TOTAL - 2], partials[TOTAL - 1]);
+		}
+	};
+
+	// Terminate
+	template <int TOTAL>
+	struct Iterate<1, TOTAL>
+	{
+		template <typename T, typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(T *partials, ReductionOp reduction_op)
+		{
+			return partials[TOTAL - 1];
+		}
+	};
+	
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Serial reduction with the specified operator
+	 */
+	template <typename T, typename ReductionOp>
+	static __device__ __forceinline__ T Invoke(
+		T *partials,
+		ReductionOp reduction_op)
+	{
+		return Iterate<NUM_ELEMENTS, NUM_ELEMENTS>::Invoke(partials, reduction_op);
+	}
+
+
+	/**
+	 * Serial reduction with the addition operator
+	 */
+	template <typename T>
+	static __device__ __forceinline__ T Invoke(
+		T *partials)
+	{
+		Sum<T> reduction_op;
+		return Invoke(partials, reduction_op);
+	}
+
+
+	/**
+	 * Serial reduction with the specified operator, seeded with the
+	 * given exclusive partial
+	 */
+	template <typename T, typename ReductionOp>
+	static __device__ __forceinline__ T Invoke(
+		T *partials,
+		T exclusive_partial,
+		ReductionOp reduction_op)
+	{
+		return reduction_op(
+			exclusive_partial,
+			Invoke(partials, reduction_op));
+	}
+
+	/**
+	 * Serial reduction with the addition operator, seeded with the
+	 * given exclusive partial
+	 */
+	template <typename T, typename ReductionOp>
+	static __device__ __forceinline__ T Invoke(
+		T *partials,
+		T exclusive_partial)
+	{
+		Sum<T> reduction_op;
+		 return Invoke(partials, exclusive_partial, reduction_op);
+	}
+};
+
+
+} // namespace reduction
+} // namespace util
+} // namespace b40c
+
+

--- a/include/b40c/util/reduction/soa/cooperative_soa_reduction.cuh
+++ b/include/b40c/util/reduction/soa/cooperative_soa_reduction.cuh
@@ -1,0 +1,256 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+/******************************************************************************
+ * Cooperative tile SOA (structure-of-arrays) reduction within CTAs
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/srts_grid.cuh>
+#include <b40c/util/reduction/soa/serial_soa_reduce.cuh>
+#include <b40c/util/reduction/soa/warp_soa_reduce.cuh>
+#include <b40c/util/scan/soa/warp_soa_scan.cuh>
+
+namespace b40c {
+namespace util {
+namespace reduction {
+namespace soa {
+
+
+/**
+ * Cooperative SOA reduction in raking smem grid hierarchies
+ */
+template <
+	typename RakingSoaDetails,
+	typename SecondaryRakingSoaDetails = typename RakingSoaDetails::SecondaryRakingSoaDetails>
+struct CooperativeSoaGridReduction;
+
+
+/**
+ * Cooperative SOA tile reduction
+ */
+template <int VEC_SIZE>
+struct CooperativeSoaTileReduction
+{
+	//---------------------------------------------------------------------
+	// Iteration structures for reducing tile SOA vectors into their
+	// corresponding raking lanes
+	//---------------------------------------------------------------------
+
+	// Next lane/load
+	template <int LANE, int TOTAL_LANES>
+	struct ReduceLane
+	{
+		template <
+			typename RakingSoaDetails,
+			typename TileSoa,
+			typename ReductionOp>
+		static __device__ __forceinline__ void Invoke(
+			RakingSoaDetails raking_soa_details,
+			TileSoa tile_soa,
+			ReductionOp reduction_op)
+		{
+			// Reduce the partials in this lane/load
+			typename RakingSoaDetails::TileTuple partial_reduction;
+			SerialSoaReduce<VEC_SIZE>::Reduce(
+				partial_reduction, tile_soa, LANE, reduction_op);
+
+			// Store partial reduction into raking grid
+			raking_soa_details.lane_partials.Set(partial_reduction, LANE, 0);
+
+			// Next load
+			ReduceLane<LANE + 1, TOTAL_LANES>::Invoke(
+				raking_soa_details, tile_soa, reduction_op);
+		}
+	};
+
+	// Terminate
+	template <int TOTAL_LANES>
+	struct ReduceLane<TOTAL_LANES, TOTAL_LANES>
+	{
+		template <
+			typename RakingSoaDetails,
+			typename TileSoa,
+			typename ReductionOp>
+		static __device__ __forceinline__ void Invoke(
+			RakingSoaDetails raking_soa_details,
+			TileSoa tile_soa,
+			ReductionOp reduction_op) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Reduce a single tile.  Carry is computed (or updated if REDUCE_INTO_CARRY is set)
+	 * only in last raking thread
+	 *
+	 * Caution: Post-synchronization is needed before grid reuse.
+	 */
+	template <
+		bool REDUCE_INTO_CARRY,
+		typename RakingSoaDetails,
+		typename TileSoa,
+		typename TileTuple,
+		typename ReductionOp>
+	static __device__ __forceinline__ void ReduceTileWithCarry(
+		RakingSoaDetails raking_soa_details,
+		TileSoa tile_soa,
+		TileTuple &carry,
+		ReductionOp reduction_op)
+	{
+		// Reduce vectors in tile, placing resulting partial into corresponding raking grid lanes
+		ReduceLane<0, RakingSoaDetails::SCAN_LANES>::Invoke(
+			raking_soa_details, tile_soa, reduction_op);
+
+		__syncthreads();
+
+		CooperativeSoaGridReduction<RakingSoaDetails>::template ReduceTileWithCarry<REDUCE_INTO_CARRY>(
+			raking_soa_details, carry, reduction_op);
+	}
+
+	/**
+	 * Reduce a single tile.  Result is computed and returned in all threads.
+	 *
+	 * No post-synchronization needed before raking_details reuse.
+	 */
+	template <
+		typename TileTuple,
+		typename RakingSoaDetails,
+		typename TileSoa,
+		typename ReductionOp>
+	static __device__ __forceinline__ void ReduceTile(
+		TileTuple &retval,
+		RakingSoaDetails raking_soa_details,
+		TileSoa tile_soa,
+		ReductionOp reduction_op)
+	{
+		// Reduce vectors in tile, placing resulting partial into corresponding raking grid lanes
+		ReduceLane<0, RakingSoaDetails::SCAN_LANES>::Invoke(
+			raking_soa_details, tile_soa, reduction_op);
+
+		__syncthreads();
+
+		return CooperativeSoaGridReduction<RakingSoaDetails>::ReduceTile(
+			raking_soa_details, reduction_op);
+	}
+};
+
+
+
+
+/******************************************************************************
+ * CooperativeSoaGridReduction
+ ******************************************************************************/
+
+/**
+ * Cooperative SOA raking grid reduction (specialized for last-level of raking grid)
+ */
+template <typename RakingSoaDetails>
+struct CooperativeSoaGridReduction<RakingSoaDetails, NullType>
+{
+	typedef typename RakingSoaDetails::TileTuple TileTuple;
+
+	/**
+	 * Reduction in last-level raking grid.  Carry is assigned (or reduced into
+	 * if REDUCE_INTO_CARRY is set), but only in last raking thread
+	 */
+	template <
+		bool REDUCE_INTO_CARRY,
+		typename ReductionOp>
+	static __device__ __forceinline__ void ReduceTileWithCarry(
+		RakingSoaDetails raking_soa_details,
+		TileTuple &carry,
+		ReductionOp reduction_op)
+	{
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			TileTuple inclusive_partial;
+			SerialSoaReduce<RakingSoaDetails::PARTIALS_PER_SEG>::Reduce(
+				inclusive_partial,
+				raking_soa_details.raking_segments,
+				reduction_op);
+
+			// Inclusive warp scan that sets warpscan total in all
+			// Raking threads. (Use warp scan instead of warp reduction
+			// because the latter supports non-commutative reduction
+			// operators)
+			TileTuple warpscan_total;
+			scan::soa::WarpSoaScan<
+				RakingSoaDetails::LOG_RAKING_THREADS,
+				false>::Scan(
+					inclusive_partial,
+					warpscan_total,
+					raking_soa_details.warpscan_partials,
+					reduction_op);
+
+			// Update/set carry
+			carry = (REDUCE_INTO_CARRY) ?
+				reduction_op(carry, warpscan_total) :
+				warpscan_total;
+		}
+	}
+
+
+	/**
+	 * Reduction in last-level raking grid.  Result is computed in all threads.
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ TileTuple ReduceTile(
+		RakingSoaDetails raking_soa_details,
+		ReductionOp reduction_op)
+	{
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			TileTuple inclusive_partial = SerialSoaReduce<RakingSoaDetails::PARTIALS_PER_SEG>::Reduce(
+				raking_soa_details.raking_segments, reduction_op);
+
+			// Warp reduction
+			TileTuple warpscan_total = WarpSoaReduce<RakingSoaDetails::LOG_RAKING_THREADS>::ReduceInLast(
+				inclusive_partial,
+				raking_soa_details.warpscan_partials,
+				reduction_op);
+		}
+
+		__syncthreads();
+
+		// Return last thread's inclusive partial
+		return raking_soa_details.CumulativePartial();
+	}
+};
+
+
+} // namespace soa
+} // namespace reduction
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/reduction/soa/serial_soa_reduce.cuh
+++ b/include/b40c/util/reduction/soa/serial_soa_reduce.cuh
@@ -1,0 +1,224 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Serial tuple reduction over structure-of-array types.
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/soa_tuple.cuh>
+
+namespace b40c {
+namespace util {
+namespace reduction {
+namespace soa {
+
+
+/**
+ * Have each thread perform a serial reduction over its specified SOA segment
+ */
+template <int NUM_ELEMENTS>					// Length of SOA array segment to reduce
+struct SerialSoaReduce
+{
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	// Next SOA tuple
+	template <int COUNT, int TOTAL>
+	struct Iterate
+	{
+		// Reduce
+		template <
+			typename Tuple,
+			typename RakingSoa,
+			typename ReductionOp>
+		static __host__ __device__ __forceinline__ Tuple Reduce(
+			RakingSoa raking_partials,
+			Tuple exclusive_partial,
+			ReductionOp reduction_op)
+		{
+			// Load current partial
+			Tuple current_partial;
+			raking_partials.Get(current_partial, COUNT);
+
+			// Compute inclusive partial from exclusive and current partials
+			Tuple inclusive_partial = reduction_op(exclusive_partial, current_partial);
+
+			// Recurse
+			return Iterate<COUNT + 1, TOTAL>::Reduce(
+				raking_partials, inclusive_partial, reduction_op);
+		}
+
+		// Reduce 2D
+		template <
+			typename Tuple,
+			typename RakingSoa,
+			typename ReductionOp>
+		static __host__ __device__ __forceinline__ Tuple Reduce(
+			RakingSoa raking_partials,
+			Tuple exclusive_partial,
+			int row,
+			ReductionOp reduction_op)
+		{
+			// Load current partial
+			Tuple current_partial;
+			raking_partials.Get(current_partial, row, COUNT);
+
+			// Compute inclusive partial from exclusive and current partials
+			Tuple inclusive_partial = reduction_op(exclusive_partial, current_partial);
+
+			// Recurse
+			return Iterate<COUNT + 1, TOTAL>::Reduce(
+				raking_partials, inclusive_partial, row, reduction_op);
+		}
+	};
+
+	// Terminate
+	template <int TOTAL>
+	struct Iterate<TOTAL, TOTAL>
+	{
+		// Reduce
+		template <
+			typename Tuple,
+			typename RakingSoa,
+			typename ReductionOp>
+		static __host__ __device__ __forceinline__ Tuple Reduce(
+			RakingSoa raking_partials,
+			Tuple exclusive_partial,
+			ReductionOp reduction_op)
+		{
+			return exclusive_partial;
+		}
+
+		// Reduce 2D
+		template <
+			typename Tuple,
+			typename RakingSoa,
+			typename ReductionOp>
+		static __host__ __device__ __forceinline__ Tuple Reduce(
+			RakingSoa raking_partials,
+			Tuple exclusive_partial,
+			int row,
+			ReductionOp reduction_op)
+		{
+			return exclusive_partial;
+		}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Reduce a structure-of-array RakingSoa into a single Tuple "slice"
+	 */
+	template <
+		typename Tuple,
+		typename RakingSoa,
+		typename ReductionOp>
+	static __host__ __device__ __forceinline__ void Reduce(
+		Tuple &retval,
+		RakingSoa raking_partials,
+		ReductionOp reduction_op)
+	{
+		// Get first partial
+		Tuple current_partial;
+		raking_partials.Get(current_partial, 0);
+
+		retval = Iterate<1, NUM_ELEMENTS>::Reduce(
+			raking_partials, current_partial, reduction_op);
+	}
+
+	/**
+	 * Reduce a structure-of-array RakingSoa into a single Tuple "slice", seeded
+	 * with exclusive_partial
+	 */
+	template <
+		typename Tuple,
+		typename RakingSoa,
+		typename ReductionOp>
+	static __host__ __device__ __forceinline__ Tuple SeedReduce(
+		RakingSoa raking_partials,
+		Tuple exclusive_partial,
+		ReductionOp reduction_op)
+	{
+		return Iterate<0, NUM_ELEMENTS>::Reduce(
+			raking_partials, exclusive_partial, reduction_op);
+	}
+
+
+	/**
+	 * Reduce one row of a 2D structure-of-array RakingSoa into a single Tuple "slice"
+	 */
+	template <
+		typename Tuple,
+		typename RakingSoa,
+		typename ReductionOp>
+	static __host__ __device__ __forceinline__ void Reduce(
+		Tuple &retval,
+		RakingSoa raking_partials,
+		int row,
+		ReductionOp reduction_op)
+	{
+		// Get first partial
+		Tuple current_partial;
+		raking_partials.Get(current_partial, row, 0);
+
+		retval = Iterate<1, NUM_ELEMENTS>::Reduce(
+			raking_partials, current_partial, row, reduction_op);
+	}
+
+
+	/**
+	 * Reduce one row of a 2D structure-of-array RakingSoa into a single Tuple "slice", seeded
+	 * with exclusive_partial
+	 */
+	template <
+		typename Tuple,
+		typename RakingSoa,
+		typename ReductionOp>
+	static __host__ __device__ __forceinline__ Tuple SeedReduce(
+		RakingSoa raking_partials,
+		Tuple exclusive_partial,
+		int row,
+		ReductionOp reduction_op)
+	{
+		return Iterate<0, NUM_ELEMENTS>::Reduce(
+			raking_partials, exclusive_partial, row, reduction_op);
+	}
+};
+
+
+} // namespace soa
+} // namespace reduction
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/reduction/soa/warp_soa_reduce.cuh
+++ b/include/b40c/util/reduction/soa/warp_soa_reduce.cuh
@@ -1,0 +1,179 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Cooperative tuple warp-reduction
+ *
+ * Does not support non-commutative operators.  (Suggested to use a warpscan
+ * instead for those scenarios)
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/soa_tuple.cuh>
+
+namespace b40c {
+namespace util {
+namespace reduction {
+namespace soa {
+
+/**
+ * Perform NUM_ELEMENTS of warp-synchronous reduction.
+ *
+ * This procedure assumes that no explicit barrier synchronization is needed
+ * between steps (i.e., warp-synchronous programming)
+ *
+ * Can be used to perform concurrent, independent warp-reductions if
+ * storage pointers and their local-thread indexing id's are set up properly.
+ *
+ * The type WarpscanSoa is a 2D structure-of-array of smem storage, each SOA array having
+ * dimensions [2][NUM_ELEMENTS].
+ */
+template <int LOG_NUM_ELEMENTS>				// Log of number of elements to warp-reduce
+struct WarpSoaReduce
+{
+	enum {
+		NUM_ELEMENTS = 1 << LOG_NUM_ELEMENTS,
+	};
+
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	// Iteration
+	template <int OFFSET_LEFT, int __dummy = 0>
+	struct Iterate
+	{
+		// Reduce
+		template <
+			typename Tuple,
+			typename WarpscanSoa,
+			typename ReductionOp>
+		static __device__ __forceinline__ Tuple Reduce(
+			Tuple exclusive_partial,
+			WarpscanSoa warpscan_partials,
+			ReductionOp reduction_op,
+			int warpscan_tid)
+		{
+			// Store exclusive partial
+			warpscan_partials.Set(exclusive_partial, 1, warpscan_tid);
+
+			if (!WarpscanSoa::VOLATILE) __threadfence_block();
+
+			// Load current partial
+			Tuple current_partial;
+			warpscan_partials.Get(current_partial, 1, warpscan_tid - OFFSET_LEFT);
+
+			if (!WarpscanSoa::VOLATILE) __threadfence_block();
+
+			// Compute inclusive partial from exclusive and current partials
+			Tuple inclusive_partial = reduction_op(current_partial, exclusive_partial);
+
+			// Recurse
+			return Iterate<OFFSET_LEFT / 2>::Reduce(
+				inclusive_partial, warpscan_partials, reduction_op, warpscan_tid);
+		}
+	};
+
+	// Termination
+	template <int __dummy>
+	struct Iterate<0, __dummy>
+	{
+		// Reduce
+		template <
+			typename Tuple,
+			typename WarpscanSoa,
+			typename ReductionOp>
+		static __device__ __forceinline__ Tuple Reduce(
+			Tuple exclusive_partial,
+			WarpscanSoa warpscan_partials,
+			ReductionOp reduction_op,
+			int warpscan_tid)
+		{
+			return exclusive_partial;
+		}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Warp-reduction.  Result is returned in all warpscan threads.
+	 */
+	template <
+		typename Tuple,
+		typename WarpscanSoa,
+		typename ReductionOp>
+	static __device__ __forceinline__ Tuple Reduce(
+		Tuple current_partial,					// Input partial
+		WarpscanSoa warpscan_partials,			// Smem for warpscanning containing at least two segments of size NUM_ELEMENTS
+		ReductionOp reduction_op,
+		int warpscan_tid = threadIdx.x)			// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		Tuple inclusive_partial = Iterate<NUM_ELEMENTS / 2>::Reduce(
+			current_partial, warpscan_partials, reduction_op, warpscan_tid);
+
+		// Write our inclusive partial
+		warpscan_partials.Set(inclusive_partial, 1, warpscan_tid);
+
+		if (!WarpscanSoa::VOLATILE) __threadfence_block();
+
+		// Return last thread's inclusive partial
+		Tuple retval;
+		return warpscan_partials.Get(retval, 1, NUM_ELEMENTS - 1);
+	}
+
+
+	/**
+	 * Warp-reduction.  Result is returned in last warpscan thread.
+	 */
+	template <
+		typename Tuple,
+		typename WarpscanSoa,
+		typename ReductionOp>
+	static __device__ __forceinline__ Tuple ReduceInLast(
+		Tuple exclusive_partial,				// Input partial
+		WarpscanSoa warpscan_partials,			// Smem for warpscanning containing at least two segments of size NUM_ELEMENTS
+		ReductionOp reduction_op,
+		int warpscan_tid = threadIdx.x)			// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		return Iterate<NUM_ELEMENTS / 2>::Reduce(
+			exclusive_partial, warpscan_partials, reduction_op, warpscan_tid);
+	}
+
+};
+
+
+
+} // namespace soa
+} // namespace reduction
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/reduction/tree_reduce.cuh
+++ b/include/b40c/util/reduction/tree_reduce.cuh
@@ -1,0 +1,310 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Tree reduction
+ *
+ * Does not support non-commutative operators.  (Suggested to use a scan
+ * instead for those scenarios
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/util/operators.cuh>
+
+namespace b40c {
+namespace util {
+namespace reduction {
+
+
+/**
+ * Perform LOG_CTA_THREADS steps of binary tree reduction, each thread
+ * contributes one reduction partial.
+ */
+template <
+	int LOG_CTA_THREADS,
+	bool ALL_RETURN>				// If true, everyone returns the result.  If false, only thread-0.
+struct TreeReduce
+{
+	static const int CTA_THREADS = 1 << LOG_CTA_THREADS;
+
+	//---------------------------------------------------------------------
+	// Helper Structures
+	//---------------------------------------------------------------------
+
+	// General iteration
+	template <
+		int OFFSET_RIGHT,
+		bool WAS_WARPSCAN,
+		bool IS_WARPSCAN = (OFFSET_RIGHT <= B40C_WARP_THREADS(__B40C_CUDA_ARCH__))>
+	struct Iterate
+	{
+		template <
+			bool ALL_VALID,
+			typename T,
+			typename TreeT,
+			typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(
+			T my_partial,
+			TreeT reduction_tree[CTA_THREADS],
+			int num_elements,
+			ReductionOp reduction_op)
+		{
+			// Store partial
+			reduction_tree[threadIdx.x] = my_partial;
+
+			__syncthreads();
+
+			if ((ALL_VALID || (threadIdx.x + OFFSET_RIGHT < num_elements)) && (threadIdx.x < OFFSET_RIGHT)) {
+				// Update my partial
+				T current_partial = reduction_tree[threadIdx.x + OFFSET_RIGHT];
+				my_partial = reduction_op(my_partial, current_partial);
+			}
+
+			// Recurse
+			return Iterate<OFFSET_RIGHT / 2, WAS_WARPSCAN>::template Invoke<ALL_VALID>(
+				my_partial, reduction_tree, num_elements, reduction_op);
+		}
+	};
+
+	// Transition into warpscan iteration
+	template <int OFFSET_RIGHT>
+	struct Iterate<OFFSET_RIGHT, false, true>
+	{
+		template <
+			bool ALL_VALID,
+			typename T,
+			typename TreeT,
+			typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(
+			T my_partial,
+			TreeT reduction_tree[CTA_THREADS],
+			int num_elements,
+			ReductionOp reduction_op)
+		{
+			// Store partial
+			reduction_tree[threadIdx.x] = my_partial;
+
+			__syncthreads();
+
+			if (threadIdx.x < OFFSET_RIGHT) {
+
+				if (ALL_VALID || (threadIdx.x + OFFSET_RIGHT < num_elements)) {
+
+					// Update my partial
+					T current_partial = reduction_tree[threadIdx.x + OFFSET_RIGHT];
+
+					if (!IsVolatile<TreeT>::VALUE) __threadfence_block();
+
+					my_partial = reduction_op(my_partial, current_partial);
+
+				}
+
+				// Recurse in warpscan mode
+				my_partial = Iterate<OFFSET_RIGHT / 2, true>::template Invoke<ALL_VALID>(
+						my_partial, reduction_tree, num_elements, reduction_op);
+			}
+
+			return my_partial;
+		}
+	};
+
+	// Warpscan iteration
+	template <int OFFSET_RIGHT, bool WAS_WARPSCAN>
+	struct Iterate<OFFSET_RIGHT, WAS_WARPSCAN, true>
+	{
+		template <
+			bool ALL_VALID,
+			typename T,
+			typename TreeT,
+			typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(
+			T my_partial,
+			TreeT reduction_tree[CTA_THREADS],
+			int num_elements,
+			ReductionOp reduction_op)
+		{
+			// Store partial
+			reduction_tree[threadIdx.x] = my_partial;
+
+			if (!IsVolatile<TreeT>::VALUE) __threadfence_block();
+
+			if (ALL_VALID || (threadIdx.x + OFFSET_RIGHT < num_elements)) {
+
+				// Update my partial
+				T current_partial = reduction_tree[threadIdx.x + OFFSET_RIGHT];
+
+				if (!IsVolatile<TreeT>::VALUE) __threadfence_block();
+
+				my_partial = reduction_op(my_partial, current_partial);
+			}
+
+			// Recurse in warpscan mode
+			return Iterate<OFFSET_RIGHT / 2, true>::template Invoke<ALL_VALID>(
+					my_partial, reduction_tree, num_elements, reduction_op);
+
+		}
+	};
+
+	// Termination
+	template <bool WAS_WARPSCAN>
+	struct Iterate<0, WAS_WARPSCAN, true>
+	{
+		template <
+			bool ALL_VALID,
+			typename T,
+			typename TreeT,
+			typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(
+			T my_partial,
+			TreeT reduction_tree[CTA_THREADS],
+			int num_elements,
+			ReductionOp reduction_op)
+		{
+			if (ALL_RETURN) {
+				reduction_tree[threadIdx.x] = my_partial;
+
+				if (!IsVolatile<TreeT>::VALUE) __threadfence_block();
+			}
+			return my_partial;
+		}
+	};
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Perform a cooperative tree reduction.  Threads with ranks less than
+	 * num_elements contribute one reduction partial.
+	 */
+	template <
+		typename T,
+		typename TreeT,
+		typename ReductionOp>
+	static __device__ __forceinline__ T Invoke(
+		T my_partial,									// Input partial
+		TreeT reduction_tree[CTA_THREADS],			// Shared memory for tree scan
+		int num_elements,								// Number of valid elements to actually reduce (may be less than number of cta-threads)
+		ReductionOp reduction_op)						// Reduction operator
+
+	{
+		my_partial = Iterate<CTA_THREADS / 2, false>::template Invoke<false>(
+			my_partial,
+			reduction_tree,
+			num_elements,
+			reduction_op);
+
+		if (ALL_RETURN) {
+
+			// Return first thread's my partial
+			__syncthreads();
+			return reduction_tree[0];
+
+		} else {
+
+			return my_partial;
+		}
+	}
+
+
+	/**
+	 * Perform a cooperative tree reduction.  Each thread contributes one
+	 * reduction partial.
+	 *
+	 * Assumes all threads contribute a valid element (no checks on num_elements)
+	 */
+	template <
+		typename T,
+		typename TreeT,
+		typename ReductionOp>
+	static __device__ __forceinline__ T Invoke(
+		T my_partial,								// Input partial
+		TreeT reduction_tree[CTA_THREADS],		// Shared memory for tree scan
+		ReductionOp reduction_op)					// Reduction operator
+	{
+		my_partial = Iterate<CTA_THREADS / 2, false>::template Invoke<true>(
+			my_partial,
+			reduction_tree,
+			0,
+			reduction_op);
+
+		if (ALL_RETURN) {
+
+			// Return first thread's my partial
+			__syncthreads();
+			return reduction_tree[0];
+
+		} else {
+
+			return my_partial;
+		}
+	}
+
+
+	/**
+	 * Perform a cooperative tree reduction using the addition operator.
+	 * Threads with ranks less than num_elements contribute one reduction partial.
+	 */
+	template <
+		typename T,
+		typename TreeT>
+	static __device__ __forceinline__ T Invoke(
+		T my_partial,									// Input partial
+		TreeT reduction_tree[CTA_THREADS],			// Shared memory for tree scan
+		int num_elements)								// Number of valid elements to actually reduce (may be less than number of cta-threads)
+	{
+		Sum<T> reduction_op;
+		return Invoke(my_partial, reduction_tree, num_elements);
+	}
+
+
+	/**
+	 * Perform a cooperative tree reduction using the addition operator.
+	 * Each thread contributes one reduction partial.
+	 *
+	 * Assumes all threads contribute a valid element (no checks on num_elements)
+	 */
+	template <
+		typename T,
+		typename TreeT>
+	static __device__ __forceinline__ T Invoke(
+		T my_partial,								// Input partial
+		TreeT reduction_tree[CTA_THREADS])		// Shared memory for tree scan
+	{
+		Sum<T> reduction_op;
+		return Invoke(my_partial, reduction_tree, reduction_op);
+	}
+};
+
+
+} // namespace reduction
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/reduction/warp_reduce.cuh
+++ b/include/b40c/util/reduction/warp_reduce.cuh
@@ -1,0 +1,186 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Cooperative warp-reduction
+ *
+ * Does not support non-commutative operators.  (Suggested to use a warpscan
+ * instead for those scenarios
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/util/operators.cuh>
+
+namespace b40c {
+namespace util {
+namespace reduction {
+
+
+/**
+ * Perform NUM_ELEMENTS of warp-synchronous reduction.
+ *
+ * Can be used to perform concurrent, independent warp-reductions if
+ * storage pointers and their local-thread indexing id's are set up properly.
+ *
+ * Requires a 2D "warpscan" structure of smem storage having dimensions [2][NUM_ELEMENTS].
+ */
+template <int LOG_NUM_ELEMENTS>				// Log of number of elements to warp-reduce
+struct WarpReduce
+{
+	enum {
+		NUM_ELEMENTS = 1 << LOG_NUM_ELEMENTS,
+	};
+
+
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	// Iterate
+	template <int OFFSET_LEFT, int __dummy = 0>
+	struct Iterate
+	{
+		template <typename T, typename WarpscanT, typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(
+			T exclusive_partial,
+			WarpscanT warpscan[][NUM_ELEMENTS],
+			ReductionOp reduction_op,
+			int warpscan_tid)
+		{
+			// Store exclusive partial
+			warpscan[1][warpscan_tid] = exclusive_partial;
+
+			if (!IsVolatile<WarpscanT>::VALUE) __threadfence_block();
+
+			// Load current partial
+			T current_partial = warpscan[1][warpscan_tid - OFFSET_LEFT];
+
+			if (!IsVolatile<WarpscanT>::VALUE) __threadfence_block();
+
+			// Compute inclusive partial
+			T inclusive_partial = reduction_op(exclusive_partial, current_partial);
+
+			// Recurse
+			return Iterate<OFFSET_LEFT / 2>::Invoke(
+				inclusive_partial, warpscan, reduction_op, warpscan_tid);
+		}
+	};
+	
+	// Termination
+	template <int __dummy>
+	struct Iterate<0, __dummy>
+	{
+		template <typename T, typename WarpscanT, typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(
+			T partial,
+			WarpscanT warpscan[][NUM_ELEMENTS],
+			ReductionOp reduction_op,
+			int warpscan_tid)
+		{
+			return partial;
+		}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Warp reduction with the specified operator, result is returned in last warpscan thread
+	 */
+	template <typename T, typename WarpscanT, typename ReductionOp>
+	static __device__ __forceinline__ T InvokeSingle(
+		T partial,								// Input partial
+		WarpscanT warpscan[][NUM_ELEMENTS],		// Smem for warpscanning containing at least two segments of size NUM_ELEMENTS
+		ReductionOp reduction_op,				// Reduction operator
+		int warpscan_tid = threadIdx.x)			// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		return Iterate<NUM_ELEMENTS / 2>::Invoke(
+			partial, warpscan, reduction_op, warpscan_tid);
+	}
+
+
+	/**
+	 * Warp reduction with the addition operator, result is returned in last warpscan thread
+	 */
+	template <typename T, typename WarpscanT>
+	static __device__ __forceinline__ T InvokeSingle(
+		T partial,								// Input partial
+		WarpscanT warpscan[][NUM_ELEMENTS],		// Smem for warpscanning containing at least two segments of size NUM_ELEMENTS
+		int warpscan_tid = threadIdx.x)			// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		Sum<T> reduction_op;
+		return InvokeSingle(partial, warpscan, reduction_op, warpscan_tid);
+	}
+
+
+	/**
+	 * Warp reduction with the specified operator, result is returned in all warpscan threads)
+	 */
+	template <typename T, typename WarpscanT, typename ReductionOp>
+	static __device__ __forceinline__ T Invoke(
+		T current_partial,						// Input partial
+		WarpscanT warpscan[][NUM_ELEMENTS],		// Smem for warpscanning containing at least two segments of size NUM_ELEMENTS
+		ReductionOp reduction_op,				// Reduction operator
+		int warpscan_tid = threadIdx.x)			// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		T inclusive_partial = InvokeSingle(
+			current_partial, warpscan, reduction_op, warpscan_tid);
+
+		// Write our inclusive partial
+		warpscan[1][warpscan_tid] = inclusive_partial;
+
+		if (!IsVolatile<WarpscanT>::VALUE) __threadfence_block();
+
+		// Return last thread's inclusive partial
+		return warpscan[1][NUM_ELEMENTS - 1];
+	}
+
+
+	/**
+	 * Warp reduction with the addition operator, result is returned in all warpscan threads)
+	 */
+	template <typename T, typename WarpscanT>
+	static __device__ __forceinline__ T Invoke(
+		T current_partial,						// Input partial
+		WarpscanT warpscan[][NUM_ELEMENTS],		// Smem for warpscanning containing at least two segments of size NUM_ELEMENTS
+		int warpscan_tid = threadIdx.x)			// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		Sum<T> reduction_op;
+		return Invoke(current_partial, warpscan, reduction_op, warpscan_tid);
+	}
+};
+
+
+} // namespace reduction
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/scan/cooperative_scan.cuh
+++ b/include/b40c/util/scan/cooperative_scan.cuh
@@ -1,0 +1,510 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Cooperative tile reduction and scanning within CTAs
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/device_intrinsics.cuh>
+#include <b40c/util/srts_grid.cuh>
+#include <b40c/util/reduction/cooperative_reduction.cuh>
+#include <b40c/util/scan/serial_scan.cuh>
+#include <b40c/util/scan/warp_scan.cuh>
+
+namespace b40c {
+namespace util {
+namespace scan {
+
+/**
+ * Cooperative reduction in raking smem grid hierarchies
+ */
+template <
+	typename RakingDetails,
+	typename SecondaryRakingDetails = typename RakingDetails::SecondaryRakingDetails>
+struct CooperativeGridScan;
+
+
+
+/**
+ * Cooperative tile scan
+ */
+template <
+	int VEC_SIZE,							// Length of vector-loads (e.g, vec-1, vec-2, vec-4)
+	bool EXCLUSIVE = true>					// Whether or not this is an exclusive scan
+struct CooperativeTileScan
+{
+	//---------------------------------------------------------------------
+	// Iteration structures for extracting partials from raking lanes and
+	// using them to seed scans of tile vectors
+	//---------------------------------------------------------------------
+
+	// Next lane/load
+	template <int LANE, int TOTAL_LANES>
+	struct ScanLane
+	{
+		template <typename RakingDetails, typename ReductionOp>
+		static __device__ __forceinline__ void Invoke(
+			RakingDetails raking_details,
+			typename RakingDetails::T data[RakingDetails::SCAN_LANES][VEC_SIZE],
+			ReductionOp scan_op)
+		{
+			// Retrieve partial reduction from raking grid
+			typename RakingDetails::T exclusive_partial = raking_details.lane_partial[LANE][0];
+
+			// Scan the partials in this lane/load
+			SerialScan<VEC_SIZE, EXCLUSIVE>::Invoke(
+				data[LANE], exclusive_partial, scan_op);
+
+			// Next load
+			ScanLane<LANE + 1, TOTAL_LANES>::Invoke(
+				raking_details, data, scan_op);
+		}
+	};
+
+	// Terminate
+	template <int TOTAL_LANES>
+	struct ScanLane<TOTAL_LANES, TOTAL_LANES>
+	{
+		template <typename RakingDetails, typename ReductionOp>
+		static __device__ __forceinline__ void Invoke(
+			RakingDetails raking_details,
+			typename RakingDetails::T data[RakingDetails::SCAN_LANES][VEC_SIZE],
+			ReductionOp scan_op) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Scan a single tile.  Total aggregate is computed and returned in all threads.
+	 *
+	 * No post-synchronization needed before grid reuse.
+	 */
+	template <typename RakingDetails, typename ReductionOp>
+	static __device__ __forceinline__ typename RakingDetails::T ScanTile(
+		RakingDetails raking_details,
+		typename RakingDetails::T data[RakingDetails::SCAN_LANES][VEC_SIZE],
+		ReductionOp scan_op)
+	{
+		// Reduce partials in each vector-load, placing resulting partial in raking smem grid lanes (one lane per load)
+		reduction::CooperativeTileReduction<VEC_SIZE>::template ReduceLane<0, RakingDetails::SCAN_LANES>::Invoke(
+			raking_details, data, scan_op);
+
+		__syncthreads();
+
+		CooperativeGridScan<RakingDetails>::ScanTile(
+			raking_details, scan_op);
+
+		__syncthreads();
+
+		// Scan each vector-load, seeded with the resulting partial from its raking grid lane,
+		ScanLane<0, RakingDetails::SCAN_LANES>::Invoke(
+			raking_details, data, scan_op);
+
+		// Return last thread's inclusive partial
+		return raking_details.CumulativePartial();
+	}
+
+	/**
+	 * Scan a single tile where carry is updated with the total aggregate only
+	 * in raking threads.
+	 *
+	 * No post-synchronization needed before grid reuse.
+	 */
+	template <typename RakingDetails, typename ReductionOp>
+	static __device__ __forceinline__ void ScanTileWithCarry(
+		RakingDetails raking_details,
+		typename RakingDetails::T data[RakingDetails::SCAN_LANES][VEC_SIZE],
+		typename RakingDetails::T &carry,
+		ReductionOp scan_op)
+	{
+		// Reduce partials in each vector-load, placing resulting partials in raking smem grid lanes (one lane per load)
+		reduction::CooperativeTileReduction<VEC_SIZE>::template ReduceLane<0, RakingDetails::SCAN_LANES>::Invoke(
+			raking_details, data, scan_op);
+
+		__syncthreads();
+
+		CooperativeGridScan<RakingDetails>::ScanTileWithCarry(
+			raking_details, carry, scan_op);
+
+		__syncthreads();
+
+		// Scan each vector-load, seeded with the resulting partial from its raking grid lane,
+		ScanLane<0, RakingDetails::SCAN_LANES>::Invoke(
+			raking_details, data, scan_op);
+	}
+
+
+	/**
+	 * Scan a single tile with atomic enqueue.  Returns updated queue offset.
+	 *
+	 * No post-synchronization needed before grid reuse.
+	 */
+	template <typename RakingDetails, typename ReductionOp>
+	static __device__ __forceinline__ typename RakingDetails::T ScanTileWithEnqueue(
+		RakingDetails raking_details,
+		typename RakingDetails::T data[RakingDetails::SCAN_LANES][VEC_SIZE],
+		typename RakingDetails::T* d_enqueue_counter,
+		ReductionOp scan_op)
+	{
+		// Reduce partials in each vector-load, placing resulting partial in raking smem grid lanes (one lane per load)
+		reduction::CooperativeTileReduction<VEC_SIZE>::template ReduceLane<0, RakingDetails::SCAN_LANES>::Invoke(
+			raking_details, data, scan_op);
+
+		__syncthreads();
+
+		CooperativeGridScan<RakingDetails>::ScanTileWithEnqueue(
+			raking_details, d_enqueue_counter, scan_op);
+
+		__syncthreads();
+
+		// Scan each vector-load, seeded with the resulting partial from its raking grid lane,
+		ScanLane<0, RakingDetails::SCAN_LANES>::Invoke(
+			raking_details, data, scan_op);
+
+		return scan_op(raking_details.QueueReservation(), raking_details.CumulativePartial());
+	}
+
+
+	/**
+	 * Scan a single tile with atomic enqueue.  Local aggregate is computed and
+	 * returned in all threads.  Enqueue offset is returned in all threads.
+	 *
+	 * No post-synchronization needed before grid reuse.
+	 */
+	template <typename RakingDetails, typename ReductionOp>
+	static __device__ __forceinline__ typename RakingDetails::T ScanTileWithEnqueue(
+		RakingDetails raking_details,
+		typename RakingDetails::T data[RakingDetails::SCAN_LANES][VEC_SIZE],
+		typename RakingDetails::T *d_enqueue_counter,
+		typename RakingDetails::T &enqueue_offset,
+		ReductionOp scan_op)
+	{
+		// Reduce partials in each vector-load, placing resulting partial in raking smem grid lanes (one lane per load)
+		reduction::CooperativeTileReduction<VEC_SIZE>::template ReduceLane<0, RakingDetails::SCAN_LANES>::Invoke(
+			raking_details, data, scan_op);
+
+		__syncthreads();
+
+		CooperativeGridScan<RakingDetails>::ScanTileWithEnqueue(
+			raking_details, d_enqueue_counter, enqueue_offset, scan_op);
+
+		__syncthreads();
+
+		// Scan each vector-load, seeded with the resulting partial from its raking grid lane,
+		ScanLane<0, RakingDetails::SCAN_LANES>::Invoke(
+			raking_details, data, scan_op);
+
+		// Return last thread's inclusive partial
+		return raking_details.CumulativePartial();
+	}
+};
+
+
+
+
+/******************************************************************************
+ * CooperativeGridScan
+ ******************************************************************************/
+
+/**
+ * Cooperative raking grid reduction (specialized for last-level of raking grid)
+ */
+template <typename RakingDetails>
+struct CooperativeGridScan<RakingDetails, NullType>
+{
+	typedef typename RakingDetails::T T;
+
+	/**
+	 * Scan in last-level raking grid.
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ void ScanTile(
+		RakingDetails raking_details,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T inclusive_partial = reduction::SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, scan_op);
+
+			// Exclusive warp scan
+			T exclusive_partial = WarpScan<RakingDetails::LOG_RAKING_THREADS>::Invoke(
+				inclusive_partial, raking_details.warpscan, scan_op);
+
+			// Exclusive raking scan
+			SerialScan<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, exclusive_partial, scan_op);
+
+		}
+	}
+
+
+	/**
+	 * Scan in last-level raking grid.  Carry-in/out is updated only in raking threads
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ void ScanTileWithCarry(
+		RakingDetails raking_details,
+		T &carry,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T inclusive_partial = reduction::SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, scan_op);
+
+			// Exclusive warp scan, get total
+			T warpscan_total;
+			T exclusive_partial = WarpScan<RakingDetails::LOG_RAKING_THREADS>::Invoke(
+				inclusive_partial, warpscan_total, raking_details.warpscan, scan_op);
+
+			// Seed exclusive partial with carry-in
+			exclusive_partial = scan_op(carry, exclusive_partial);
+
+			// Exclusive raking scan
+			SerialScan<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, exclusive_partial, scan_op);
+
+			// Update carry
+			carry = scan_op(carry, warpscan_total);			// Increment the CTA's running total by the full tile reduction
+		}
+	}
+
+
+	/**
+	 * Scan in last-level raking grid with atomic enqueue
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ void ScanTileWithEnqueue(
+		RakingDetails raking_details,
+		T *d_enqueue_counter,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T inclusive_partial = reduction::SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, scan_op);
+
+			// Exclusive warp scan, get total
+			T warpscan_total;
+			T exclusive_partial = WarpScan<RakingDetails::LOG_RAKING_THREADS>::Invoke(
+					inclusive_partial, warpscan_total, raking_details.warpscan, scan_op);
+
+			// Atomic-increment the global counter with the total allocation
+			T reservation_offset;
+			if (threadIdx.x == 0) {
+				reservation_offset = util::AtomicInt<T>::Add(
+					d_enqueue_counter,
+					warpscan_total);
+				raking_details.warpscan[1][0] = reservation_offset;
+			}
+
+			// Seed exclusive partial with queue reservation offset
+			reservation_offset = raking_details.warpscan[1][0];
+			exclusive_partial = scan_op(reservation_offset, exclusive_partial);
+
+			// Exclusive raking scan
+			SerialScan<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, exclusive_partial, scan_op);
+		}
+	}
+
+	/**
+	 * Scan in last-level raking grid with atomic enqueue
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ void ScanTileWithEnqueue(
+		RakingDetails raking_details,
+		T *d_enqueue_counter,
+		T &enqueue_offset,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T inclusive_partial = reduction::SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, scan_op);
+
+			// Exclusive warp scan, get total
+			T warpscan_total;
+			T exclusive_partial = WarpScan<RakingDetails::LOG_RAKING_THREADS>::Invoke(
+				inclusive_partial, warpscan_total, raking_details.warpscan, scan_op);
+
+			// Atomic-increment the global counter with the total allocation
+			if (threadIdx.x == 0) {
+				enqueue_offset = util::AtomicInt<T>::Add(
+					d_enqueue_counter,
+					warpscan_total);
+			}
+
+			// Exclusive raking scan
+			SerialScan<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, exclusive_partial, scan_op);
+		}
+	}
+};
+
+
+/**
+ * Cooperative raking grid reduction for multi-level raking grids
+ */
+template <
+	typename RakingDetails,
+	typename SecondaryRakingDetails>
+struct CooperativeGridScan
+{
+	typedef typename RakingDetails::T T;
+
+	/**
+	 * Scan in raking grid.
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ void ScanTile(
+		RakingDetails raking_details,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T partial = reduction::SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, scan_op);
+
+			// Place partial in next grid
+			raking_details.secondary_details.lane_partial[0][0] = partial;
+		}
+
+		__syncthreads();
+
+		// Collectively scan in next grid
+		CooperativeGridScan<SecondaryRakingDetails>::ScanTile(
+			raking_details.secondary_details, scan_op);
+
+		__syncthreads();
+
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Retrieve partial from next grid
+			T exclusive_partial = raking_details.secondary_details.lane_partial[0][0];
+
+			// Exclusive raking scan
+			SerialScan<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, exclusive_partial, scan_op);
+		}
+	}
+
+	/**
+	 * Scan in raking grid.  Carry-in/out is updated only in raking threads (homogeneously)
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ void ScanTileWithCarry(
+		RakingDetails raking_details,
+		T &carry,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T partial = reduction::SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, scan_op);
+
+			// Place partial in next grid
+			raking_details.secondary_details.lane_partial[0][0] = partial;
+		}
+
+		__syncthreads();
+
+		// Collectively scan in next grid
+		CooperativeGridScan<SecondaryRakingDetails>::ScanTileWithCarry(
+			raking_details.secondary_details, carry, scan_op);
+
+		__syncthreads();
+
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Retrieve partial from next grid
+			T exclusive_partial = raking_details.secondary_details.lane_partial[0][0];
+
+			// Exclusive raking scan
+			SerialScan<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, exclusive_partial, scan_op);
+		}
+	}
+
+	/**
+	 * Scan in raking grid.  Carry-in/out is updated only in raking threads (homogeneously)
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ void ScanTileWithEnqueue(
+		RakingDetails raking_details,
+		T* d_enqueue_counter,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			T partial = reduction::SerialReduce<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, scan_op);
+
+			// Place partial in next grid
+			raking_details.secondary_details.lane_partial[0][0] = partial;
+		}
+
+		__syncthreads();
+
+		// Collectively scan in next grid
+		CooperativeGridScan<SecondaryRakingDetails>::ScanTileWithEnqueue(
+			raking_details.secondary_details, d_enqueue_counter, scan_op);
+
+		__syncthreads();
+
+		if (threadIdx.x < RakingDetails::RAKING_THREADS) {
+
+			// Retrieve partial from next grid
+			T exclusive_partial = raking_details.secondary_details.lane_partial[0][0];
+
+			// Exclusive raking scan
+			SerialScan<RakingDetails::PARTIALS_PER_SEG>::Invoke(
+				raking_details.raking_segment, exclusive_partial, scan_op);
+		}
+	}
+};
+
+
+
+} // namespace scan
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/scan/serial_scan.cuh
+++ b/include/b40c/util/scan/serial_scan.cuh
@@ -1,0 +1,146 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Serial scan over array types
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/operators.cuh>
+
+namespace b40c {
+namespace util {
+namespace scan {
+
+/**
+ * Have each thread perform a serial scan over its specified segment.
+ */
+template <
+	int NUM_ELEMENTS,				// Length of array segment to scan
+	bool EXCLUSIVE = true>			// Whether or not this is an exclusive scan
+struct SerialScan
+{
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	// Iterate
+	template <int COUNT, int TOTAL>
+	struct Iterate
+	{
+		template <typename T, typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(
+			T partials[],
+			T results[],
+			T exclusive_partial,
+			ReductionOp scan_op)
+		{
+			T inclusive_partial = scan_op(partials[COUNT], exclusive_partial);
+			results[COUNT] = (EXCLUSIVE) ? exclusive_partial : inclusive_partial;
+			return Iterate<COUNT + 1, TOTAL>::Invoke(
+				partials, results, inclusive_partial, scan_op);
+		}
+	};
+
+	// Terminate
+	template <int TOTAL>
+	struct Iterate<TOTAL, TOTAL>
+	{
+		template <typename T, typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(
+			T partials[], T results[], T exclusive_partial, ReductionOp scan_op)
+		{
+			return exclusive_partial;
+		}
+	};
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Serial scan with the specified operator
+	 */
+	template <typename T, typename ReductionOp>
+	static __device__ __forceinline__ T Invoke(
+		T partials[],
+		T exclusive_partial,			// Exclusive partial to seed with
+		ReductionOp scan_op)
+	{
+		return Iterate<0, NUM_ELEMENTS>::Invoke(
+			partials, partials, exclusive_partial, scan_op);
+	}
+
+	/**
+	 * Serial scan with the addition operator
+	 */
+	template <typename T>
+	static __device__ __forceinline__ T Invoke(
+		T partials[],
+		T exclusive_partial)			// Exclusive partial to seed with
+	{
+		Sum<T> reduction_op;
+		return Invoke(partials, exclusive_partial, reduction_op);
+	}
+
+
+	/**
+	 * Serial scan with the specified operator
+	 */
+	template <typename T, typename ReductionOp>
+	static __device__ __forceinline__ T Invoke(
+		T partials[],
+		T results[],
+		T exclusive_partial,			// Exclusive partial to seed with
+		ReductionOp scan_op)
+	{
+		return Iterate<0, NUM_ELEMENTS>::Invoke(
+			partials, results, exclusive_partial, scan_op);
+	}
+
+	/**
+	 * Serial scan with the addition operator
+	 */
+	template <typename T>
+	static __device__ __forceinline__ T Invoke(
+		T partials[],
+		T results[],
+		T exclusive_partial)			// Exclusive partial to seed with
+	{
+		Sum<T> reduction_op;
+		return Invoke(partials, results, exclusive_partial, reduction_op);
+	}
+};
+
+
+
+} // namespace scan
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/scan/soa/cooperative_soa_scan.cuh
+++ b/include/b40c/util/scan/soa/cooperative_soa_scan.cuh
@@ -1,0 +1,413 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Cooperative tile SOA (structure-of-arrays) scan within CTAs
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/srts_grid.cuh>
+#include <b40c/util/reduction/soa/cooperative_soa_reduction.cuh>
+#include <b40c/util/scan/soa/serial_soa_scan.cuh>
+#include <b40c/util/scan/soa/warp_soa_scan.cuh>
+
+namespace b40c {
+namespace util {
+namespace scan {
+namespace soa {
+
+/**
+ * Cooperative SOA reduction in raking smem grid hierarchies
+ */
+template <
+	typename RakingSoaDetails,
+	typename SecondaryRakingSoaDetails = typename RakingSoaDetails::SecondaryRakingSoaDetails>
+struct CooperativeSoaGridScan;
+
+
+
+/**
+ * Cooperative SOA tile scan
+ */
+template <
+	int VEC_SIZE,							// Length of vector-loads (e.g, vec-1, vec-2, vec-4)
+	bool EXCLUSIVE = true>					// Whether or not this is an exclusive scan
+struct CooperativeSoaTileScan
+{
+	//---------------------------------------------------------------------
+	// Iteration structures for extracting partials from raking lanes and
+	// using them to seed scans of tile vectors
+	//---------------------------------------------------------------------
+
+	// Next lane/load
+	template <int LANE, int TOTAL_LANES>
+	struct ScanLane
+	{
+		template <
+			typename RakingSoaDetails,
+			typename TileSoa,
+			typename ReductionOp>
+		static __device__ __forceinline__ void Invoke(
+			RakingSoaDetails raking_soa_details,
+			TileSoa tile_soa,
+			ReductionOp scan_op)
+		{
+			// Retrieve partial reduction from raking grid
+			typename RakingSoaDetails::TileTuple exclusive_partial;
+			raking_soa_details.lane_partials.Get(exclusive_partial, LANE, 0);
+
+			// Scan the partials in this lane/load
+			SerialSoaScan<VEC_SIZE, EXCLUSIVE>::Scan(
+				tile_soa, exclusive_partial, LANE, scan_op);
+
+			// Next load
+			ScanLane<LANE + 1, TOTAL_LANES>::Invoke(
+				raking_soa_details, tile_soa, scan_op);
+		}
+	};
+
+	// Terminate
+	template <int TOTAL_LANES>
+	struct ScanLane<TOTAL_LANES, TOTAL_LANES>
+	{
+		template <
+			typename RakingSoaDetails,
+			typename TileSoa,
+			typename ReductionOp>
+		static __device__ __forceinline__ void Invoke(
+			RakingSoaDetails raking_soa_details,
+			TileSoa tile_soa,
+			ReductionOp scan_op) {}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Scan a single tile where carry is assigned (or updated if REDUCE_INTO_CARRY is set)
+	 * with the total aggregate only in raking threads.
+	 *
+	 * No post-synchronization needed before grid reuse.
+	 */
+	template <
+		bool REDUCE_INTO_CARRY,
+		typename RakingSoaDetails,
+		typename TileSoa,
+		typename TileTuple,
+		typename ReductionOp>
+	static __device__ __forceinline__ void ScanTileWithCarry(
+		RakingSoaDetails raking_soa_details,
+		TileSoa tile_soa,
+		TileTuple &carry,
+		ReductionOp scan_op)
+	{
+		// Reduce vectors in tile, placing resulting partial into corresponding raking grid lanes
+		reduction::soa::CooperativeSoaTileReduction<VEC_SIZE>::template
+			ReduceLane<0, RakingSoaDetails::SCAN_LANES>::Invoke(
+				raking_soa_details, tile_soa, scan_op);
+
+		__syncthreads();
+
+		CooperativeSoaGridScan<RakingSoaDetails>::template ScanTileWithCarry<REDUCE_INTO_CARRY>(
+			raking_soa_details, carry, scan_op);
+
+		__syncthreads();
+
+		// Scan partials in tile, retrieving resulting partial from raking grid lane partial
+		ScanLane<0, RakingSoaDetails::SCAN_LANES>::Invoke(
+			raking_soa_details, tile_soa, scan_op);
+	}
+
+
+	/**
+	 * Scan a single tile.  Total aggregate is computed and returned in all threads.
+	 *
+	 * No post-synchronization needed before grid reuse.
+	 */
+	template <
+		typename RakingSoaDetails,
+		typename TileSoa,
+		typename TileTuple,
+		typename ReductionOp>
+	static __device__ __forceinline__ void ScanTile(
+		TileTuple &retval,
+		RakingSoaDetails raking_soa_details,
+		TileSoa tile_soa,
+		ReductionOp scan_op)
+	{
+		// Reduce vectors in tile, placing resulting partial into corresponding raking grid lanes
+		reduction::soa::CooperativeSoaTileReduction<VEC_SIZE>::template
+			ReduceLane<0, RakingSoaDetails::SCAN_LANES>::Invoke(
+				raking_soa_details, tile_soa, scan_op);
+
+		__syncthreads();
+
+		CooperativeSoaGridScan<RakingSoaDetails>::ScanTile(
+			raking_soa_details, scan_op);
+
+		__syncthreads();
+
+		// Scan partials in tile, retrieving resulting partial from raking grid lane partial
+		ScanLane<0, RakingSoaDetails::SCAN_LANES>::Invoke(
+			raking_soa_details, tile_soa, scan_op);
+
+		// Return last thread's inclusive partial
+		retval = raking_soa_details.CumulativePartial();
+	}
+};
+
+
+
+
+/******************************************************************************
+ * CooperativeSoaGridScan
+ ******************************************************************************/
+
+/**
+ * Cooperative SOA raking grid reduction (specialized for last-level of raking grid)
+ */
+template <typename RakingSoaDetails>
+struct CooperativeSoaGridScan<RakingSoaDetails, NullType>
+{
+	typedef typename RakingSoaDetails::TileTuple TileTuple;
+
+
+	/**
+	 * Scan in last-level raking grid.
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ void ScanTile(
+		RakingSoaDetails raking_soa_details,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			TileTuple inclusive_partial;
+			reduction::soa::SerialSoaReduce<RakingSoaDetails::PARTIALS_PER_SEG>::Reduce(
+				inclusive_partial,
+				raking_soa_details.raking_segments,
+				scan_op);
+
+			// Exclusive warp scan
+			TileTuple exclusive_partial = WarpSoaScan<RakingSoaDetails::LOG_RAKING_THREADS>::Scan(
+				inclusive_partial,
+				raking_soa_details.warpscan_partials,
+				scan_op);
+
+			// Exclusive raking scan
+			SerialSoaScan<RakingSoaDetails::PARTIALS_PER_SEG>::Scan(
+				raking_soa_details.raking_segments, exclusive_partial, scan_op);
+		}
+	}
+
+
+	/**
+	 * Scan in last-level raking grid.  Carry-in/out is updated only in raking threads (homogeneously)
+	 */
+	template <
+		bool REDUCE_INTO_CARRY,
+		typename ReductionOp>
+	static __device__ __forceinline__ void ScanTileWithCarry(
+		RakingSoaDetails raking_soa_details,
+		TileTuple &carry,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			TileTuple inclusive_partial;
+			reduction::soa::SerialSoaReduce<RakingSoaDetails::PARTIALS_PER_SEG>::Reduce(
+				inclusive_partial,
+				raking_soa_details.raking_segments,
+				scan_op);
+
+			// Exclusive warp scan, get total
+			TileTuple warpscan_total;
+			TileTuple exclusive_partial = WarpSoaScan<
+				RakingSoaDetails::LOG_RAKING_THREADS>::Scan(
+					inclusive_partial,
+					warpscan_total,
+					raking_soa_details.warpscan_partials,
+					scan_op);
+
+
+			// Seed exclusive partial with carry-in
+			if (REDUCE_INTO_CARRY) {
+
+				if (!ReductionOp::IDENTITY_STRIDES && (threadIdx.x == 0)) {
+
+					// Thread-zero can't use the exclusive partial from the warpscan
+					// because it contains garbage
+					exclusive_partial = carry;
+
+				} else {
+
+					// Seed exclusive partial with the carry partial
+					exclusive_partial = scan_op(carry, exclusive_partial);
+				}
+
+				// Update carry
+				carry = scan_op(carry, warpscan_total);
+
+			} else {
+				// Set carry
+				carry = warpscan_total;
+			}
+
+			// Exclusive raking scan
+			SerialSoaScan<RakingSoaDetails::PARTIALS_PER_SEG>::Scan(
+				raking_soa_details.raking_segments, exclusive_partial, scan_op);
+
+		}
+	}
+
+};
+
+
+
+/**
+ * Cooperative SOA raking grid reduction (specialized for last-level of raking grid)
+ */
+template <
+	typename RakingSoaDetails,
+	typename SecondaryRakingSoaDetails>
+struct CooperativeSoaGridScan
+{
+	typedef typename RakingSoaDetails::TileTuple TileTuple;
+
+	/**
+	 * Scan in last-level raking grid.
+	 */
+	template <typename ReductionOp>
+	static __device__ __forceinline__ void ScanTile(
+		RakingSoaDetails raking_soa_details,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			TileTuple inclusive_partial;
+			reduction::soa::SerialSoaReduce<RakingSoaDetails::PARTIALS_PER_SEG>::Reduce(
+				inclusive_partial,
+				raking_soa_details.raking_segments,
+				scan_op);
+
+			// Store partial reduction into next raking grid
+			raking_soa_details.secondary_details.lane_partials.Set(inclusive_partial, 0, 0);
+		}
+
+		__syncthreads();
+
+
+		// Collectively scan in next grid
+		CooperativeSoaGridScan<SecondaryRakingSoaDetails>::ScanTile(
+			raking_soa_details.secondary_details,
+			scan_op);
+
+		__syncthreads();
+
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Retrieve partial reduction from next raking grid
+			TileTuple exclusive_partial;
+			raking_soa_details.secondary_details.lane_partials.Get(exclusive_partial, 0, 0);
+
+			// Exclusive raking scan
+			SerialSoaScan<RakingSoaDetails::PARTIALS_PER_SEG>::Scan(
+				raking_soa_details.raking_segments,
+				exclusive_partial,
+				scan_op);
+		}
+
+	}
+
+	/**
+	 * Scan in last-level raking grid.  Carry-in/out is updated only in raking threads (homogeneously)
+	 */
+	template <
+		bool REDUCE_INTO_CARRY,
+		typename ReductionOp>
+	static __device__ __forceinline__ void ScanTileWithCarry(
+		RakingSoaDetails raking_soa_details,
+		TileTuple &carry,
+		ReductionOp scan_op)
+	{
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Raking reduction
+			TileTuple inclusive_partial;
+			reduction::soa::SerialSoaReduce<RakingSoaDetails::PARTIALS_PER_SEG>::Reduce(
+				inclusive_partial,
+				raking_soa_details.raking_segments,
+				scan_op);
+
+			// Store partial reduction into next raking grid
+			raking_soa_details.secondary_details.lane_partials.Set(inclusive_partial, 0, 0);
+		}
+
+		__syncthreads();
+
+		// Collectively scan in next grid
+		CooperativeSoaGridScan<SecondaryRakingSoaDetails>::template ScanTileWithCarry<REDUCE_INTO_CARRY>(
+			raking_soa_details.secondary_details,
+			carry,
+			scan_op);
+
+		__syncthreads();
+
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Retrieve partial reduction from next raking grid
+			TileTuple exclusive_partial;
+			raking_soa_details.secondary_details.lane_partials.Get(exclusive_partial, 0, 0);
+
+			// Exclusive raking scan
+			SerialSoaScan<RakingSoaDetails::PARTIALS_PER_SEG>::Scan(
+				raking_soa_details.raking_segments,
+				exclusive_partial,
+				scan_op);
+		}
+	}
+
+
+
+};
+
+
+
+
+
+} // namespace soa
+} // namespace scan
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/scan/soa/serial_soa_scan.cuh
+++ b/include/b40c/util/scan/soa/serial_soa_scan.cuh
@@ -1,0 +1,242 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Serial tuple scan over structure-of-array types.
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/soa_tuple.cuh>
+
+namespace b40c {
+namespace util {
+namespace scan {
+namespace soa {
+
+
+/**
+ * Have each thread perform a serial scan over its specified SOA segment
+ */
+template <
+	int NUM_ELEMENTS,				// Length of SOA array segment to scan
+	bool EXCLUSIVE = true>			// Whether or not this is an exclusive scan
+struct SerialSoaScan
+{
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	// Iterate
+	template <int COUNT, int TOTAL>
+	struct Iterate
+	{
+		// Scan
+		template <
+			typename Tuple,
+			typename RakingSoa,
+			typename ReductionOp>
+		static __host__ __device__ __forceinline__ Tuple Scan(
+			RakingSoa raking_partials,
+			RakingSoa raking_results,
+			Tuple exclusive_partial,
+			ReductionOp scan_op)
+		{
+			// Load current partial
+			Tuple current_partial;
+			raking_partials.Get(current_partial, COUNT);
+
+			// Compute inclusive partial from exclusive and current partials
+			Tuple inclusive_partial = scan_op(exclusive_partial, current_partial);
+
+			if (EXCLUSIVE) {
+				// Store exclusive partial
+				raking_results.Set(exclusive_partial, COUNT);
+			} else {
+				// Store inclusive partial
+				raking_results.Set(inclusive_partial, COUNT);
+			}
+
+			// Recurse
+			return Iterate<COUNT + 1, TOTAL>::Scan(
+				raking_partials, raking_results, inclusive_partial, scan_op);
+		}
+
+		// Scan 2D
+		template <
+			typename Tuple,
+			typename RakingSoa,
+			typename ReductionOp>
+		static __host__ __device__ __forceinline__ Tuple Scan(
+			RakingSoa raking_partials,
+			RakingSoa raking_results,
+			Tuple exclusive_partial,
+			int row,
+			ReductionOp scan_op)
+		{
+			// Load current partial
+			Tuple current_partial;
+			raking_partials.Get(current_partial, row, COUNT);
+
+			// Compute inclusive partial from exclusive and current partials
+			Tuple inclusive_partial = scan_op(exclusive_partial, current_partial);
+
+			if (EXCLUSIVE) {
+				// Store exclusive partial
+				raking_results.Set(exclusive_partial, row, COUNT);
+			} else {
+				// Store inclusive partial
+				raking_results.Set(inclusive_partial, row, COUNT);
+			}
+
+			// Recurse
+			return Iterate<COUNT + 1, TOTAL>::Scan(
+				raking_partials, raking_results, inclusive_partial, row, scan_op);
+		}
+	};
+
+	// Terminate
+	template <int TOTAL>
+	struct Iterate<TOTAL, TOTAL>
+	{
+		// Scan
+		template <
+			typename Tuple,
+			typename RakingSoa,
+			typename ReductionOp>
+		static __host__ __device__ __forceinline__ Tuple Scan(
+			RakingSoa raking_partials,
+			RakingSoa raking_results,
+			Tuple exclusive_partial,
+			ReductionOp scan_op)
+		{
+			return exclusive_partial;
+		}
+
+		// Scan 2D
+		template <
+			typename Tuple,
+			typename RakingSoa,
+			typename ReductionOp>
+		static __host__ __device__ __forceinline__ Tuple Scan(
+			RakingSoa raking_partials,
+			RakingSoa raking_results,
+			Tuple exclusive_partial,
+			int row,
+			ReductionOp scan_op)
+		{
+			return exclusive_partial;
+		}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Scan a 2D structure-of-array RakingSoa, seeded  with exclusive_partial.
+	 * The tuple returned is the inclusive total.
+	 */
+	template <
+		typename Tuple,
+		typename RakingSoa,
+		typename ReductionOp>
+	static __host__ __device__ __forceinline__ Tuple Scan(
+		RakingSoa raking_partials,			// Scan input/output
+		Tuple exclusive_partial,			// Exclusive partial to seed with
+		ReductionOp scan_op)
+	{
+		return Iterate<0, NUM_ELEMENTS>::Scan(
+			raking_partials, raking_partials, exclusive_partial, scan_op);
+	}
+
+
+	/**
+	 * Scan a 2D structure-of-array RakingSoa, seeded  with exclusive_partial.
+	 * The tuple returned is the inclusive total.
+	 */
+	template <
+		typename Tuple,
+		typename RakingSoa,
+		typename ReductionOp>
+	static __host__ __device__ __forceinline__ Tuple Scan(
+		RakingSoa raking_partials,			// Scan input
+		RakingSoa raking_results,			// Scan output
+		Tuple exclusive_partial,			// Exclusive partial to seed with
+		ReductionOp scan_op)
+	{
+		return Iterate<0, NUM_ELEMENTS>::Scan(
+			raking_partials, raking_results, exclusive_partial, scan_op);
+	}
+
+
+	/**
+	 * Scan one row of a 2D structure-of-array RakingSoa, seeded
+	 * with exclusive_partial.  The tuple returned is the inclusive total.
+	 */
+	template <
+		typename Tuple,
+		typename RakingSoa,
+		typename ReductionOp>
+	static __host__ __device__ __forceinline__ Tuple Scan(
+		RakingSoa raking_partials,			// Scan input/output
+		Tuple exclusive_partial,			// Exclusive partial to seed with
+		int row,
+		ReductionOp scan_op)
+	{
+		return Iterate<0, NUM_ELEMENTS>::Scan(
+			raking_partials, raking_partials, exclusive_partial, row, scan_op);
+	}
+
+
+	/**
+	 * Scan one row of a 2D structure-of-array RakingSoa, seeded
+	 * with exclusive_partial.  The tuple returned is the inclusive total.
+	 */
+	template <
+		typename Tuple,
+		typename RakingSoa,
+		typename ReductionOp>
+	static __host__ __device__ __forceinline__ Tuple Scan(
+		RakingSoa raking_partials,			// Scan input
+		RakingSoa raking_results,			// Scan output
+		Tuple exclusive_partial,			// Exclusive partial to seed with
+		int row,
+		ReductionOp scan_op)
+	{
+		return Iterate<0, NUM_ELEMENTS>::Scan(
+			raking_partials, raking_results, exclusive_partial, row, scan_op);
+	}
+};
+
+} // namespace soa
+} // namespace scan
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/scan/soa/warp_soa_scan.cuh
+++ b/include/b40c/util/scan/soa/warp_soa_scan.cuh
@@ -1,0 +1,208 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Cooperative tuple warp-scan
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/soa_tuple.cuh>
+
+namespace b40c {
+namespace util {
+namespace scan {
+namespace soa {
+
+/**
+ * Structure-of-arrays tuple warpscan.  Performs STEPS steps of a
+ * Kogge-Stone style prefix scan.
+ *
+ * This procedure assumes that no explicit barrier synchronization is needed
+ * between steps (i.e., warp-synchronous programming)
+ *
+ * The type WarpscanSoa is a 2D structure-of-array of smem storage, each SOA array having
+ * dimensions [2][NUM_ELEMENTS].
+ */
+template <
+	int LOG_NUM_ELEMENTS,					// Log of number of elements to warp-reduce
+	bool EXCLUSIVE = true,					// Whether or not this is an exclusive scan
+	int STEPS = LOG_NUM_ELEMENTS>			// Number of steps to run, i.e., produce scanned segments of (1 << STEPS) elements
+struct WarpSoaScan
+{
+	static const int NUM_ELEMENTS = 1 << LOG_NUM_ELEMENTS;
+
+	//---------------------------------------------------------------------
+	// Iteration Structures
+	//---------------------------------------------------------------------
+
+	// Iteration
+	template <int OFFSET_LEFT, int WIDTH>
+	struct Iterate
+	{
+		// Scan
+		template <
+			typename Tuple,
+			typename WarpscanSoa,
+			typename ReductionOp>
+		static __device__ __forceinline__ Tuple Scan(
+			Tuple partial,
+			WarpscanSoa warpscan_partials,
+			ReductionOp scan_op,
+			int warpscan_tid)
+		{
+			// Store exclusive partial
+			warpscan_partials.Set(partial, 1, warpscan_tid);
+
+			if (!WarpscanSoa::VOLATILE) __threadfence_block();
+
+			if (ReductionOp::IDENTITY_STRIDES || (warpscan_tid >= OFFSET_LEFT)) {
+
+				// Load current partial
+				Tuple current_partial;
+				warpscan_partials.Get(current_partial, 1, warpscan_tid - OFFSET_LEFT);
+
+				// Compute inclusive partial from exclusive and current partials
+				partial = scan_op(current_partial, partial);
+			}
+
+			if (!WarpscanSoa::VOLATILE) __threadfence_block();
+
+			// Recurse
+			return Iterate<OFFSET_LEFT * 2, WIDTH>::Scan(
+				partial, warpscan_partials, scan_op, warpscan_tid);
+		}
+	};
+
+	// Termination
+	template <int WIDTH>
+	struct Iterate<WIDTH, WIDTH>
+	{
+		// Scan
+		template <
+			typename Tuple,
+			typename WarpscanSoa,
+			typename ReductionOp>
+		static __device__ __forceinline__ Tuple Scan(
+			Tuple exclusive_partial,
+			WarpscanSoa warpscan_partials,
+			ReductionOp scan_op,
+			int warpscan_tid)
+		{
+			return exclusive_partial;
+		}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Cooperative warp-scan.  Returns the calling thread's scanned partial.
+	 */
+	template <
+		typename Tuple,
+		typename WarpscanSoa,
+		typename ReductionOp>
+	static __device__ __forceinline__ Tuple Scan(
+		Tuple current_partial,						// Input partial
+		WarpscanSoa warpscan_partials,				// Smem for warpscanning containing at least two segments of size NUM_ELEMENTS (the first being initialized to zero's)
+		ReductionOp scan_op,						// Scan operator
+		int warpscan_tid = threadIdx.x)				// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		Tuple inclusive_partial = Iterate<1, (1 << STEPS)>::Scan(
+			current_partial,
+			warpscan_partials,
+			scan_op,
+			warpscan_tid);
+
+		if (EXCLUSIVE) {
+
+			// Write our inclusive partial
+			warpscan_partials.Set(inclusive_partial, 1, warpscan_tid);
+
+			if (!WarpscanSoa::VOLATILE) __threadfence_block();
+
+			// Return exclusive partial
+			Tuple exclusive_partial;
+			warpscan_partials.Get(exclusive_partial, 1, warpscan_tid - 1);
+			return exclusive_partial;
+
+		} else {
+			return inclusive_partial;
+		}
+	}
+
+	/**
+	 * Cooperative warp-scan.  Returns the calling thread's scanned partial.
+	 */
+	template <
+		typename Tuple,
+		typename WarpscanSoa,
+		typename ReductionOp>
+	static __device__ __forceinline__ Tuple Scan(
+		Tuple current_partial,						// Input partial
+		Tuple &total_reduction,						// Total reduction (out param)
+		WarpscanSoa warpscan_partials,				// Smem for warpscanning containing at least two segments of size NUM_ELEMENTS (the first being initialized to zero's)
+		ReductionOp scan_op,						// Scan operator
+		int warpscan_tid = threadIdx.x)				// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		Tuple inclusive_partial = Iterate<1, (1 << STEPS)>::Scan(
+			current_partial,
+			warpscan_partials,
+			scan_op,
+			warpscan_tid);
+
+		// Write our inclusive partial
+		warpscan_partials.Set(inclusive_partial, 1, warpscan_tid);
+
+		if (!WarpscanSoa::VOLATILE) __threadfence_block();
+
+		// Set total to the last thread's inclusive partial
+		warpscan_partials.Get(total_reduction, 1, NUM_ELEMENTS - 1);
+
+		if (EXCLUSIVE) {
+
+			// Return exclusive partial
+			Tuple exclusive_partial;
+			warpscan_partials.Get(exclusive_partial, 1, warpscan_tid - 1);
+			return exclusive_partial;
+
+		} else {
+			return inclusive_partial;
+		}
+	}
+};
+
+
+} // namespace soa
+} // namespace scan
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/scan/warp_scan.cuh
+++ b/include/b40c/util/scan/warp_scan.cuh
@@ -1,0 +1,223 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Cooperative warp-scan
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/util/operators.cuh>
+
+namespace b40c {
+namespace util {
+namespace scan {
+
+
+
+/**
+ * Performs STEPS steps of a Kogge-Stone style prefix scan.
+ *
+ * Requires a 2D "warpscan" structure of smem storage having dimensions [2][NUM_ELEMENTS].
+ */
+template <
+	int LOG_NUM_ELEMENTS,					// Log of number of elements to warp-reduce
+	bool EXCLUSIVE = true,					// Whether or not this is an exclusive scan
+	int STEPS = LOG_NUM_ELEMENTS>			// Number of steps to run, i.e., produce scanned segments of (1 << STEPS) elements
+struct WarpScan
+{
+	enum {
+		NUM_ELEMENTS = 1 << LOG_NUM_ELEMENTS,
+	};
+
+	//---------------------------------------------------------------------
+	// Helper Structures
+	//---------------------------------------------------------------------
+
+	// General iteration
+	template <int OFFSET_LEFT, int WIDTH>
+	struct Iterate
+	{
+		template <typename T, typename WarpscanT, typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(
+			T exclusive_partial,
+			WarpscanT warpscan[][NUM_ELEMENTS],
+			ReductionOp scan_op,
+			int warpscan_tid)
+		{
+			warpscan[1][warpscan_tid] = exclusive_partial;
+
+			if (!IsVolatile<WarpscanT>::VALUE) __threadfence_block();
+
+			T offset_partial = warpscan[1][warpscan_tid - OFFSET_LEFT];
+
+			if (!IsVolatile<WarpscanT>::VALUE) __threadfence_block();
+
+			T inclusive_partial = scan_op(offset_partial, exclusive_partial);
+
+			return Iterate<OFFSET_LEFT * 2, WIDTH>::Invoke(
+				inclusive_partial,
+				warpscan,
+				scan_op,
+				warpscan_tid);
+		}
+	};
+
+	// Termination
+	template <int WIDTH>
+	struct Iterate<WIDTH, WIDTH>
+	{
+		template <typename T, typename WarpscanT, typename ReductionOp>
+		static __device__ __forceinline__ T Invoke(
+			T exclusive_partial,
+			WarpscanT warpscan[][NUM_ELEMENTS],
+			ReductionOp scan_op,
+			int warpscan_tid)
+		{
+			return exclusive_partial;
+		}
+	};
+
+
+	//---------------------------------------------------------------------
+	// Interface
+	//---------------------------------------------------------------------
+
+	/**
+	 * Warpscan with the specified operator
+	 */
+	template <typename T, typename WarpscanT, typename ReductionOp>
+	static __device__ __forceinline__ T Invoke(
+		T current_partial,							// Input partial
+		WarpscanT warpscan[][NUM_ELEMENTS],		// Smem for warpscanning.  Contains at least two segments of size NUM_ELEMENTS (the first being initialized to identity)
+		ReductionOp scan_op,						// Scan operator
+		int warpscan_tid = threadIdx.x)				// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		const int WIDTH = 1 << STEPS;
+		T inclusive_partial = Iterate<1, WIDTH>::Invoke(
+			current_partial,
+			warpscan,
+			scan_op,
+			warpscan_tid);
+
+		if (EXCLUSIVE) {
+			// Write out our inclusive partial
+			warpscan[1][warpscan_tid] = inclusive_partial;
+
+			if (!IsVolatile<WarpscanT>::VALUE) __threadfence_block();
+
+			// Return exclusive partial
+			return warpscan[1][warpscan_tid - 1];
+
+		} else {
+			return inclusive_partial;
+		}
+	}
+
+
+	/**
+	 * Warpscan with the addition operator
+	 */
+	template <typename T, typename WarpscanT>
+	static __device__ __forceinline__ T Invoke(
+		T current_partial,							// Input partial
+		WarpscanT warpscan[][NUM_ELEMENTS],		// Smem for warpscanning.  Contains at least two segments of size NUM_ELEMENTS (the first being initialized to identity)
+		int warpscan_tid = threadIdx.x)				// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		Sum<T> scan_op;
+		return Invoke(
+			current_partial,
+			warpscan,
+			scan_op,
+			warpscan_tid);
+	}
+
+
+	/**
+	 * Warpscan with the specified operator, returning the cumulative reduction
+	 */
+	template <typename T, typename WarpscanT, typename ReductionOp>
+	static __device__ __forceinline__ T Invoke(
+		T current_partial,							// Input partial
+		T &total_reduction,							// Total reduction (out param)
+		WarpscanT warpscan[][NUM_ELEMENTS],		// Smem for warpscanning.  Contains at least two segments of size NUM_ELEMENTS (the first being initialized to identity)
+		ReductionOp scan_op,						// Scan operator
+		int warpscan_tid = threadIdx.x)				// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		const int WIDTH = 1 << STEPS;
+		T inclusive_partial = Iterate<1, WIDTH>::Invoke(
+			current_partial,
+			warpscan,
+			scan_op,
+			warpscan_tid);
+
+		// Write our inclusive partial and then set total to the last thread's inclusive partial
+		warpscan[1][warpscan_tid] = inclusive_partial;
+
+		if (!IsVolatile<WarpscanT>::VALUE) __threadfence_block();
+
+		// Get total
+		total_reduction = warpscan[1][NUM_ELEMENTS - 1];
+
+		if (EXCLUSIVE) {
+
+			// Return exclusive partial
+			return warpscan[1][warpscan_tid - 1];
+
+		} else {
+			return inclusive_partial;
+		}
+	}
+
+	/**
+	 * Warpscan with the addition operator, returning the cumulative reduction
+	 */
+	template <typename T, typename WarpscanT>
+	static __device__ __forceinline__ T Invoke(
+		T current_partial,							// Input partial
+		T &total_reduction,							// Total reduction (out param)
+		WarpscanT warpscan[][NUM_ELEMENTS],		// Smem for warpscanning.  Contains at least two segments of size NUM_ELEMENTS (the first being initialized to identity)
+		int warpscan_tid = threadIdx.x)				// Thread's local index into a segment of NUM_ELEMENTS items
+	{
+		Sum<T> scan_op;
+		return Invoke(
+			current_partial,
+			total_reduction,
+			warpscan,
+			scan_op,
+			warpscan_tid);
+	}
+};
+
+
+
+} // namespace scan
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/soa_tuple.cuh
+++ b/include/b40c/util/soa_tuple.cuh
@@ -1,0 +1,332 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Simple tuple types for assisting AOS <-> SOA work
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/basic_utils.cuh>
+
+namespace b40c {
+namespace util {
+
+
+template <
+	typename T0 = NullType,
+	typename T1 = NullType,
+	typename T2 = NullType,
+	typename T3 = NullType>
+struct Tuple;
+
+/**
+ * 1 element tuple
+ */
+template <typename _T0>
+struct Tuple<_T0, NullType, NullType, NullType>
+{
+	// Typedefs
+	typedef _T0 T0;
+
+	enum {
+		NUM_FIELDS 		= 1,
+		VOLATILE 		= util::IsVolatile<typename util::RemovePointers<T0>::Type>::VALUE,
+	};
+
+
+	// Fields
+	T0 t0;
+
+	// Constructors
+	__host__ __device__ __forceinline__ Tuple() {}
+	__host__ __device__ __forceinline__ Tuple(T0 t0) : t0(t0) {}
+
+	// Manipulators
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Set(
+		const TupleSlice &tuple,
+		const int col)
+	{
+		t0[col] = tuple.t0;
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Set(
+		const TupleSlice &tuple,
+		const int row,
+		const int col)
+	{
+		t0[row][col] = tuple.t0;
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Get(
+		TupleSlice &retval,
+		const int col) const
+	{
+		retval = TupleSlice(t0[col]);
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Get(
+		TupleSlice &retval,
+		const int row,
+		const int col) const
+	{
+		retval = TupleSlice(t0[row][col]);
+	}
+};
+
+
+/**
+ * 2 element tuple
+ */
+template <typename _T0, typename _T1>
+struct Tuple<_T0, _T1, NullType, NullType>
+{
+	// Typedefs
+	typedef _T0 T0;
+	typedef _T1 T1;
+
+	enum {
+		NUM_FIELDS 		= 2,
+		VOLATILE 		= (util::IsVolatile<typename util::RemovePointers<T0>::Type>::VALUE &&
+							util::IsVolatile<typename util::RemovePointers<T1>::Type>::VALUE),
+	};
+
+	// Fields
+	T0 t0;
+	T1 t1;
+
+
+	// Constructors
+	__host__ __device__ __forceinline__ Tuple() {}
+	__host__ __device__ __forceinline__ Tuple(T0 t0) : t0(t0) {}
+	__host__ __device__ __forceinline__ Tuple(T0 t0, T1 t1) : t0(t0), t1(t1) {}
+
+	// Manipulators
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Set(
+		const TupleSlice &tuple,
+		const int col)
+	{
+		t0[col] = tuple.t0;
+		t1[col] = tuple.t1;
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Set(
+		const TupleSlice &tuple,
+		const int row,
+		const int col)
+	{
+		t0[row][col] = tuple.t0;
+		t1[row][col] = tuple.t1;
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Get(
+		TupleSlice &retval,
+		const int col) const
+	{
+		retval = TupleSlice(t0[col], t1[col]);
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Get(
+		TupleSlice &retval,
+		const int row,
+		const int col) const
+	{
+		retval = TupleSlice(t0[row][col], t1[row][col]);
+	}
+};
+
+
+/**
+ * 3 element tuple
+ */
+template <typename _T0, typename _T1, typename _T2>
+struct Tuple<_T0, _T1, _T2, NullType>
+{
+	// Typedefs
+	typedef _T0 T0;
+	typedef _T1 T1;
+	typedef _T2 T2;
+
+	enum {
+		NUM_FIELDS 		= 3,
+		VOLATILE 		= (util::IsVolatile<typename util::RemovePointers<T0>::Type>::VALUE &&
+							util::IsVolatile<typename util::RemovePointers<T1>::Type>::VALUE &&
+							util::IsVolatile<typename util::RemovePointers<T2>::Type>::VALUE),
+	};
+
+	// Fields
+	T0 t0;
+	T1 t1;
+	T2 t2;
+
+	// Constructor
+	__host__ __device__ __forceinline__ Tuple(T0 t0, T1 t1, T2 t2) : t0(t0), t1(t1), t2(t2) {}
+
+	// Manipulators
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Set(
+		const TupleSlice &tuple,
+		const int col)
+	{
+		t0[col] = tuple.t0;
+		t1[col] = tuple.t1;
+		t2[col] = tuple.t2;
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Set(
+		const TupleSlice &tuple,
+		const int row,
+		const int col)
+	{
+		t0[row][col] = tuple.t0;
+		t1[row][col] = tuple.t1;
+		t2[row][col] = tuple.t2;
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Get(
+		TupleSlice &retval,
+		const int col) const
+	{
+		retval = TupleSlice(
+			t0[col],
+			t1[col],
+			t2[col]);
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Get(
+		TupleSlice &retval,
+		const int row,
+		const int col) const
+	{
+		retval = TupleSlice(
+			t0[row][col],
+			t1[row][col],
+			t2[row][col]);
+	}
+};
+
+
+/**
+ * 4 element tuple
+ */
+template <typename _T0, typename _T1, typename _T2, typename _T3>
+struct Tuple
+{
+	// Typedefs
+	typedef _T0 T0;
+	typedef _T1 T1;
+	typedef _T2 T2;
+	typedef _T3 T3;
+
+	enum {
+		NUM_FIELDS 		= 3,
+		VOLATILE 		= (util::IsVolatile<typename util::RemovePointers<T0>::Type>::VALUE &&
+							util::IsVolatile<typename util::RemovePointers<T1>::Type>::VALUE &&
+							util::IsVolatile<typename util::RemovePointers<T2>::Type>::VALUE &&
+							util::IsVolatile<typename util::RemovePointers<T3>::Type>::VALUE),
+	};
+
+	// Fields
+	T0 t0;
+	T1 t1;
+	T2 t2;
+	T3 t3;
+
+	// Constructor
+	__host__ __device__ __forceinline__ Tuple(T0 t0, T1 t1, T2 t2, T3 t3) : t0(t0), t1(t1), t2(t2), t3(t3) {}
+
+	// Manipulators
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Set(
+		const TupleSlice &tuple,
+		const int col)
+	{
+		t0[col] = tuple.t0;
+		t1[col] = tuple.t1;
+		t2[col] = tuple.t2;
+		t3[col] = tuple.t3;
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Set(
+		const TupleSlice &tuple,
+		const int row,
+		const int col)
+	{
+		t0[row][col] = tuple.t0;
+		t1[row][col] = tuple.t1;
+		t2[row][col] = tuple.t2;
+		t3[row][col] = tuple.t3;
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Get(
+		TupleSlice &retval,
+		const int col) const
+	{
+		retval = TupleSlice(
+			t0[col],
+			t1[col],
+			t2[col],
+			t3[col]);
+	}
+
+	template <typename TupleSlice>
+	__host__ __device__ __forceinline__ void Get(
+		TupleSlice &retval,
+		const int row,
+		const int col) const
+	{
+		retval = TupleSlice(
+			t0[row][col],
+			t1[row][col],
+			t2[row][col],
+			t3[row][col]);
+	}
+};
+
+
+
+
+} // namespace util
+} // namespace b40c

--- a/include/b40c/util/spine.cuh
+++ b/include/b40c/util/spine.cuh
@@ -1,0 +1,240 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Management of temporary device storage needed for maintaining partial
+ * reductions between subsequent grids
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/error_utils.cuh>
+
+namespace b40c {
+namespace util {
+
+/**
+ * Manages device storage needed for communicating partial reductions
+ * between CTAs in subsequent grids
+ */
+struct Spine
+{
+	//---------------------------------------------------------------------
+	// Members
+	//---------------------------------------------------------------------
+
+	// Device spine storage
+	void *d_spine;
+
+	// Host-mapped spine storage (if so constructed)
+	void *h_spine;
+
+	// Number of bytes backed by d_spine
+	size_t spine_bytes;
+
+	// GPU d_spine was allocated on
+	int gpu;
+
+	// Whether or not the spine has a shadow spine on the host
+	bool host_shadow;
+
+
+	//---------------------------------------------------------------------
+	// Methods
+	//---------------------------------------------------------------------
+
+	/**
+	 * Constructor (device-allocated spine)
+	 */
+	Spine() :
+		d_spine(NULL),
+		h_spine(NULL),
+		spine_bytes(0),
+		gpu(B40C_INVALID_DEVICE),
+		host_shadow(false) {}
+
+
+	/**
+	 * Constructor
+	 *
+	 * @param host_shadow
+	 * 		Whether or not the spine has a shadow spine on the host
+	 */
+	Spine(bool host_shadow) :
+		d_spine(NULL),
+		h_spine(NULL),
+		spine_bytes(0),
+		gpu(B40C_INVALID_DEVICE),
+		host_shadow(host_shadow) {}
+
+
+	/**
+	 * Deallocates and resets the spine
+	 */
+	cudaError_t HostReset()
+	{
+		cudaError_t retval = cudaSuccess;
+		do {
+
+			if (gpu == B40C_INVALID_DEVICE) return retval;
+
+			// Save current gpu
+			int current_gpu;
+			if (retval = util::B40CPerror(cudaGetDevice(&current_gpu),
+				"Spine cudaGetDevice failed: ", __FILE__, __LINE__)) break;
+#if CUDA_VERSION >= 4000
+			if (retval = util::B40CPerror(cudaSetDevice(gpu),
+				"Spine cudaSetDevice failed: ", __FILE__, __LINE__)) break;
+#endif
+			if (d_spine) {
+				// Deallocate
+				if (retval = util::B40CPerror(cudaFree(d_spine),
+					"Spine cudaFree d_spine failed: ", __FILE__, __LINE__)) break;
+				d_spine = NULL;
+			}
+			if (h_spine) {
+				// Deallocate
+				if (retval = util::B40CPerror(cudaFreeHost((void *) h_spine),
+					"Spine cudaFreeHost h_spine failed", __FILE__, __LINE__)) break;
+
+				h_spine = NULL;
+			}
+
+#if CUDA_VERSION >= 4000
+			// Restore current gpu
+			if (retval = util::B40CPerror(cudaSetDevice(current_gpu),
+				"Spine cudaSetDevice failed: ", __FILE__, __LINE__)) break;
+#endif
+
+			gpu 			= B40C_INVALID_DEVICE;
+			spine_bytes	 	= 0;
+
+		} while (0);
+
+		return retval;
+	}
+
+
+	/**
+	 * Destructor
+	 */
+	virtual ~Spine()
+	{
+		HostReset();
+	}
+
+
+	/**
+	 * Device spine storage accessor
+	 */
+	void* operator()()
+	{
+		return d_spine;
+	}
+
+
+	/**
+	 * Sets up the spine to accommodate partials of the specified type
+	 * produced/consumed by grids of the specified sweep grid size (lazily
+	 * allocating it if necessary)
+	 *
+	 * Grows as necessary.
+	 */
+	template <typename T>
+	cudaError_t Setup(int spine_elements)
+	{
+		cudaError_t retval = cudaSuccess;
+		do {
+			size_t problem_spine_bytes = spine_elements * sizeof(T);
+
+			// Get current gpu
+			int current_gpu;
+			if (retval = util::B40CPerror(cudaGetDevice(&current_gpu),
+				"Spine cudaGetDevice failed: ", __FILE__, __LINE__)) break;
+
+			// Check if big enough and if lives on proper GPU
+			if ((problem_spine_bytes > spine_bytes) || (gpu != current_gpu)) {
+
+				// Deallocate if exists
+				if (retval = HostReset()) break;
+
+				// Remember device
+				gpu = current_gpu;
+
+				// Reallocate
+				spine_bytes = problem_spine_bytes;
+
+				// Allocate on device
+				if (retval = util::B40CPerror(cudaMalloc((void**) &d_spine, spine_bytes),
+					"Spine cudaMalloc d_spine failed", __FILE__, __LINE__)) break;
+
+				if (host_shadow) {
+					// Allocate pinned memory for h_spine
+					int flags = cudaHostAllocMapped;
+					if (retval = util::B40CPerror(cudaHostAlloc((void **)&h_spine, problem_spine_bytes, flags),
+						"Spine cudaHostAlloc h_spine failed", __FILE__, __LINE__)) break;
+				}
+			}
+		} while (0);
+
+		return retval;
+	}
+
+
+	/**
+	 * Syncs the shadow host spine with device spine
+	 */
+	cudaError_t Sync(cudaStream_t stream)
+	{
+		return cudaMemcpyAsync(
+			h_spine,
+			d_spine,
+			spine_bytes,
+			cudaMemcpyDeviceToHost,
+			stream);
+	}
+
+
+	/**
+	 * Syncs the shadow host spine with device spine
+	 */
+	cudaError_t Sync()
+	{
+		return cudaMemcpy(
+			h_spine,
+			d_spine,
+			spine_bytes,
+			cudaMemcpyDeviceToHost);
+	}
+
+
+};
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/srts_details.cuh
+++ b/include/b40c/util/srts_details.cuh
@@ -1,0 +1,293 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Operational details for threads working in an raking grid
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/basic_utils.cuh>
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Operational details for threads working in an raking grid
+ */
+template <
+	typename RakingGrid,
+	typename SecondaryRakingGrid = typename RakingGrid::SecondaryGrid>
+struct RakingDetails;
+
+
+/**
+ * Operational details for threads working in an raking grid (specialized for one-level raking grid)
+ */
+template <typename RakingGrid>
+struct RakingDetails<RakingGrid, NullType> : RakingGrid
+{
+	enum {
+		QUEUE_RSVN_THREAD 	= 0,
+		CUMULATIVE_THREAD 	= RakingGrid::RAKING_THREADS - 1,
+		WARP_THREADS 		= B40C_WARP_THREADS(RakingSoaDetails::CUDA_ARCH)
+	};
+
+	typedef typename RakingGrid::T T;													// Partial type
+	typedef typename RakingGrid::WarpscanT (*WarpscanStorage)[WARP_THREADS];			// Warpscan storage type
+	typedef NullType SecondaryRakingDetails;											// Type of next-level grid raking details
+
+
+	/**
+	 * Smem pool backing raking grid lanes
+	 */
+	T *smem_pool;
+
+	/**
+	 * Warpscan storage
+	 */
+	WarpscanStorage warpscan;
+
+	/**
+	 * The location in the smem grid where the calling thread can insert/extract
+	 * its partial for raking reduction/scan into the first lane.
+	 */
+	typename RakingGrid::LanePartial lane_partial;
+
+	/**
+	 * Returns the location in the smem grid where the calling thread can begin serial
+	 * raking/scanning
+	 */
+	typename RakingGrid::RakingSegment raking_segment;
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ RakingDetails(
+		T *smem_pool) :
+			smem_pool(smem_pool),
+			lane_partial(RakingGrid::MyLanePartial(smem_pool))						// set lane partial pointer
+	{
+		if (threadIdx.x < RakingGrid::RAKING_THREADS) {
+
+			// Set raking segment pointer
+			raking_segment = RakingGrid::MyRakingSegment(smem_pool);
+		}
+	}
+
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ RakingDetails(
+		T *smem_pool,
+		WarpscanStorage warpscan) :
+			smem_pool(smem_pool),
+			warpscan(warpscan),
+			lane_partial(RakingGrid::MyLanePartial(smem_pool))						// set lane partial pointer
+	{
+		if (threadIdx.x < RakingGrid::RAKING_THREADS) {
+
+			// Set raking segment pointer
+			raking_segment = RakingGrid::MyRakingSegment(smem_pool);
+		}
+	}
+
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ RakingDetails(
+		T *smem_pool,
+		WarpscanStorage warpscan,
+		T warpscan_identity) :
+			smem_pool(smem_pool),
+			warpscan(warpscan),
+			lane_partial(RakingGrid::MyLanePartial(smem_pool))						// set lane partial pointer
+	{
+		if (threadIdx.x < RakingGrid::RAKING_THREADS) {
+
+			// Initialize first half of warpscan storage to identity
+			warpscan[0][threadIdx.x] = warpscan_identity;
+
+			// Set raking segment pointer
+			raking_segment = RakingGrid::MyRakingSegment(smem_pool);
+		}
+	}
+
+
+	/**
+	 * Return the cumulative partial left in the final warpscan cell
+	 */
+	__device__ __forceinline__ T CumulativePartial() const
+	{
+		return warpscan[1][CUMULATIVE_THREAD];
+	}
+
+
+	/**
+	 * Return the queue reservation in the first warpscan cell
+	 */
+	__device__ __forceinline__ T QueueReservation() const
+	{
+		return warpscan[1][QUEUE_RSVN_THREAD];
+	}
+
+
+	/**
+	 *
+	 */
+	__device__ __forceinline__ T* SmemPool()
+	{
+		return smem_pool;
+	}
+};
+
+
+/**
+ * Operational details for threads working in a hierarchical raking grid
+ */
+template <
+	typename RakingGrid,
+	typename SecondaryRakingGrid>
+struct RakingDetails : RakingGrid
+{
+	enum {
+		CUMULATIVE_THREAD 	= RakingGrid::RAKING_THREADS - 1,
+		WARP_THREADS 		= B40C_WARP_THREADS(RakingSoaDetails::CUDA_ARCH)
+	};
+
+	typedef typename RakingGrid::T T;													// Partial type
+	typedef typename RakingGrid::WarpscanT (*WarpscanStorage)[WARP_THREADS];			// Warpscan storage type
+	typedef RakingDetails<SecondaryRakingGrid> SecondaryRakingDetails;					// Type of next-level grid raking details
+
+
+	/**
+	 * The location in the smem grid where the calling thread can insert/extract
+	 * its partial for raking reduction/scan into the first lane.
+	 */
+	typename RakingGrid::LanePartial lane_partial;
+
+	/**
+	 * Returns the location in the smem grid where the calling thread can begin serial
+	 * raking/scanning
+	 */
+	typename RakingGrid::RakingSegment raking_segment;
+
+	/**
+	 * Secondary-level grid details
+	 */
+	SecondaryRakingDetails secondary_details;
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ RakingDetails(
+		T *smem_pool) :
+			lane_partial(RakingGrid::MyLanePartial(smem_pool)),							// set lane partial pointer
+			secondary_details(
+				smem_pool + RakingGrid::RAKING_ELEMENTS)
+	{
+		if (threadIdx.x < RakingGrid::RAKING_THREADS) {
+			// Set raking segment pointer
+			raking_segment = RakingGrid::MyRakingSegment(smem_pool);
+		}
+	}
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ RakingDetails(
+		T *smem_pool,
+		WarpscanStorage warpscan) :
+			lane_partial(RakingGrid::MyLanePartial(smem_pool)),							// set lane partial pointer
+			secondary_details(
+				smem_pool + RakingGrid::RAKING_ELEMENTS,
+				warpscan)
+	{
+		if (threadIdx.x < RakingGrid::RAKING_THREADS) {
+			// Set raking segment pointer
+			raking_segment = RakingGrid::MyRakingSegment(smem_pool);
+		}
+	}
+
+
+	/**
+	 * Constructor
+	 */
+	__device__ __forceinline__ RakingDetails(
+		T *smem_pool,
+		WarpscanStorage warpscan,
+		T warpscan_identity) :
+			lane_partial(RakingGrid::MyLanePartial(smem_pool)),							// set lane partial pointer
+			secondary_details(
+				smem_pool + RakingGrid::RAKING_ELEMENTS,
+				warpscan,
+				warpscan_identity)
+	{
+		if (threadIdx.x < RakingGrid::RAKING_THREADS) {
+			// Set raking segment pointer
+			raking_segment = RakingGrid::MyRakingSegment(smem_pool);
+		}
+	}
+
+
+	/**
+	 * Return the cumulative partial left in the final warpscan cell
+	 */
+	__device__ __forceinline__ T CumulativePartial() const
+	{
+		return secondary_details.CumulativePartial();
+	}
+
+	/**
+	 * Return the queue reservation in the first warpscan cell
+	 */
+	__device__ __forceinline__ T QueueReservation() const
+	{
+		return secondary_details.QueueReservation();
+	}
+
+	/**
+	 *
+	 */
+	__device__ __forceinline__ T* SmemPool()
+	{
+		return secondary_details.SmemPool();
+	}
+};
+
+
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/srts_grid.cuh
+++ b/include/b40c/util/srts_grid.cuh
@@ -1,0 +1,294 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * raking Grid Description
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/basic_utils.cuh>
+#include <b40c/util/numeric_traits.cuh>
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Description of a (typically) conflict-free serial-reduce-then-scan (raking) 
+ * shared-memory grid.
+ *
+ * A "lane" for reduction/scan consists of one value (i.e., "partial") per
+ * active thread.  A grid consists of one or more scan lanes. The lane(s)
+ * can be sequentially "raked" by the specified number of raking threads
+ * (e.g., for upsweep reduction or downsweep scanning), where each raking
+ * thread progresses serially through a segment that is its share of the
+ * total grid.
+ *
+ * Depending on how the raking threads are further reduced/scanned, the lanes
+ * can be independent (i.e., only reducing the results from every
+ * SEGS_PER_LANE raking threads), or fully dependent (i.e., reducing the
+ * results from every raking thread)
+ *
+ * Must have at least as many raking threads as lanes (i.e., at least one
+ * raking thread for each lane).
+ *
+ * If (there are prefix dependences between lanes) AND (more than one warp
+ * of raking threads is specified), a secondary raking grid will
+ * be typed-out in order to facilitate communication between warps of raking
+ * threads.
+ *
+ * (N.B.: Typically two-level grids are a losing performance proposition)
+ */
+template <
+	int _CUDA_ARCH,
+	typename _T,									// Type of items we will be reducing/scanning
+	int _LOG_ACTIVE_THREADS, 						// Number of threads placing a lane partial (i.e., the number of partials per lane)
+	int _LOG_SCAN_LANES,							// Number of scan lanes
+	int _LOG_RAKING_THREADS, 						// Number of threads used for raking (typically 1 warp)
+	bool _DEPENDENT_LANES>							// If there are prefix dependences between lanes (i.e., downsweeping will incorporate aggregates from previous lanes)
+
+struct RakingGrid
+{
+	// Type of items we will be reducing/scanning
+	typedef _T T;
+	
+	// Warpscan type (using volatile storage for built-in types allows us to omit thread-fence
+	// operations during warp-synchronous code)
+	typedef typename util::If<
+		(util::NumericTraits<T>::REPRESENTATION == util::NOT_A_NUMBER),
+		T,
+		volatile T>::Type WarpscanT;
+
+	// N.B.: We use an enum type here b/c of a NVCC-win compiler bug where the
+	// compiler can't handle ternary expressions in static-const fields having
+	// both evaluation targets as local const expressions.
+	enum {
+
+		CUDA_ARCH						= _CUDA_ARCH,
+
+		// Number of scan lanes
+		LOG_SCAN_LANES					= _LOG_SCAN_LANES,
+		SCAN_LANES						= 1 <<LOG_SCAN_LANES,
+
+		// Number number of partials per lane
+		LOG_PARTIALS_PER_LANE 			= _LOG_ACTIVE_THREADS,
+		PARTIALS_PER_LANE				= 1 << LOG_PARTIALS_PER_LANE,
+
+		// Number of raking threads
+		LOG_RAKING_THREADS				= _LOG_RAKING_THREADS,
+		RAKING_THREADS					= 1 << LOG_RAKING_THREADS,
+
+		// Number of raking threads per lane
+		LOG_RAKING_THREADS_PER_LANE		= LOG_RAKING_THREADS - LOG_SCAN_LANES,			// must be positive!
+		RAKING_THREADS_PER_LANE			= 1 << LOG_RAKING_THREADS_PER_LANE,
+
+		// Partials to be raked per raking thread
+		LOG_PARTIALS_PER_SEG 			= LOG_PARTIALS_PER_LANE - LOG_RAKING_THREADS_PER_LANE,
+		PARTIALS_PER_SEG 				= 1 << LOG_PARTIALS_PER_SEG,
+
+		// Number of partials that we can put in one stripe across the shared memory banks
+		LOG_PARTIALS_PER_BANK_ARRAY		= B40C_LOG_MEM_BANKS(CUDA_ARCH) +
+											B40C_LOG_BANK_STRIDE_BYTES(CUDA_ARCH) -
+											Log2<sizeof(T)>::VALUE,
+		PARTIALS_PER_BANK_ARRAY			= 1 << LOG_PARTIALS_PER_BANK_ARRAY,
+
+		LOG_SEGS_PER_BANK_ARRAY 		= B40C_MAX(0, LOG_PARTIALS_PER_BANK_ARRAY - LOG_PARTIALS_PER_SEG),
+		SEGS_PER_BANK_ARRAY				= 1 << LOG_SEGS_PER_BANK_ARRAY,
+
+		// Whether or not one warp of raking threads can rake entirely in one stripe across the shared memory banks
+		NO_PADDING = (LOG_SEGS_PER_BANK_ARRAY >= B40C_LOG_WARP_THREADS(CUDA_ARCH)),
+
+		// Number of raking segments we can have without padding (i.e., a "row")
+		LOG_SEGS_PER_ROW 				= (NO_PADDING) ?
+											LOG_RAKING_THREADS :												// All raking threads (segments)
+											B40C_MIN(LOG_RAKING_THREADS_PER_LANE, LOG_SEGS_PER_BANK_ARRAY),		// Up to as many segments per lane (all lanes must have same amount of padding to have constant lane stride)
+		SEGS_PER_ROW					= 1 << LOG_SEGS_PER_ROW,
+
+		// Number of partials per row
+		LOG_PARTIALS_PER_ROW			= LOG_SEGS_PER_ROW + LOG_PARTIALS_PER_SEG,
+		PARTIALS_PER_ROW				= 1 << LOG_PARTIALS_PER_ROW,
+
+		// Number of partials that we must use to "pad out" one memory bank
+		LOG_BANK_PADDING_PARTIALS		= B40C_MAX(0, B40C_LOG_BANK_STRIDE_BYTES(CUDA_ARCH) - Log2<sizeof(T)>::VALUE),
+		BANK_PADDING_PARTIALS			= 1 << LOG_BANK_PADDING_PARTIALS,
+
+		// Number of partials that we must use to "pad out" a lane to one memory bank
+		LANE_PADDING_PARTIALS			= B40C_MAX(0, PARTIALS_PER_BANK_ARRAY - PARTIALS_PER_LANE),
+
+		// Number of partials (including padding) per "row"
+		PADDED_PARTIALS_PER_ROW			= (NO_PADDING) ?
+											PARTIALS_PER_ROW :
+											PARTIALS_PER_ROW + LANE_PADDING_PARTIALS + BANK_PADDING_PARTIALS,
+
+		// Number of rows in the grid
+		LOG_ROWS						= LOG_RAKING_THREADS - LOG_SEGS_PER_ROW,
+		ROWS 							= 1 << LOG_ROWS,
+
+		// Number of rows per lane (always at least one)
+		LOG_ROWS_PER_LANE				= B40C_MAX(0, LOG_RAKING_THREADS_PER_LANE - LOG_SEGS_PER_ROW),
+		ROWS_PER_LANE					= 1 << LOG_ROWS_PER_LANE,
+
+		// Padded stride between lanes (in partials)
+		LANE_STRIDE						= (NO_PADDING) ?
+											PARTIALS_PER_LANE :
+											ROWS_PER_LANE * PADDED_PARTIALS_PER_ROW,
+
+		// Number of elements needed to back this level of the raking grid
+		RAKING_ELEMENTS					= ROWS * PADDED_PARTIALS_PER_ROW,
+	};
+
+	// If there are prefix dependences between lanes, a secondary raking grid
+	// type will be needed in the event we have more than one warp of raking threads
+
+	typedef typename If<_DEPENDENT_LANES && (LOG_RAKING_THREADS > B40C_LOG_WARP_THREADS(CUDA_ARCH)),
+		RakingGrid<										// Yes secondary grid
+			CUDA_ARCH,
+			T,													// Partial type
+			LOG_RAKING_THREADS,									// Depositing threads (the primary raking threads)
+			0,													// 1 lane (the primary raking threads only make one deposit)
+			B40C_LOG_WARP_THREADS(CUDA_ARCH),					// Raking threads (1 warp)
+			false>,												// There is only one lane, so there are no inter-lane prefix dependences
+		NullType>										// No secondary grid
+			::Type SecondaryGrid;
+
+
+	/**
+	 * Utility class for totaling the SMEM elements needed for an raking grid hierarchy
+	 */
+	template <typename RakingGrid, int __dummy = 0>
+	struct TotalRakingElements
+	{
+		// Recurse
+		enum { VALUE = RakingGrid::RAKING_ELEMENTS + TotalRakingElements<typename RakingGrid::SecondaryGrid>::VALUE };
+	};
+	template <int __dummy>
+	struct TotalRakingElements<NullType, __dummy>
+	{
+		// Terminate
+		enum { VALUE = 0 };
+	};
+
+
+	enum {
+		// Total number of smem raking elements needed back this hierarchy
+		// of raking grids (may be reused for other purposes)
+		TOTAL_RAKING_ELEMENTS = TotalRakingElements<RakingGrid>::VALUE,
+	};
+
+
+	/**
+	 * Type of pointer for inserting partials into lanes, e.g., lane_partial[LANE][0] = ...
+	 */
+	typedef T (*LanePartial)[LANE_STRIDE];
+
+
+	/**
+	 * Type of pointer for raking across lane segments
+	 */
+	typedef T* RakingSegment;
+
+
+	/**
+	 * Returns the location in the smem grid where the calling thread can insert/extract
+	 * its partial for raking reduction/scan into the first lane.  Positions in subsequent
+	 * lanes can be obtained via increments of LANE_STRIDE.
+	 */
+	static __host__ __device__ __forceinline__  LanePartial MyLanePartial(T *smem)
+	{
+		int row = threadIdx.x >> LOG_PARTIALS_PER_ROW;
+		int col = threadIdx.x & (PARTIALS_PER_ROW - 1);
+
+		return (LanePartial) (smem + (row * PADDED_PARTIALS_PER_ROW) + col);
+	}
+
+
+	/**
+	 * Returns the location in the smem grid where the calling thread can begin serial
+	 * raking/scanning
+	 */
+	static __host__ __device__ __forceinline__  RakingSegment MyRakingSegment(T *smem)
+	{
+		int row = threadIdx.x >> LOG_SEGS_PER_ROW;
+		int col = (threadIdx.x & (SEGS_PER_ROW - 1)) << LOG_PARTIALS_PER_SEG;
+		return (RakingSegment) (smem + (row * PADDED_PARTIALS_PER_ROW) + col);
+	}
+
+
+	/**
+	 * Displays configuration to standard out
+	 */
+	static __host__ __device__ __forceinline__ void Print()
+	{
+		printf("SCAN_LANES: %d\n"
+				"PARTIALS_PER_LANE: %d\n"
+				"RAKING_THREADS: %d\n"
+				"RAKING_THREADS_PER_LANE: %d\n"
+				"PARTIALS_PER_SEG: %d\n"
+				"PARTIALS_PER_BANK_ARRAY: %d\n"
+				"SEGS_PER_BANK_ARRAY: %d\n"
+				"NO_PADDING: %d\n"
+				"SEGS_PER_ROW: %d\n"
+				"PARTIALS_PER_ROW: %d\n"
+				"BANK_PADDING_PARTIALS: %d\n"
+				"LANE_PADDING_PARTIALS: %d\n"
+				"PADDED_PARTIALS_PER_ROW: %d\n"
+				"ROWS: %d\n"
+				"ROWS_PER_LANE: %d\n"
+				"LANE_STRIDE: %d\n"
+				"RAKING_ELEMENTS: %d\n",
+			SCAN_LANES,
+			PARTIALS_PER_LANE,
+			RAKING_THREADS,
+			RAKING_THREADS_PER_LANE,
+			PARTIALS_PER_SEG,
+			PARTIALS_PER_BANK_ARRAY,
+			SEGS_PER_BANK_ARRAY,
+			NO_PADDING,
+			SEGS_PER_ROW,
+			PARTIALS_PER_ROW,
+			BANK_PADDING_PARTIALS,
+			LANE_PADDING_PARTIALS,
+			PADDED_PARTIALS_PER_ROW,
+			ROWS,
+			ROWS_PER_LANE,
+			LANE_STRIDE,
+			RAKING_ELEMENTS);
+	}
+};
+
+
+
+
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/srts_soa_details.cuh
+++ b/include/b40c/util/srts_soa_details.cuh
@@ -1,0 +1,308 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Operational details for threads working in an SOA (structure of arrays)
+ * raking grid
+ ******************************************************************************/
+
+#pragma once
+
+#include <b40c/util/cuda_properties.cuh>
+#include <b40c/util/basic_utils.cuh>
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Operational details for threads working in an raking grid
+ */
+template <
+	typename TileTuple,
+	typename RakingGridTuple,
+	int Grids = RakingGridTuple::NUM_FIELDS,
+	typename SecondaryRakingGridTuple = typename If<
+		Equals<NullType, typename RakingGridTuple::T0::SecondaryGrid>::VALUE,
+		NullType,
+		Tuple<
+			typename RakingGridTuple::T0::SecondaryGrid,
+			typename RakingGridTuple::T1::SecondaryGrid> >::Type>
+struct RakingSoaDetails;
+
+
+/**
+ * Two-field raking details
+ */
+template <
+	typename _TileTuple,
+	typename RakingGridTuple>
+struct RakingSoaDetails<
+	_TileTuple,
+	RakingGridTuple,
+	2,
+	NullType> : RakingGridTuple::T0
+{
+	enum {
+		CUMULATIVE_THREAD 	= RakingSoaDetails::RAKING_THREADS - 1,
+		WARP_THREADS 		= B40C_WARP_THREADS(RakingSoaDetails::CUDA_ARCH)
+	};
+
+	// Simple SOA tuple "slice" type
+	typedef _TileTuple TileTuple;
+
+	// SOA type of raking lanes
+	typedef Tuple<
+		typename TileTuple::T0*,
+		typename TileTuple::T1*> GridStorageSoa;
+
+	// SOA type of warpscan storage
+	typedef Tuple<
+		typename RakingGridTuple::T0::WarpscanT (*)[WARP_THREADS],
+		typename RakingGridTuple::T1::WarpscanT (*)[WARP_THREADS]> WarpscanSoa;
+
+	// SOA type of partial-insertion pointers
+	typedef Tuple<
+		typename RakingGridTuple::T0::LanePartial,
+		typename RakingGridTuple::T1::LanePartial> LaneSoa;
+
+	// SOA type of raking segments
+	typedef Tuple<
+		typename RakingGridTuple::T0::RakingSegment,
+		typename RakingGridTuple::T1::RakingSegment> RakingSoa;
+
+	typedef NullType SecondaryRakingSoaDetails;
+
+	/**
+	 * Warpscan storages
+	 */
+	WarpscanSoa warpscan_partials;
+
+	/**
+	 * Lane insertion/extraction pointers.
+	 */
+	LaneSoa lane_partials;
+
+	/**
+	 * Raking pointers
+	 */
+	RakingSoa raking_segments;
+
+
+	/**
+	 * Constructor
+	 */
+	__host__ __device__ __forceinline__ RakingSoaDetails(
+		GridStorageSoa smem_pools,
+		WarpscanSoa warpscan_partials) :
+
+			warpscan_partials(warpscan_partials),
+			lane_partials(												// set lane partial pointer
+				RakingGridTuple::T0::MyLanePartial(smem_pools.t0),
+				RakingGridTuple::T1::MyLanePartial(smem_pools.t1))
+	{
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Set raking segment pointers
+			raking_segments = RakingSoa(
+				RakingGridTuple::T0::MyRakingSegment(smem_pools.t0),
+				RakingGridTuple::T1::MyRakingSegment(smem_pools.t1));
+		}
+	}
+
+
+	/**
+	 * Constructor
+	 */
+	__host__ __device__ __forceinline__ RakingSoaDetails(
+		GridStorageSoa smem_pools,
+		WarpscanSoa warpscan_partials,
+		TileTuple soa_tuple_identity) :
+
+			warpscan_partials(warpscan_partials),
+			lane_partials(												// set lane partial pointer
+				RakingGridTuple::T0::MyLanePartial(smem_pools.t0),
+				RakingGridTuple::T1::MyLanePartial(smem_pools.t1))
+	{
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Set raking segment pointers
+			raking_segments = RakingSoa(
+				RakingGridTuple::T0::MyRakingSegment(smem_pools.t0),
+				RakingGridTuple::T1::MyRakingSegment(smem_pools.t1));
+
+			// Initialize first half of warpscan storages to identity
+			warpscan_partials.Set(soa_tuple_identity, 0, threadIdx.x);
+		}
+	}
+
+
+	/**
+	 * Return the cumulative partial left in the final warpscan cell
+	 */
+	__device__ __forceinline__ TileTuple CumulativePartial()
+	{
+		TileTuple retval;
+		warpscan_partials.Get(retval, 1, CUMULATIVE_THREAD);
+		return retval;
+	}
+};
+
+
+
+/**
+ * Two-field raking details
+ */
+template <
+	typename _TileTuple,
+	typename RakingGridTuple,
+	typename SecondaryRakingGridTuple>
+struct RakingSoaDetails<
+	_TileTuple,
+	RakingGridTuple,
+	2,
+	SecondaryRakingGridTuple> : RakingGridTuple::T0
+{
+	enum {
+		CUMULATIVE_THREAD 	= RakingSoaDetails::RAKING_THREADS - 1,
+		WARP_THREADS 		= B40C_WARP_THREADS(RakingSoaDetails::CUDA_ARCH)
+	};
+
+	// Simple SOA tuple "slice" type
+	typedef _TileTuple TileTuple;
+
+	// SOA type of raking lanes
+	typedef Tuple<
+		typename TileTuple::T0*,
+		typename TileTuple::T1*> GridStorageSoa;
+
+	// SOA type of warpscan storage
+	typedef Tuple<
+		typename RakingGridTuple::T0::WarpscanT (*)[WARP_THREADS],
+		typename RakingGridTuple::T1::WarpscanT (*)[WARP_THREADS]> WarpscanSoa;
+
+	// SOA type of partial-insertion pointers
+	typedef Tuple<
+		typename RakingGridTuple::T0::LanePartial,
+		typename RakingGridTuple::T1::LanePartial> LaneSoa;
+
+	// SOA type of raking segments
+	typedef Tuple<
+		typename RakingGridTuple::T0::RakingSegment,
+		typename RakingGridTuple::T1::RakingSegment> RakingSoa;
+
+	// SOA type of secondary details
+	typedef RakingSoaDetails<TileTuple, SecondaryRakingGridTuple> SecondaryRakingSoaDetails;
+
+	/**
+	 * Lane insertion/extraction pointers.
+	 */
+	LaneSoa lane_partials;
+
+	/**
+	 * Raking pointers
+	 */
+	RakingSoa raking_segments;
+
+	/**
+	 * Secondary-level grid details
+	 */
+	SecondaryRakingSoaDetails secondary_details;
+
+
+	/**
+	 * Constructor
+	 */
+	__host__ __device__ __forceinline__ RakingSoaDetails(
+		GridStorageSoa smem_pools,
+		WarpscanSoa warpscan_partials) :
+
+			lane_partials(												// set lane partial pointer
+				RakingGridTuple::T0::MyLanePartial(smem_pools.t0),
+				RakingGridTuple::T1::MyLanePartial(smem_pools.t1)),
+			secondary_details(
+				GridStorageSoa(
+					smem_pools.t0 + RakingGridTuple::T0::RAKING_ELEMENTS,
+					smem_pools.t1 + RakingGridTuple::T1::RAKING_ELEMENTS),
+				warpscan_partials)
+	{
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Set raking segment pointers
+			raking_segments = RakingSoa(
+				RakingGridTuple::T0::MyRakingSegment(smem_pools.t0),
+				RakingGridTuple::T1::MyRakingSegment(smem_pools.t1));
+		}
+	}
+
+
+	/**
+	 * Constructor
+	 */
+	__host__ __device__ __forceinline__ RakingSoaDetails(
+		GridStorageSoa smem_pools,
+		WarpscanSoa warpscan_partials,
+		TileTuple soa_tuple_identity) :
+
+			lane_partials(												// set lane partial pointer
+				RakingGridTuple::T0::MyLanePartial(smem_pools.t0),
+				RakingGridTuple::T1::MyLanePartial(smem_pools.t1)),
+			secondary_details(
+				GridStorageSoa(
+					smem_pools.t0 + RakingGridTuple::T0::RAKING_ELEMENTS,
+					smem_pools.t1 + RakingGridTuple::T1::RAKING_ELEMENTS),
+				warpscan_partials)
+	{
+		if (threadIdx.x < RakingSoaDetails::RAKING_THREADS) {
+
+			// Set raking segment pointers
+			raking_segments = RakingSoa(
+				RakingGridTuple::T0::MyRakingSegment(smem_pools.t0),
+				RakingGridTuple::T1::MyRakingSegment(smem_pools.t1));
+		}
+	}
+
+
+	/**
+	 * Return the cumulative partial left in the final warpscan cell
+	 */
+	__device__ __forceinline__ TileTuple CumulativePartial()
+	{
+		return secondary_details.CumulativePartial();
+	}
+};
+
+
+
+
+
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/b40c/util/vector_types.cuh
+++ b/include/b40c/util/vector_types.cuh
@@ -1,0 +1,124 @@
+/******************************************************************************
+ * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2013, NVIDIA CORPORATION.  All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Utility code for working with vector types of arbitary typenames
+ ******************************************************************************/
+
+#pragma once
+
+namespace b40c {
+namespace util {
+
+
+/**
+ * Specializations of this vector-type template can be used to indicate the 
+ * proper vector type for a given typename and vector size. We can use the ::Type
+ * typedef to declare and work with the appropriate vectorized type for a given 
+ * typename T.
+ * 
+ * For example, consider the following copy kernel that uses vec-2 loads 
+ * and stores:
+ * 
+ * 		template <typename T>
+ * 		__global__ void CopyKernel(T *d_in, T *d_out) 
+ * 		{
+ * 			typedef typename VecType<T, 2>::Type Vector;
+ *
+ * 			Vector datum;
+ * 
+ * 			Vector *d_in_v2 = (Vector *) d_in;
+ * 			Vector *d_out_v2 = (Vector *) d_out;
+ * 
+ * 			datum = d_in_v2[threadIdx.x];
+ * 			d_out_v2[threadIdx.x] = datum;
+ * 		} 
+ * 
+ */
+template <typename T, int vec_elements> struct VecType;
+
+/**
+ * Partially-specialized generic vec1 type 
+ */
+template <typename T> 
+struct VecType<T, 1> {
+	T x;
+	typedef VecType<T, 1> Type;
+};
+
+/**
+ * Partially-specialized generic vec2 type 
+ */
+template <typename T> 
+struct VecType<T, 2> {
+	T x;
+	T y;
+	typedef VecType<T, 2> Type;
+};
+
+/**
+ * Partially-specialized generic vec4 type 
+ */
+template <typename T> 
+struct VecType<T, 4> {
+	T x;
+	T y;
+	T z;
+	T w;
+	typedef VecType<T, 4> Type;
+};
+
+
+/**
+ * Macro for expanding partially-specialized built-in vector types
+ */
+#define B40C_DEFINE_VECTOR_TYPE(base_type,short_type)                           \
+  template<> struct VecType<base_type, 1> { typedef short_type##1 Type; };      \
+  template<> struct VecType<base_type, 2> { typedef short_type##2 Type; };      \
+  template<> struct VecType<base_type, 4> { typedef short_type##4 Type; };     
+
+B40C_DEFINE_VECTOR_TYPE(char,               char)
+B40C_DEFINE_VECTOR_TYPE(signed char,        char)
+B40C_DEFINE_VECTOR_TYPE(short,              short)
+B40C_DEFINE_VECTOR_TYPE(int,                int)
+B40C_DEFINE_VECTOR_TYPE(long,               long)
+B40C_DEFINE_VECTOR_TYPE(long long,          longlong)
+B40C_DEFINE_VECTOR_TYPE(unsigned char,      uchar)
+B40C_DEFINE_VECTOR_TYPE(unsigned short,     ushort)
+B40C_DEFINE_VECTOR_TYPE(unsigned int,       uint)
+B40C_DEFINE_VECTOR_TYPE(unsigned long,      ulong)
+B40C_DEFINE_VECTOR_TYPE(unsigned long long, ulonglong)
+B40C_DEFINE_VECTOR_TYPE(float,              float)
+B40C_DEFINE_VECTOR_TYPE(double,             double)
+
+#undef B40C_DEFINE_VECTOR_TYPE
+
+
+} // namespace util
+} // namespace b40c
+

--- a/include/loops/transform.h
+++ b/include/loops/transform.h
@@ -99,7 +99,8 @@
         (65,simdOps::Tan) ,\
         (66,simdOps::TanDerivative) ,\
         (67,simdOps::SELU) ,\
-        (68,simdOps::SELUDerivative)
+        (68,simdOps::SELUDerivative) ,\
+        (70,simdOps::Reverse)
 
 
 

--- a/include/ops/specials.h
+++ b/include/ops/specials.h
@@ -465,7 +465,7 @@ void quickSort_parallel_internal(T* array, int *xShapeInfo, int left, int right,
 }
 
 template<typename T>
-void quickSort_parallel(T* array, int *xShapeInfo, int lenArray, int numThreads, bool desending){
+void quickSort_parallel(T* array, int *xShapeInfo, int lenArray, int numThreads, bool descending){
 
     int cutoff = 1000;
 
@@ -473,10 +473,29 @@ void quickSort_parallel(T* array, int *xShapeInfo, int lenArray, int numThreads,
     {
 #pragma omp single nowait
         {
-            quickSort_parallel_internal(array, xShapeInfo, 0, lenArray-1, cutoff, desending);
+            quickSort_parallel_internal(array, xShapeInfo, 0, lenArray-1, cutoff, descending);
         }
     }
 
+}
+
+int nextPowerOf2(int number) {
+    int pos = 0;
+
+    while (number > 0) {
+        pos++;
+        number = number >> 1;
+    }
+    return (int) pow(2, pos);
+}
+
+int lastPowerOf2(int number) {
+    int p = 1;
+    while (p <= number)
+        p <<= 1;
+
+    p >>= 1;
+    return p;
 }
 
 

--- a/include/ops/specials_cuda.h
+++ b/include/ops/specials_cuda.h
@@ -1,0 +1,152 @@
+//
+// @author raver119@gmail.com
+//
+
+#ifndef PROJECT_SPECIALS_CUDA_H
+#define PROJECT_SPECIALS_CUDA_H
+
+#ifdef __CUDACC__
+
+__device__ inline int getDevicePosition(int *xShapeInfo, int index) {
+    int xEWS = shape::elementWiseStride(xShapeInfo);
+
+    if (xEWS == 1) {
+        return index;
+    } else if (xEWS > 1) {
+        return index * xEWS;
+    } else {
+        int xCoord[MAX_RANK];
+        int xRank = shape::rank(xShapeInfo);
+        int *xShape = shape::shapeOf(xShapeInfo);
+        int *xStride = shape::stride(xShapeInfo);
+
+        shape::ind2subC(xRank, xShape, index, xCoord);
+        int xOffset = shape::getOffset(0, xShape, xStride, xCoord, xRank);
+
+        return xOffset;
+    }
+}
+
+template<typename T>
+__device__
+ void bitonic_sort_step(T *x, int *xShapeInfo, int j, int k, bool descending) {
+  unsigned int i, ixj; /* Sorting partners: i and ixj */
+  i = threadIdx.x + blockDim.x * blockIdx.x;
+  ixj = i^j;
+
+  /* The threads with the lowest ids sort the array. */
+  if ((ixj)>i) {
+    int posI = getDevicePosition(xShapeInfo, i);
+    int posIXJ = getDevicePosition(xShapeInfo, ixj);
+
+    if ((i&k)==0) {
+      /* Sort ascending */
+      if (x[posI]>x[posIXJ]) {
+        /* exchange(i,ixj); */
+        T temp = x[posI];
+        x[posI] = x[posIXJ];
+        x[posIXJ] = temp;
+      }
+    }
+    if ((i&k)!=0) {
+      /* Sort descending */
+      if (x[posI]<x[posIXJ]) {
+        /* exchange(i,ixj); */
+        T temp = x[posI];
+        x[posI] = x[posIXJ];
+        x[posIXJ] = temp;
+      }
+    }
+  }
+}
+
+
+template<typename T>
+__device__
+void odd_even_sort(T *x, int *xShapeInfo, int length, bool descending) {
+    int tid = threadIdx.x;
+
+    int xLength = length;
+
+    int rem = xLength % 2;
+    for(int i=0;i < (xLength / 2) + rem; i++) {
+
+            if((!(tid & 1)) && tid < xLength - 1) {
+                if(x[tid] > x[tid+1]) {
+                    T temp = x[tid+1];
+                    x[tid+1] = x[tid];
+                    x[tid] = temp;
+                }
+            }
+            __syncthreads();
+
+            if((tid & 1) && tid < xLength - 1) {
+                if(x[tid] > x[tid+1]) {
+                    T temp = x[tid+1];
+                    x[tid+1] = x[tid];
+                    x[tid] = temp;
+                }
+            }
+            __syncthreads();
+    }
+}
+
+
+template<typename T>
+__device__
+void oes_tad(T *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
+    __shared__ int xLength;
+    __shared__ int xTadLength;
+    __shared__ int numTads;
+    __shared__ T *dx;
+    if (threadIdx.x == 0) {
+        xLength = shape::length(xShapeInfo);
+        xTadLength = shape::tadLength(xShapeInfo, dimension, dimensionLength);
+        numTads = xLength / xTadLength;
+    }
+    __syncthreads();
+
+    for (int r = blockIdx.x; r < numTads; r += gridDim.x) {
+        if (threadIdx.x == 0) {
+            dx = x + tadOffsets[r];
+        }
+        __syncthreads();
+
+        odd_even_sort<T>(dx, tadShapeInfo, xTadLength, descending);
+        __syncthreads();
+    }
+}
+
+
+
+extern "C" __global__ void cudaSortFloat(float *x, int *xShapeInfo, int j, int k, bool descending) {
+    //bitonic_sort_step<float>(x, xShapeInfo, j, k, descending);
+    //odd_even_sort<float>(x, xShapeInfo, descending);
+}
+
+extern "C" __global__ void cudaSortDouble(double *x, int *xShapeInfo, int j, int k, bool descending) {
+    //bitonic_sort_step<double>(x, xShapeInfo, j, k, descending);
+}
+
+extern "C" __global__ void cudaSortHalf(float16 *x, int *xShapeInfo, int j, int k, bool descending) {
+    //bitonic_sort_step<float16>(x, xShapeInfo, j, k, descending);
+}
+
+extern "C" __global__ void cudaSortTadFloat(float *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
+    //bitonic_sort_step<float>(x, xShapeInfo, j, k, descending);
+    oes_tad<float>(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets,  descending);
+}
+
+extern "C" __global__ void cudaSortTadDouble(double *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
+    //bitonic_sort_step<float>(x, xShapeInfo, j, k, descending);
+    oes_tad<double>(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending);
+}
+
+extern "C" __global__ void cudaSortTadHalf(float16 *x, int *xShapeInfo, int *dimension, int dimensionLength, int *tadShapeInfo, int *tadOffsets, bool descending) {
+    //bitonic_sort_step<float>(x, xShapeInfo, j, k, descending);
+    oes_tad<float16>(x, xShapeInfo, dimension, dimensionLength, tadShapeInfo, tadOffsets, descending);
+}
+
+#endif
+
+#endif //PROJECT_SPECIALS_CUDA_H

--- a/include/types/float16.h
+++ b/include/types/float16.h
@@ -335,6 +335,10 @@ local_def half cpu_float2half_rn(float f)
   template <class T>
   local_def float16 operator-(const float16& a, const T& b) { return float16((float)a - (float)b); }
 
+
+//  template <class T>
+//  local_def int operator&(const T& a, const float16& b) { return a & (float)b; }
+
   template <class T>
   local_def float16 operator*(const float16& a, const T& b) { return float16((float)a * (float)b); }
 


### PR DESCRIPTION
Native key-only sort for libnd4j:
- Parallel quicksort for CPU backend (both simple sort, and sort along dimension)
- Odd-even sort for CUDA for sort along dimension
- Radix sort for CUDA large float & double arrays (not a views)
- Bitonic 2^N + arbitrary sort for CUDA fp16, float & double arrays. And for views.
