### PR TITLE
Shyrma zeta

### DIFF
--- a/include/ops/declarable/CustomOperations.h
+++ b/include/ops/declarable/CustomOperations.h
@@ -201,6 +201,7 @@ namespace nd4j {
         DECLARE_CONFIGURABLE_OP(invert_permutation, 1, 1, false, 0, 0);        
         DECLARE_CONFIGURABLE_OP(matrix_set_diag, 2, 1, false, 0, 0)
         DECLARE_CONFIGURABLE_OP(betainc, 3, 1, false, 0, 0)
+        DECLARE_CONFIGURABLE_OP(zeta, 2, 1, false, 0, 0)
 
         // grad ops
         DECLARE_CONFIGURABLE_OP(sigmoid_bp, 2, 1, true, 0, 0);

--- a/include/ops/declarable/generic/parity_ops/zeta.cpp
+++ b/include/ops/declarable/generic/parity_ops/zeta.cpp
@@ -1,0 +1,45 @@
+//
+// Created by Yurii Shyrma on 12.12.2017.
+//
+
+#include <ops/declarable/CustomOperations.h>
+#include <ops/declarable/helpers/zeta.h>
+
+namespace nd4j {
+    namespace ops {
+
+
+//////////////////////////////////////////////////////////////////////////
+// calculate the Hurwitz zeta function
+CONFIGURABLE_OP_IMPL(zeta, 2, 1, false, 0, 0) {
+
+	NDArray<T>* x = INPUT_VARIABLE(0);
+    NDArray<T>* q = INPUT_VARIABLE(1);
+
+	NDArray<T>* output   = OUTPUT_VARIABLE(0);
+
+    if(!x->isSameShape(q))
+        throw "CONFIGURABLE_OP zeta: two input arrays must have the same shapes !";
+
+    int arrLen = x->lengthOf();
+
+    for(int i = 0; i < arrLen; ++i ) {
+        
+        if((*x)(i) <= (T)1.)
+            throw "CONFIGURABLE_OP zeta: all elements of x array must be > 1 !";
+        
+        if((*q)(i) <= (T)0.)
+            throw "CONFIGURABLE_OP zeta: all elements of q array must be > 0 !";
+    }
+
+    *output = helpers::zeta<T>(*x, *q);
+
+    return ND4J_STATUS_OK;
+}
+DECLARE_SYN(Zeta, zeta);
+
+
+
+}
+}
+

--- a/include/ops/declarable/helpers/cpu/betaInc.cpp
+++ b/include/ops/declarable/helpers/cpu/betaInc.cpp
@@ -35,6 +35,8 @@ const double weights[18] = {0.0055657196642445571,
 0.085346685739338721,0.085983275670394821};
 
 
+
+
 ///////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////
 // modified Lentz’s algorithm for continued fractions, 
@@ -42,6 +44,7 @@ const double weights[18] = {0.0055657196642445571,
 template <typename T> 
 static T continFract(const T a, const T b, const T x) {	
 
+	const T min = DataTypeUtils::min<T>() / DataTypeUtils::eps<T>();
     const T amu = a - (T)1.;
     const T apu = a + (T)1.;
     const T apb = a + b;
@@ -49,8 +52,8 @@ static T continFract(const T a, const T b, const T x) {
     // first iteration 
     T c = (T)1.;
     T d = (T)1. - apb * x / apu; 
-    if(math::nd4j_abs<T>(d) < DataTypeUtils::DataTypeUtils::min<T>())
-			d = DataTypeUtils::min<T>();
+    if(math::nd4j_abs<T>(d) < min)
+			d = min;
 	d = (T)1./d;
     T f = d;
          
@@ -64,13 +67,13 @@ static T continFract(const T a, const T b, const T x) {
 		val = i * (b - i) * x / ((amu + i2) * (a + i2));		
 
 		d = (T)(1.) + val * d;
-		if(math::nd4j_abs<T>(d) < DataTypeUtils::min<T>())
-			d = DataTypeUtils::min<T>();
+		if(math::nd4j_abs<T>(d) < min)
+			d = min;
 		d = (T)1. / d;
 
 		c = (T)(1.) + val / c;
-		if(math::nd4j_abs<T>(c) < DataTypeUtils::min<T>())
-			c = DataTypeUtils::min<T>();		
+		if(math::nd4j_abs<T>(c) < min)
+			c = min;		
 		
 		f *= c * d;
 
@@ -79,13 +82,13 @@ static T continFract(const T a, const T b, const T x) {
 		val = -(a + i) * (apb + i) * x / ((a + i2) * (apu + i2));
 		
 		d = (T)(1.) + val * d;
-		if(math::nd4j_abs<T>(d) < DataTypeUtils::min<T>())
-			d = DataTypeUtils::min<T>();
+		if(math::nd4j_abs<T>(d) < min)
+			d = min;
 		d = (T)1. / d;
 
 		c = (T)(1.) + val / c;
-		if(math::nd4j_abs<T>(c) < DataTypeUtils::min<T>())
-			c = DataTypeUtils::min<T>();
+		if(math::nd4j_abs<T>(c) < min)
+			c = min;
 
 		delta = c * d;
 		f *= delta;

--- a/include/ops/declarable/helpers/cpu/zeta.cpp
+++ b/include/ops/declarable/helpers/cpu/zeta.cpp
@@ -10,12 +10,17 @@ namespace nd4j {
 namespace ops {
 namespace helpers {
 
-const int maxIter = 1000000;				// max number of loop iterations 
+const int maxIter = 1000000;							// max number of loop iterations 
+const double machep =  1.11022302462515654042e-16;		
+
+// expansion coefficients for Euler-Maclaurin summation formula (2k)! / B2k, where B2k are Bernoulli numbers
+const double coeff[] = { 12.0,-720.0,30240.0,-1209600.0,47900160.0,-1.8924375803183791606e9,7.47242496e10,-2.950130727918164224e12, 1.1646782814350067249e14, -4.5979787224074726105e15, 1.8152105401943546773e17, -7.1661652561756670113e18};
+
 
 //////////////////////////////////////////////////////////////////////////
-// calculate the Hurwitz zeta function
+// slow implementation
 template <typename T>
-T zeta(const T x, const T q) {
+T zetaSlow(const T x, const T q) {
 	
 	const T precision = (T)1e-7; 									// function stops the calculation of series when next item is <= precision
 		
@@ -27,7 +32,6 @@ T zeta(const T x, const T q) {
 
 	T item;
 	T result = (T)0.;
-
 // #pragma omp declare reduction (add : double,float,float16 : omp_out += omp_in) initializer(omp_priv = (T)0.)
 // #pragma omp simd private(item) reduction(add:result)
 	for(int i = 0; i < maxIter; ++i) {		
@@ -44,7 +48,58 @@ T zeta(const T x, const T q) {
 
 
 //////////////////////////////////////////////////////////////////////////
-// calculate the Hurwitz zeta function
+// fast implementation, it is based on Euler-Maclaurin summation formula
+template <typename T>
+T zeta(const T x, const T q) {
+	
+	// if (x <= (T)1.) 
+	// 	throw("zeta function: x must be > 1 !");
+
+	// if (q <= (T)0.) 
+	// 	throw("zeta function: q must be > 0 !");
+
+	T a, b(0.), k, s, t, w;
+		
+	s = math::nd4j_pow(q, -x);
+	a = q;
+	int i = 0;
+
+	while(i < 9 || a <= (T)9.) {
+		i += 1;
+		a += (T)1.0;
+		b = math::nd4j_pow(a, -x);
+		s += b;
+		if(math::nd4j_abs(b / s) < (T)machep)
+			return s;
+	}
+	
+	w = a;
+	s += b * (w / (x - (T)1.) - (T)0.5);
+	a = (T)1.;
+	k = (T)0.;
+	
+	for(i = 0; i < 12; ++i) {
+		a *= x + k;
+		b /= w;
+		t = a * b / coeff[i];
+		s += t;
+		t = math::nd4j_abs(t / s);
+		
+		if(t < (T)machep)
+			return s;
+		
+		k += (T)1.;
+		a *= x + k;
+		b /= w;
+		k += (T)1.;
+	}
+	
+	return s;
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+// calculate the Hurwitz zeta function for arrays
 template <typename T>
 NDArray<T> zeta(const NDArray<T>& x, const NDArray<T>& q) {
 

--- a/include/ops/declarable/helpers/cpu/zeta.cpp
+++ b/include/ops/declarable/helpers/cpu/zeta.cpp
@@ -1,0 +1,73 @@
+//
+// Created by Yurii Shyrma on 12.12.2017
+//
+
+
+#include <DataTypeUtils.h>
+#include<ops/declarable/helpers/zeta.h>
+
+namespace nd4j {
+namespace ops {
+namespace helpers {
+
+const int maxIter = 1000000;				// max number of loop iterations 
+
+//////////////////////////////////////////////////////////////////////////
+// calculate the Hurwitz zeta function
+template <typename T>
+T zeta(const T x, const T q) {
+	
+	const T precision = (T)1e-7; 									// function stops the calculation of series when next item is <= precision
+		
+	// if (x <= (T)1.) 
+	// 	throw("zeta function: x must be > 1 !");
+
+	// if (q <= (T)0.) 
+	// 	throw("zeta function: q must be > 0 !");
+
+	T item;
+	T result = (T)0.;
+
+// #pragma omp declare reduction (add : double,float,float16 : omp_out += omp_in) initializer(omp_priv = (T)0.)
+// #pragma omp simd private(item) reduction(add:result)
+	for(int i = 0; i < maxIter; ++i) {		
+		
+		item = math::nd4j_pow((q + i),-x);
+		result += item;
+		
+		if(item <= precision)
+			break;
+	}
+
+	return result;
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+// calculate the Hurwitz zeta function
+template <typename T>
+NDArray<T> zeta(const NDArray<T>& x, const NDArray<T>& q) {
+
+	NDArray<T> result(&x, false, x.getWorkspace());
+
+#pragma omp parallel for if(x.lengthOf() > Environment::getInstance()->elementwiseThreshold()) schedule(guided)	
+	for(int i = 0; i < x.lengthOf(); ++i)
+		result(i) = zeta<T>(x(i), q(i));
+
+	return result;
+}
+
+
+template float   zeta<float>  (const float   x, const float   q);
+template float16 zeta<float16>(const float16 x, const float16 q);
+template double  zeta<double> (const double  x, const double  q);
+
+template NDArray<float>   zeta<float>  (const NDArray<float>&   x, const NDArray<float>&   q);
+template NDArray<float16> zeta<float16>(const NDArray<float16>& x, const NDArray<float16>& q);
+template NDArray<double>  zeta<double> (const NDArray<double>&  x, const NDArray<double>&  q);
+
+
+}
+}
+}
+

--- a/include/ops/declarable/helpers/matrixSetDiag.h
+++ b/include/ops/declarable/helpers/matrixSetDiag.h
@@ -21,4 +21,4 @@ namespace helpers {
 }
 
 
-#endif //LIBND4J_COL2IM_H
+#endif //LIBND4J_MATRIXSETDIAG_H

--- a/include/ops/declarable/helpers/zeta.h
+++ b/include/ops/declarable/helpers/zeta.h
@@ -1,0 +1,26 @@
+//
+// Created by Yurii Shyrma on 12.12.2017.
+//
+
+#ifndef LIBND4J_ZETA_H
+#define LIBND4J_ZETA_H
+
+#include <ops/declarable/helpers/helpers.h>
+#include "NDArray.h"
+
+namespace nd4j {
+namespace ops {
+namespace helpers {
+
+
+	// calculate the Hurwitz zeta function
+    template <typename T>
+    NDArray<T> zeta(const NDArray<T>& x, const NDArray<T>& q);
+    
+
+}
+}
+}
+
+
+#endif //LIBND4J_ZETA_H

--- a/tests_cpu/layers_tests/DeclarableOpsTests3.cpp
+++ b/tests_cpu/layers_tests/DeclarableOpsTests3.cpp
@@ -1232,19 +1232,165 @@ TEST_F(DeclarableOpsTests3, zeta_test1) {
     NDArrayFactory<double>::linspace(1., q);    
     x.assign(2.);
     
-    NDArray<double> expected('c', {3,3}, {1.64493,0.64493,0.39493,0.28382,0.22132,0.18132,0.15355,0.13314,0.11751});
+    NDArray<double> expected('c', {3,3}, {1.64493407,0.64493407,0.39493407,0.28382296,0.22132296,0.18132296,0.15354518,0.13313701,0.11751201});
 
     nd4j::ops::zeta<double> op;
     nd4j::ResultSet<double>* results = op.execute({&x, &q}, {}, {});
 
     ASSERT_EQ(ND4J_STATUS_OK, results->status());
 
-    NDArray<double> *output = results->at(0);        
+    NDArray<double> *output = results->at(0);            
 
     ASSERT_TRUE(expected.isSameShape(output));
     ASSERT_TRUE(expected.equalsTo(output));
 
     delete results;
 }
+
+///////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests3, zeta_test2) {
+        
+    NDArray<double> x('c', {3,3});    
+    NDArray<double> q('c', {3,3});        
+
+    NDArrayFactory<double>::linspace(10., q);    
+    x.assign(2.);
+    
+    NDArray<double> expected('c', {3,3}, {0.10516634,0.09516634,0.08690187,0.07995743,0.07404027,0.06893823,0.06449378,0.06058753,0.05712733});
+
+    nd4j::ops::zeta<double> op;
+    nd4j::ResultSet<double>* results = op.execute({&x, &q}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, results->status());
+
+    NDArray<double> *output = results->at(0);            
+
+    ASSERT_TRUE(expected.isSameShape(output));
+    ASSERT_TRUE(expected.equalsTo(output));
+
+    delete results;
+}
+
+///////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests3, zeta_test3) {
+        
+    NDArray<double> x('c', {3,3});    
+    NDArray<double> q('c', {3,3});        
+
+    NDArrayFactory<double>::linspace(100., q);    
+    x.assign(2.);
+    
+    NDArray<double> expected('c', {3,3}, {0.01005017,0.00995017,0.00985214,0.00975602,0.00966176,0.0095693 ,0.0094786 ,0.0093896 ,0.00930226});
+
+    nd4j::ops::zeta<double> op;
+    nd4j::ResultSet<double>* results = op.execute({&x, &q}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, results->status());
+
+    NDArray<double> *output = results->at(0);            
+
+    ASSERT_TRUE(expected.isSameShape(output));
+    ASSERT_TRUE(expected.equalsTo(output));
+
+    delete results;
+}
+
+
+///////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests3, zeta_test4) {
+        
+    NDArray<double> x('c', {3,3});    
+    NDArray<double> q('c', {3,3});        
+
+    NDArrayFactory<double>::linspace(100., q);    
+    x.assign(2.);
+    
+    NDArray<double> expected('c', {3,3}, {0.01005017,0.00995017,0.00985214,0.00975602,0.00966176,0.0095693 ,0.0094786 ,0.0093896 ,0.00930226});
+
+    nd4j::ops::zeta<double> op;
+    nd4j::ResultSet<double>* results = op.execute({&x, &q}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, results->status());
+
+    NDArray<double> *output = results->at(0);            
+
+    ASSERT_TRUE(expected.isSameShape(output));
+    ASSERT_TRUE(expected.equalsTo(output));
+
+    delete results;
+}
+
+///////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests3, zeta_test5) {
+        
+    NDArray<double> x('c', {3,3});    
+    NDArray<double> q('c', {3,3});        
+
+    NDArrayFactory<double>::linspace(1., q);    
+    x.assign(1.1);
+    
+    NDArray<double> expected('c', {3,3}, {10.58444846,9.58444846,9.11793197, 8.81927915,8.60164151,8.43137352, 8.29204706,8.17445116,8.07291961});
+
+    nd4j::ops::zeta<double> op;
+    nd4j::ResultSet<double>* results = op.execute({&x, &q}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, results->status());
+
+    NDArray<double> *output = results->at(0);            
+
+    ASSERT_TRUE(expected.isSameShape(output));
+    ASSERT_TRUE(expected.equalsTo(output));
+
+    delete results;
+}
+
+///////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests3, zeta_test6) {
+        
+    NDArray<double> x('c', {3,3});    
+    NDArray<double> q('c', {3,3});        
+
+    NDArrayFactory<double>::linspace(1., q);    
+    x.assign(1.01);
+    
+    NDArray<double> expected('c', {3,3}, {100.57794334,99.57794334,99.08139709, 98.75170576,98.50514758,98.30834069, 98.1446337 ,98.00452955,97.88210202});
+
+    nd4j::ops::zeta<double> op;
+    nd4j::ResultSet<double>* results = op.execute({&x, &q}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, results->status());
+
+    NDArray<double> *output = results->at(0);            
+
+    ASSERT_TRUE(expected.isSameShape(output));
+    ASSERT_TRUE(expected.equalsTo(output));
+
+    delete results;
+}
+
+///////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests3, zeta_test7) {
+        
+    NDArray<double> x('c', {3,3});    
+    NDArray<double> q('c', {3,3});        
+
+    NDArrayFactory<double>::linspace(1., q);    
+    x.assign(10.);
+    
+    NDArray<double> expected('c', {3,3}, {1.00099458e+00,9.94575128e-04,1.80126278e-05,1.07754001e-06,1.23865693e-07,2.14656932e-08,4.92752156e-09,1.38738839e-09,4.56065812e-10});
+
+    nd4j::ops::zeta<double> op;
+    nd4j::ResultSet<double>* results = op.execute({&x, &q}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, results->status());
+
+    NDArray<double> *output = results->at(0);            
+
+    ASSERT_TRUE(expected.isSameShape(output));
+    ASSERT_TRUE(expected.equalsTo(output));
+
+    delete results;
+}
+
 
 

--- a/tests_cpu/layers_tests/DeclarableOpsTests3.cpp
+++ b/tests_cpu/layers_tests/DeclarableOpsTests3.cpp
@@ -1192,7 +1192,7 @@ TEST_F(DeclarableOpsTests3, betainc_test9) {
     NDArray<double> *output = results->at(0);    
 
     ASSERT_TRUE(expected.isSameShape(output));
-    ASSERT_TRUE(expected.equalsTo(output, 1e-6));
+    ASSERT_TRUE(expected.equalsTo(output));
 
     delete results;
 }
@@ -1222,4 +1222,29 @@ TEST_F(DeclarableOpsTests3, betainc_test10) {
 
     delete results;
 }
+
+///////////////////////////////////////////////////////////////////
+TEST_F(DeclarableOpsTests3, zeta_test1) {
+        
+    NDArray<double> x('c', {3,3});    
+    NDArray<double> q('c', {3,3});        
+
+    NDArrayFactory<double>::linspace(1., q);    
+    x.assign(2.);
+    
+    NDArray<double> expected('c', {3,3}, {1.64493,0.64493,0.39493,0.28382,0.22132,0.18132,0.15355,0.13314,0.11751});
+
+    nd4j::ops::zeta<double> op;
+    nd4j::ResultSet<double>* results = op.execute({&x, &q}, {}, {});
+
+    ASSERT_EQ(ND4J_STATUS_OK, results->status());
+
+    NDArray<double> *output = results->at(0);        
+
+    ASSERT_TRUE(expected.isSameShape(output));
+    ASSERT_TRUE(expected.equalsTo(output));
+
+    delete results;
+}
+
 


### PR DESCRIPTION
added 2 algorithms for calculation of Hurwitz zeta function: one is simple/straight and directly based on formula for zeta, second is based on Euler-Maclaurin summation formula (https://math.stackexchange.com/questions/917100/numerical-evaluation-of-hurwitz-zeta-function). Second is faster compared to first one.