### PR TITLE
Scalar tweaks

### DIFF
--- a/blas/NDArray.h
+++ b/blas/NDArray.h
@@ -70,6 +70,8 @@ namespace nd4j {
         *  default constructor, do not allocate memory, memory for array is passed from outside 
         */
         NDArray(T *buffer = nullptr, int *shapeInfo = nullptr, nd4j::memory::Workspace* workspace = nullptr);
+
+        NDArray(std::initializer_list<int> shape, nd4j::memory::Workspace* workspace = nullptr);
         
         /**
          * Constructor for scalar NDArray

--- a/blas/cpu/NDArray.cpp
+++ b/blas/cpu/NDArray.cpp
@@ -110,6 +110,22 @@ NDArray<T>::NDArray(const Nd4jIndex length, const char order, nd4j::memory::Work
     delete[] shape;
 }
 
+    template <typename T>
+    NDArray<T>::NDArray(std::initializer_list<int> s, nd4j::memory::Workspace* workspace) {
+        std::vector<int> shape(s);
+        int rank = (int) shape.size();
+
+
+        ALLOCATE(_shapeInfo, workspace, shape::shapeInfoLength(rank), int);
+
+        shape::shapeBuffer(rank, shape.data(), _shapeInfo);
+
+        ALLOCATE(_buffer, workspace, shape::length(_shapeInfo), T);
+
+        _isShapeAlloc = true;
+        _isBuffAlloc = true;
+    }
+
 ////////////////////////////////////////////////////////////////////////
 // this constructor creates 2D NDArray, memory for array is allocated in this constructor 
 template <typename T>

--- a/include/helpers/ShapeBuilder.h
+++ b/include/helpers/ShapeBuilder.h
@@ -1,0 +1,33 @@
+//
+// Created by raver119 on 09.01.18.
+//
+
+#ifndef LIBND4J_SHAPEBUILDER_H
+#define LIBND4J_SHAPEBUILDER_H
+
+#include <op_boilerplate.h>
+
+namespace nd4j {
+    class ShapeBuilder {
+    public:
+        static FORCEINLINE void shapeScalar(int *buffer) {
+            buffer[0] = 0;
+            buffer[1] = 0;
+            buffer[2] = 1;
+            buffer[3] = 99;
+        }
+
+        static FORCEINLINE void shapeVector(int length, int *buffer) {
+            buffer[0] = 1;
+            buffer[1] = length;
+            buffer[2] = 1;
+            buffer[3] = 0;
+            buffer[4] = 1;
+            buffer[5] = 99;
+        }
+    };
+}
+
+
+
+#endif //LIBND4J_SHAPEBUILDER_H

--- a/include/helpers/impl/ShapeBuilder.cpp
+++ b/include/helpers/impl/ShapeBuilder.cpp
@@ -1,0 +1,5 @@
+//
+// @author raver119@gmail.com
+//
+
+#include "../ShapeBuilder.h"

--- a/include/helpers/shape.h
+++ b/include/helpers/shape.h
@@ -3216,10 +3216,13 @@ __host__ __device__
 #endif
 
     INLINEDEF Nd4jIndex length(int *shapeInfo) {
-        if (shape::rank(shapeInfo) == 0)
+        int rank = shape::rank(shapeInfo);
+        if (rank == 0)
             return 1L;
+        if (rank == 1)
+            return shapeInfo[1];
 
-        return shape::prodLong(shape::shapeOf(shapeInfo), shape::rank(shapeInfo));
+        return shape::prodLong(shape::shapeOf(shapeInfo), rank);
     }
 
 #ifdef __CUDACC__

--- a/include/helpers/shape.h
+++ b/include/helpers/shape.h
@@ -3222,6 +3222,7 @@ __host__ __device__
         if (rank == 1)
             return shapeInfo[1];
 
+
         return shape::prodLong(shape::shapeOf(shapeInfo), rank);
     }
 

--- a/include/ops/declarable/CustomOperations.h
+++ b/include/ops/declarable/CustomOperations.h
@@ -21,6 +21,7 @@
 #include <ops/declarable/headers/loss.h>
 #include <ops/declarable/headers/datatypes.h>
 #include <ops/declarable/headers/third_party.h>
+#include <helpers/ShapeBuilder.h>
 #include <dll.h>
 
 

--- a/include/ops/declarable/generic/broadcastable/add.cpp
+++ b/include/ops/declarable/generic/broadcastable/add.cpp
@@ -19,9 +19,7 @@ namespace nd4j {
                 OVERWRITE_RESULT(tZ);
             }
 
-            tZ->printShapeInfo("tz");
-    
-			return ND4J_STATUS_OK;
+    		return ND4J_STATUS_OK;
         }
 
         DECLARE_SHAPE_FN(add) {

--- a/include/ops/declarable/generic/parity_ops/range.cpp
+++ b/include/ops/declarable/generic/parity_ops/range.cpp
@@ -82,7 +82,7 @@ namespace nd4j {
                     }
                 }
 
-                auto array = new nd4j::NDArray<T>(1, data.size(), 'c', block.getWorkspace());
+                auto array = new nd4j::NDArray<T>({(int) data.size()}, block.getWorkspace());
                 memcpy(array->buffer(), data.data(), data.size() * sizeof(T));
 
                 //block.pushNDArrayToVariableSpace(block.nodeId(), 0, array);
@@ -95,7 +95,7 @@ namespace nd4j {
         }
         DECLARE_SHAPE_FN(range) {
             int *newShape;
-            std::vector<int> shape({1});
+            std::vector<int> shape;
             if (block.getIArguments()->size() > 0) {
                 int start = INT_ARG(0);
                 int stop = INT_ARG(1);
@@ -141,8 +141,9 @@ namespace nd4j {
                 shape.emplace_back(119);
             }
             
-            ALLOCATE(newShape, block.getWorkspace(), shape::shapeInfoLength(2), int);
-            shape::shapeBuffer(2, shape.data(), newShape);
+            ALLOCATE(newShape, block.getWorkspace(), shape::shapeInfoLength(1), int);
+            //shape::shapeBuffer(1, shape.data(), newShape);
+            nd4j::ShapeBuilder::shapeVector(shape[0], newShape);
 
             return new ShapeList(newShape);
         }

--- a/include/ops/declarable/generic/parity_ops/rank.cpp
+++ b/include/ops/declarable/generic/parity_ops/rank.cpp
@@ -18,16 +18,9 @@ namespace nd4j {
         }
         DECLARE_SHAPE_FN(rank) {
             int *newShape;
-            ALLOCATE(newShape, block.getWorkspace(), shape::shapeInfoLength(2), int);
+            ALLOCATE(newShape, block.getWorkspace(), shape::shapeInfoLength(0), int);
 
-            newShape[0] = 2;
-            newShape[1] = 1;
-            newShape[2] = 1;
-            newShape[3] = 1;
-            newShape[4] = 1;
-            newShape[5] = 0;
-            newShape[6] = 1;
-            newShape[7] = 99;
+            nd4j::ShapeBuilder::shapeScalar(newShape);
 
             return new ShapeList(newShape);
         }

--- a/include/ops/declarable/generic/parity_ops/size.cpp
+++ b/include/ops/declarable/generic/parity_ops/size.cpp
@@ -18,16 +18,9 @@ namespace nd4j {
         }
         DECLARE_SHAPE_FN(size) {
             int *newShape;
-            ALLOCATE(newShape, block.getWorkspace(), shape::shapeInfoLength(2), int);
+            ALLOCATE(newShape, block.getWorkspace(), shape::shapeInfoLength(0), int);
 
-            newShape[0] = 2;
-            newShape[1] = 1;
-            newShape[2] = 1;
-            newShape[3] = 1;
-            newShape[4] = 1;
-            newShape[5] = 0;
-            newShape[6] = 1;
-            newShape[7] = 99;
+            nd4j::ShapeBuilder::shapeScalar(newShape);
 
             return new ShapeList(newShape);
         }

--- a/include/ops/declarable/generic/shape/shape.cpp
+++ b/include/ops/declarable/generic/shape/shape.cpp
@@ -21,11 +21,11 @@ namespace nd4j {
 
         DECLARE_SHAPE_FN(shape_of) {
             auto inShape = inputShape->at(0);
-            std::vector<int> shape({1, shape::rank(inShape)});
 
             int *newshape;
-            ALLOCATE(newshape, block.getWorkspace(), shape::shapeInfoLength(inShape), int);
-            shape::shapeBuffer(2, shape.data(), newshape);
+            ALLOCATE(newshape, block.getWorkspace(), shape::shapeInfoLength(1), int);
+            nd4j::ShapeBuilder::shapeVector(shape::rank(inShape), newshape);
+
             return new ShapeList(newshape);
         };
     }

--- a/include/ops/declarable/generic/shape/shapes.cpp
+++ b/include/ops/declarable/generic/shape/shapes.cpp
@@ -24,11 +24,10 @@ namespace nd4j {
 
             for (int e = 0; e < inputShape->size(); e++) {
                 auto inShape = inputShape->at(e);
-                std::vector<int> shape({1, shape::rank(inShape)});
 
                 int *newshape;
-                ALLOCATE(newshape, block.getWorkspace(), shape::shapeInfoLength(inShape), int);
-                shape::shapeBuffer(2, shape.data(), newshape);
+                ALLOCATE(newshape, block.getWorkspace(), shape::shapeInfoLength(1), int);
+                nd4j::ShapeBuilder::shapeVector(shape::rank(inShape), newshape);
 
                 shapeList->push_back(newshape);
             }

--- a/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
+++ b/tests_cpu/layers_tests/DeclarableOpsTests1.cpp
@@ -3303,7 +3303,7 @@ TEST_F(DeclarableOpsTests1, Stack_6) {
 }
 
 TEST_F(DeclarableOpsTests1, Test_Range_Integer_1) {
-    NDArray<float> exp('c', {1, 4});
+    NDArray<float> exp({4});
     NDArrayFactory<float>::linspace(1, exp);
 
     nd4j::ops::range<float> op;
@@ -3323,7 +3323,7 @@ TEST_F(DeclarableOpsTests1, Test_Range_Integer_1) {
 
 
 TEST_F(DeclarableOpsTests1, Test_Range_Integer_2) {
-    NDArray<float> exp('c', {1, 4});
+    NDArray<float> exp({4});
     NDArrayFactory<float>::linspace(1, exp);
 
     NDArray<float> start('c', {1, 1});
@@ -3342,6 +3342,8 @@ TEST_F(DeclarableOpsTests1, Test_Range_Integer_2) {
 
     auto array = result->at(0);
 
+    array->printShapeInfo("z");
+
     ASSERT_TRUE(exp.isSameShape(array));
     ASSERT_TRUE(exp.equalsTo(array));
 
@@ -3350,7 +3352,7 @@ TEST_F(DeclarableOpsTests1, Test_Range_Integer_2) {
 
 
 TEST_F(DeclarableOpsTests1, Test_Range_Integer_3) {
-    NDArray<float> exp('c', {1, 4});
+    NDArray<float> exp({4});
     NDArrayFactory<float>::linspace(1, exp);
 
     nd4j::ops::range<float> op;

--- a/tests_cpu/layers_tests/DeclarableOpsTests3.cpp
+++ b/tests_cpu/layers_tests/DeclarableOpsTests3.cpp
@@ -321,7 +321,7 @@ TEST_F(DeclarableOpsTests3, Test_Range_1) {
     NDArray<float> start('c', {1, 1}, {2});
     NDArray<float> stop('c', {1, 1}, {0});
     NDArray<float> step('c', {1, 1}, {1});
-    NDArray<float> exp('c', {1, 2}, {2, 1});
+    NDArray<float> exp('c', {2}, {2, 1});
 
     nd4j::ops::range<float> op;
     auto result = op.execute({&start, &stop, &step}, {}, {});
@@ -341,7 +341,7 @@ TEST_F(DeclarableOpsTests3, Test_Range_2) {
     NDArray<float> start('c', {1, 1}, {2});
     NDArray<float> stop('c', {1, 1}, {0});
     NDArray<float> step('c', {1, 1}, {-1});
-    NDArray<float> exp('c', {1, 2}, {2, 1});
+    NDArray<float> exp('c', {2}, {2, 1});
 
     nd4j::ops::range<float> op;
     auto result = op.execute({&start, &stop, &step}, {}, {});
@@ -349,6 +349,8 @@ TEST_F(DeclarableOpsTests3, Test_Range_2) {
     ASSERT_EQ(ND4J_STATUS_OK, result->status());
 
     auto z = result->at(0);
+
+    z->printShapeInfo("shape");
 
     ASSERT_TRUE(exp.isSameShape(z));
     ASSERT_TRUE(exp.equalsTo(z));
@@ -360,7 +362,7 @@ TEST_F(DeclarableOpsTests3, Test_Range_3) {
     NDArray<float> start('c', {1, 1}, {0});
     NDArray<float> stop('c', {1, 1}, {2});
     NDArray<float> step('c', {1, 1}, {1});
-    NDArray<float> exp('c', {1, 2}, {0, 1});
+    NDArray<float> exp('c', {2}, {0, 1});
 
     nd4j::ops::range<float> op;
     auto result = op.execute({&start, &stop, &step}, {}, {});
@@ -377,7 +379,7 @@ TEST_F(DeclarableOpsTests3, Test_Range_3) {
 
 
 TEST_F(DeclarableOpsTests3, Test_Range_4) {
-    NDArray<float> exp('c', {1, 2}, {2, 1});
+    NDArray<float> exp('c', {2}, {2, 1});
 
     nd4j::ops::range<float> op;
     auto result = op.execute({}, {2, 0, 1}, {});
@@ -394,7 +396,7 @@ TEST_F(DeclarableOpsTests3, Test_Range_4) {
 
 
 TEST_F(DeclarableOpsTests3, Test_Range_5) {
-    NDArray<float> exp('c', {1, 2}, {2, 1});
+    NDArray<float> exp('c', {2}, {2, 1});
 
     nd4j::ops::range<float> op;
     auto result = op.execute({}, {2, 0, -1}, {});
@@ -410,7 +412,7 @@ TEST_F(DeclarableOpsTests3, Test_Range_5) {
 }
 
 TEST_F(DeclarableOpsTests3, Test_Range_6) {
-    NDArray<float> exp('c', {1, 2}, {0, 1});
+    NDArray<float> exp('c', {2}, {0, 1});
 
     nd4j::ops::range<float> op;
     auto result = op.execute({}, {0, 2, 1}, {});
@@ -426,7 +428,7 @@ TEST_F(DeclarableOpsTests3, Test_Range_6) {
 }
 
 TEST_F(DeclarableOpsTests3, Test_Range_7) {
-    NDArray<float> exp('c', {1, 2}, {2, 1});
+    NDArray<float> exp('c', {2}, {2, 1});
 
     nd4j::ops::range<float> op;
     auto result = op.execute({}, {}, {2, 0, 1});
@@ -443,7 +445,7 @@ TEST_F(DeclarableOpsTests3, Test_Range_7) {
 
 
 TEST_F(DeclarableOpsTests3, Test_Range_8) {
-    NDArray<float> exp('c', {1, 2}, {2, 1});
+    NDArray<float> exp('c', {2}, {2, 1});
 
     nd4j::ops::range<float> op;
     auto result = op.execute({}, {}, {2, 0, -1});
@@ -459,7 +461,7 @@ TEST_F(DeclarableOpsTests3, Test_Range_8) {
 }
 
 TEST_F(DeclarableOpsTests3, Test_Range_9) {
-    NDArray<float> exp('c', {1, 2}, {0, 1});
+    NDArray<float> exp('c', {2}, {0, 1});
 
     nd4j::ops::range<float> op;
     auto result = op.execute({}, {}, {0, 2, 1});

--- a/tests_cpu/layers_tests/JavaInteropTests.cpp
+++ b/tests_cpu/layers_tests/JavaInteropTests.cpp
@@ -54,7 +54,7 @@ TEST_F(JavaInteropTests, TestShapeExposure1) {
 
 TEST_F(JavaInteropTests, TestShapeExposure2) {
     NDArray<float> input('c', {1, 2, 5, 4});
-    NDArray<float> exp('c', {1, 4}, {1, 2, 5, 4});
+    NDArray<float> exp('c', {4}, {1, 2, 5, 4});
 
 
     NativeOps nativeOps;
@@ -73,7 +73,6 @@ TEST_F(JavaInteropTests, TestShapeExposure2) {
 
     ASSERT_EQ(exp.rankOf(), shape::rank((int *)shapeList->at(0)));
     ASSERT_EQ(exp.sizeAt(0), shape::shapeOf((int *)shapeList->at(0))[0]);
-    ASSERT_EQ(exp.sizeAt(1), shape::shapeOf((int *)shapeList->at(0))[1]);
 
     nativeOps.deleteShapeList((Nd4jPointer) shapeList);
 }

--- a/tests_cpu/layers_tests/ParityOpsTests.cpp
+++ b/tests_cpu/layers_tests/ParityOpsTests.cpp
@@ -279,7 +279,7 @@ TEST_F(ParityOpsTests, ExpandDimsTest4) {
 
 TEST_F(ParityOpsTests, Test_Shape_1) {
     NDArray<float> x('c', {3, 4, 5, 6});
-    NDArray<float> exp('c', {1, 4}, {3, 4, 5, 6});
+    NDArray<float> exp('c', {4}, {3, 4, 5, 6});
 
     nd4j::ops::shape_of<float> op;
     auto result = op.execute({&x}, {}, {});


### PR DESCRIPTION
This PR applies tweaks/fixes related to scalars/vectors. Mostly removal of legacy workarounds, so ops that were returning scalars as [1, 1] are now returning [] as they should etc