### PR TITLE
Update document for MacOS build

### DIFF
--- a/macOSx10 (CPU only).md
+++ b/macOSx10 (CPU only).md
@@ -37,11 +37,11 @@ brew insall gcc
 7. `cd $LIBND4J_HOME` 
 8. `./buildnativeoperations.sh` (This will give a LOT of warnings, dont fret, if the last line is something like `[100%] Built target nd4j`)
 
-9. Now download the latest JavaCPP (https://github.com/bytedeco/javacpp) and build it using `mvn clean install -X -DskipTests -Dmaven.javadoc.skip=true`
+9. make sure you have maven installed and accessible via terminal at time its available to intelliJ but but via terminal ( try `mvn --version`) if you dont have `brew install maven`
 
-10. Now download the latest nd4j files from the repo
+10. Now download the latest JavaCPP (https://github.com/bytedeco/javacpp) and build it using `mvn clean install -X -DskipTests -Dmaven.javadoc.skip=true`
 
-11. make sure you have maven installed and accessible via terminal at time its available to intelliJ but but via terminal ( try `mvn --version`) if you dont have `brew install maven`
+11. Now download the latest [nd4j](https://github.com/deeplearning4j/nd4j.git) project from the repo
 
 12. inside the nd4j directory run `mvn clean install -X -DskipTests -Dmaven.javadoc.skip=true -pl '!org.nd4j:nd4j-cuda-8.0,!org.nd4j:nd4j-tests,!org.nd4j:nd4j-cuda-8.0-platform'` this should mainly fly by.
 


### PR DESCRIPTION
I updated some parts of document about MacOS build.
- Change order for maven install. It needs to be shown before 'javacpp' build because it also needs maven installed
- Fix some guide for nd4j

Please look on. Thanks!