### PR TITLE
Link dynamically to GCC runtimes on Mac to support C++ exceptions

### DIFF
--- a/blas/CMakeLists.txt
+++ b/blas/CMakeLists.txt
@@ -227,7 +227,8 @@ endif()
     endif()
 
     if(APPLE)
-        SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++")
+        # We cannot use those to propagate C++ exceptions across shared libraries.
+        # SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++")
     elseif(MSYS)
         SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -static")
     endif()

--- a/perform-release.sh
+++ b/perform-release.sh
@@ -15,7 +15,7 @@ RELEASE_PROFILE=${RELEASE_PROFILE:-sonatype}
 echo "Releasing version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $RELEASE_PROFILE $STAGING_REPOSITORY"
 echo "========================================================================================================="
 
-if [[ ! -z $(git tag -l "nd4j-$RELEASE_VERSION") ]]; then
+if [[ ! -z $(git tag -l "libnd4j-$RELEASE_VERSION") ]]; then
     echo "Error: Version $RELEASE_VERSION has already been released!"
     exit 1
 fi


### PR DESCRIPTION
Linking with static runtime libraries results in SIGABRT when throwing C++ exceptions across libraries on Mac, see https://github.com/deeplearning4j/nd4j/issues/2813