### PR TITLE
Add legacy op number for atanh

### DIFF
--- a/include/loops/legacy_ops.h
+++ b/include/loops/legacy_ops.h
@@ -132,7 +132,8 @@
         (89,simdOps::LogSigmoidDerivative) ,\
         (90,simdOps::Erfc) ,\
         (91,simdOps::Expm1), \
-        (92, simdOps::PowDerivative)
+        (92, simdOps::PowDerivative), \
+        (93,simdOps::ATanh)
 
 
 


### PR DESCRIPTION
Part of fix for: https://github.com/deeplearning4j/nd4j/issues/2507