### PR TITLE
Minor fixes for cnpy

### DIFF
--- a/blas/NativeOps.h
+++ b/blas/NativeOps.h
@@ -2822,6 +2822,15 @@ public:
     Nd4jPointer numpyFromFile(std::string path);
 
     /**
+     * This method releases pointer.
+     *
+     * PLEASE NOTE: This method shouldn't be ever called for anything but numpy arrays created from FILE
+     *
+     * @param npyArray
+     */
+    void releaseNumpy(Nd4jPointer npyArray);
+
+    /**
      * Return the length of a shape buffer
      * based on the pointer
      * @param buffer  the buffer pointer to check

--- a/blas/cpu/NativeOps.cpp
+++ b/blas/cpu/NativeOps.cpp
@@ -2908,7 +2908,7 @@ Nd4jPointer NativeOps::shapeBufferForNumpy(Nd4jPointer npyArray) {
  */
 Nd4jPointer NativeOps::dataPointForNumpy(Nd4jPointer npyArray) {
     char *buff = reinterpret_cast<char *>(npyArray);
-    printf("Pointer contents %s\n",buff);
+    //printf("Pointer contents %s\n",buff);
     cnpy::NpyArray arr = cnpy::loadNpyFromPointer(reinterpret_cast<char *>(npyArray));
     cnpy::NpyArray *arrPointer = &arr;
     char *data = arrPointer->data;
@@ -2958,6 +2958,10 @@ int NativeOps::elementSizeForNpyArray(Nd4jPointer npyArray) {
     int size = arrPointer->wordSize;
    // arrPointer->destruct();
     return size;
+}
+
+void NativeOps::releaseNumpy(Nd4jPointer npyArray) {
+    free((void *) npyArray);
 }
 
 /**


### PR DESCRIPTION
Minor fixes for cnpy:
- cuda backend should use the same code as native does
- memory release method should be assumed for fromFile use case