### PR TITLE
Fixes for P-norm pooling backprop

### DIFF
--- a/include/ops/declarable/generic/convo/pooling/pnormpool2d.cpp
+++ b/include/ops/declarable/generic/convo/pooling/pnormpool2d.cpp
@@ -210,15 +210,17 @@ namespace nd4j {
             T extraParams2[] = {1.f/pnorm};
             pNorm->template applyTransform<simdOps::Pow<T>>(extraParams2);
 
-            NDArray<T>* numerator = new NDArray<T>(col2d->getShapeInfo(), block.getWorkspace());
+            NDArray<T>* numerator;
             if (pnorm != 2) {
                 NDArray<T>* absp2 = new NDArray<T>(col2d->getShapeInfo(), block.getWorkspace());
                 col2d->template applyTransform<simdOps::Abs<T>>(absp2, nullptr);
                 T extraParams3[] = {(T) (pnorm - 2)};
                 absp2->template applyTransform<simdOps::Pow<T>>(extraParams3);
-                nd4j::NDArrayFactory<T>::mmulHelper(col2d, absp2, numerator, (T)1.f, (T)0.f);
+				numerator->template applyPairwiseTransform<simdOps::Multiply<T>>(col2d, absp2, nullptr);
                 delete absp2;
-            }
+            } else {
+				numerator = new NDArray<T>(col2d->getShapeInfo(), block.getWorkspace());
+			}
             NDArray<T>* denom = new NDArray<T>(pNorm->getShapeInfo(), block.getWorkspace());
             T extraParams4[] = {(T) (pnorm - 1)};
 


### PR DESCRIPTION
***WIP DO NOT MERGE***

This fixes a bug in pnorm pooling backprop.

However, DL4J gradient checks do NOT pass with this change - though they did not pass before it either.

Specifically, note the use of mmul instead of muli in libnd4j compared to the DL4J implementation:
https://github.com/deeplearning4j/deeplearning4j/blob/419241898a3cc23ec48d6ef098210ede360d0db9/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/layers/convolution/subsampling/SubsamplingLayer.java#L225