### PR TITLE
Get rid of macOS hack

### DIFF
--- a/blas/CMakeLists.txt
+++ b/blas/CMakeLists.txt
@@ -59,14 +59,14 @@ if(!CUDA_BLAS)
     endif()
 endif()
 
-
-if (APPLE)
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        if ("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER 6.0 OR "${CMAKE_C_COMPILER_VERSION}" VERSION_EQUAL 6.0)
-            SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wa,-mavx512f,-mavx512vl,-mavx512bw,-mavx512dq,-mavx512cd ")
-        endif()
-    endif()
-endif()
+# TODO: get rid of this once problem confirmed solved
+#if (APPLE)
+#    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+#        if ("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER 6.0 OR "${CMAKE_C_COMPILER_VERSION}" VERSION_EQUAL 6.0)
+#            SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wa,-mavx512f,-mavx512vl,-mavx512bw,-mavx512dq,-mavx512cd ")
+#        endif()
+#    endif()
+#endif()
 
 
 if(CUDA_BLAS)

--- a/include/ops/declarable/generic/convo/conv3d.cpp
+++ b/include/ops/declarable/generic/convo/conv3d.cpp
@@ -40,7 +40,7 @@ CUSTOM_OP_IMPL(conv3dnew, 2, 1, false, 0, 13) {
     int indIOioC, indIOioD, indWoC, indWiC, indWkD;       // corresponding indexes
     ConvolutionUtils<T>::getSizesAndIndexesConv3d(isNCDHW, *input, *output, bS, iC, iD, iH, iW, oC, oD, oH, oW, indIOioC, indIOioD, indWiC, indWoC, indWkD);
 
-    REQUIRE_TRUE(weights->sizeAt(indWiC) == iC && weights->sizeAt(indWoC) == oC && weights->sizeAt(indWkD) == kD && weights->sizeAt(indWkD+1) == kH && weights->sizeAt(indWkD+2) == kW, 0, "CUSTOM CONV3D OP: wrong shape of weights array !");
+    REQUIRE_TRUE(weights->sizeAt(indWiC) == iC && weights->sizeAt(indWoC) == oC && weights->sizeAt(indWkD) == kD && weights->sizeAt(indWkD+1) == kH && weights->sizeAt(indWkD+2) == kW, 0, "CUSTOM CONV3D OP: wrong shape of weights array! Expected: [%i, %i, %i, %i]; Received: [%i, %i, %i, %i]", iC, oC, kD, kH, kW, weights->sizeAt(indWiC), weights->sizeAt(indWoC), weights->sizeAt(indWkD), weights->sizeAt(indWkD+1), weights->sizeAt(indWkD+2));
     if (bias) {
         REQUIRE_TRUE(bias->rankOf() == 1,    0, "CUSTOM CONV3D OP: rank of biases array must be equal to 1 !");
         REQUIRE_TRUE(oC == bias->lengthOf(), 0, "CUSTOM CONV3D OP: length of bias array must be equal to outChannels, but got %i instead", bias->lengthOf());        

--- a/tests_cpu/layers_tests/CMakeLists.txt
+++ b/tests_cpu/layers_tests/CMakeLists.txt
@@ -35,14 +35,14 @@ else()
     endif()
 endif()
 
-
-if (APPLE)
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        if ("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER 6.0 OR "${CMAKE_C_COMPILER_VERSION}" VERSION_EQUAL 6.0)
-            SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wa,-mavx512f -fmax-errors=1")
-        endif()
-    endif()
-endif()
+# TODO: get rid of this once problem confirmed solved
+#if (APPLE)
+#    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+#        if ("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER 6.0 OR "${CMAKE_C_COMPILER_VERSION}" VERSION_EQUAL 6.0)
+#            SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wa,-mavx512f -fmax-errors=1")
+#        endif()
+#    endif()
+#endif()
 
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/tests_cpu/layers_tests/ConvolutionTests.cpp
+++ b/tests_cpu/layers_tests/ConvolutionTests.cpp
@@ -1822,10 +1822,15 @@ TEST_F(ConvolutionTests, conv3d_test8) {
 TEST_F(ConvolutionTests, conv3d_test9) {
     NDArray<float> x('c', {4, 2, 28, 28, 3});
     NDArray<float> y('c', {2, 5, 5, 3, 4});
+    NDArray<float> e('c', {4, 1, 7, 10, 4});
 
     nd4j::ops::conv3dnew<float> op;
-    auto result = op.execute({&x, &y}, {}, {2,5,5, 5,4,3, 0,0,0, 1,1,1, 0,0});
+    auto result = op.execute({&x, &y}, {}, {2,5,5, 5,4,3, 0,0,0, 1,1,1, 1,1});
     ASSERT_EQ(Status::OK(), result->status());
+
+    auto z = result->at(0);
+
+    ASSERT_TRUE(e.isSameShape(z));
 
     delete result;
 }

--- a/tests_cpu/layers_tests/ConvolutionTests.cpp
+++ b/tests_cpu/layers_tests/ConvolutionTests.cpp
@@ -1808,14 +1808,28 @@ TEST_F(ConvolutionTests, conv3d_test8) {
     
     nd4j::ops::conv3dnew<float> op;
     ResultSet<float>* results = op.execute({&input, &weights}, {}, {kD,kH,kW,  sD,sH,sW,  pD,pH,pW,  dD,dH,dW, paddingMode, dataFormat});
-    NDArray<float>* output = results->at(0);    
 
     ASSERT_EQ(Status::OK(), results->status());
+
+    NDArray<float>* output = results->at(0);
     ASSERT_TRUE(expected.isSameShape(output));
     ASSERT_TRUE(expected.equalsTo(output));    
     
     delete results;
 }
+
+
+TEST_F(ConvolutionTests, conv3d_test9) {
+    NDArray<float> x('c', {4, 2, 28, 28, 3});
+    NDArray<float> y('c', {2, 5, 5, 3, 4});
+
+    nd4j::ops::conv3dnew<float> op;
+    auto result = op.execute({&x, &y}, {}, {2,5,5, 5,4,3, 0,0,0, 1,1,1, 0,0});
+    ASSERT_EQ(Status::OK(), result->status());
+
+    delete result;
+}
+
 #endif //LIBND4J_CONVOLUTIONTESTS_H
 
 


### PR DESCRIPTION
This PR gets rid of macos specific compilation hack for gcc-7 used for a while, and became useless now.